### PR TITLE
Add add-product button to catalog

### DIFF
--- a/feedme.client/src/app/components/catalog/catalog.component.css
+++ b/feedme.client/src/app/components/catalog/catalog.component.css
@@ -8,18 +8,40 @@
   position: relative;
 }
 
+.catalog-controls {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  height: 59px;
+  background-color: #f5f5f5;
+  width: 100%;
+  box-shadow: none;
+  padding: 0 20px;
+}
+
 .primary-action-btn {
-  background-color: #FA502D;
-  color: #fff;
+  width: 180px;
+  height: 40px;
+  background-color: #fa502d;
+  color: #ffffff;
+  border-radius: 8px;
   border: none;
-  border-radius: 6px;
-  padding: 10px 16px;
-  font-size: 14px;
   cursor: pointer;
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.3s ease;
 }
 
   .primary-action-btn:hover {
     background-color: #e64827;
+  }
+
+  .primary-action-btn img {
+    width: 20px;
+    height: 20px;
+    margin-right: 6px;
   }
 
 .custom-table {

--- a/feedme.client/src/app/components/catalog/catalog.component.html
+++ b/feedme.client/src/app/components/catalog/catalog.component.html
@@ -1,7 +1,8 @@
 <div class="content">
-  <div class="container" *ngIf="!showNewProductForm" style="justify-content: space-between; padding: 0 20px;">
+  <div class="catalog-controls container">
     <button class="primary-action-btn" (click)="handleAddNewItemClick()">
-      + Новый товар
+      <img src="assets/plus.svg" alt="Добавить товар" class="button-icon">
+      <span>Добавить товар</span>
     </button>
   </div>
 

--- a/feedme.client/src/assets/plus.svg
+++ b/feedme.client/src/assets/plus.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <path d="M11 11V2h2v9h9v2h-9v9h-2v-9H2v-2h9z"/>
+</svg>


### PR DESCRIPTION
## Summary
- show add-product button within catalog-controls bar
- always display controls bar

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fa19bd4e483238c239b0eef0623dd