### PR TITLE
Add receipt popup component

### DIFF
--- a/feedme.client/src/app/components/add-receipt-popup/add-receipt-popup.component.css
+++ b/feedme.client/src/app/components/add-receipt-popup/add-receipt-popup.component.css
@@ -1,0 +1,38 @@
+.popup-backdrop {
+  /* затемнённый фон */
+}
+.popup-content {
+  width: 480px;
+  background: #fff;
+  border-radius: 8px;
+  padding: 24px;
+}
+.popup-content h2 {
+  margin-bottom: 16px;
+  text-align: center;
+}
+label {
+  display: block;
+  margin-top: 12px;
+  font-weight: 500;
+}
+input,
+select {
+  width: 100%;
+  padding: 8px;
+  margin-top: 4px;
+  box-sizing: border-box;
+}
+.popup-buttons {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  margin-top: 24px;
+}
+.cancel-btn {
+  background: #ccc;
+}
+.save-btn {
+  background: #007bff;
+  color: #fff;
+}

--- a/feedme.client/src/app/components/add-receipt-popup/add-receipt-popup.component.html
+++ b/feedme.client/src/app/components/add-receipt-popup/add-receipt-popup.component.html
@@ -1,0 +1,53 @@
+<div class="popup-backdrop" (click)="onClose()">
+  <div class="popup-content" (click)="$event.stopPropagation()">
+    <h2>Новая поставка</h2>
+    <form [formGroup]="form" (ngSubmit)="onSubmit()">
+
+      <label>Товар</label>
+      <select formControlName="productId">
+        <option value="">— Выберите —</option>
+        <option *ngFor="let p of catalog" [value]="p.id">{{ p.name }}</option>
+      </select>
+
+      <label>Поставщик</label>
+      <input formControlName="supplierId" disabled />
+
+      <label>Код ТН ВЭД</label>
+      <input formControlName="tnvedCode" disabled />
+
+      <label>Метод списания</label>
+      <input formControlName="writeoffMethod" disabled />
+
+      <label>Цена закупки за единицу</label>
+      <input formControlName="unitPrice" disabled />
+
+      <label>Дата приёмки</label>
+      <input type="date" formControlName="receiptDate" />
+
+      <label>Номер документа</label>
+      <input type="text" formControlName="documentNumber" />
+
+      <label>Количество</label>
+      <input type="number" formControlName="quantity" />
+
+      <label>Ед. изм.</label>
+      <select formControlName="unit">
+        <option *ngFor="let u of units" [value]="u">{{ u }}</option>
+      </select>
+
+      <label>Общая сумма</label>
+      <input formControlName="totalCost" disabled />
+
+      <label>Срок годности</label>
+      <input type="date" formControlName="expiryDate" />
+
+      <label>Номер партии</label>
+      <input type="text" formControlName="batchCode" />
+
+      <div class="popup-buttons">
+        <button type="button" class="cancel-btn" (click)="onClose()">Отмена</button>
+        <button type="submit" class="save-btn" [disabled]="form.invalid">Сохранить</button>
+      </div>
+    </form>
+  </div>
+</div>

--- a/feedme.client/src/app/components/add-receipt-popup/add-receipt-popup.component.spec.ts
+++ b/feedme.client/src/app/components/add-receipt-popup/add-receipt-popup.component.spec.ts
@@ -1,0 +1,37 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { of } from 'rxjs';
+
+import { AddReceiptPopupComponent } from './add-receipt-popup.component';
+import { CatalogService } from '../../services/catalog.service';
+import { ReceiptService } from '../../services/receipt.service';
+
+describe('AddReceiptPopupComponent', () => {
+  let component: AddReceiptPopupComponent;
+  let fixture: ComponentFixture<AddReceiptPopupComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AddReceiptPopupComponent],
+      providers: [
+        { provide: CatalogService, useValue: { getAll: () => of([]), getById: () => of() } },
+        { provide: ReceiptService, useValue: { saveReceipt: () => of() } }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AddReceiptPopupComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should emit close on onClose', () => {
+    spyOn(component.close, 'emit');
+    const btn = fixture.debugElement.query(By.css('.cancel-btn'));
+    btn.nativeElement.click();
+    expect(component.close.emit).toHaveBeenCalled();
+  });
+});

--- a/feedme.client/src/app/components/add-receipt-popup/add-receipt-popup.component.ts
+++ b/feedme.client/src/app/components/add-receipt-popup/add-receipt-popup.component.ts
@@ -1,0 +1,78 @@
+import { Component, EventEmitter, OnInit, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+
+import { CatalogService, CatalogItem } from '../../services/catalog.service';
+import { ReceiptService } from '../../services/receipt.service';
+
+@Component({
+  selector: 'app-add-receipt-popup',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  templateUrl: './add-receipt-popup.component.html',
+  styleUrls: ['./add-receipt-popup.component.css']
+})
+export class AddReceiptPopupComponent implements OnInit {
+  @Output() close = new EventEmitter<void>();
+
+  form = this.fb.group({
+    productId: ['', Validators.required],
+    supplierId: [{ value: '', disabled: true }],
+    tnvedCode: [{ value: '', disabled: true }],
+    writeoffMethod: [{ value: '', disabled: true }],
+    unitPrice: [{ value: 0, disabled: true }],
+
+    receiptDate: [new Date(), Validators.required],
+    documentNumber: [''],
+    quantity: [0, Validators.required],
+    unit: ['шт', Validators.required],
+    totalCost: [{ value: 0, disabled: true }],
+
+    expiryDate: [null],
+    batchCode: ['']
+  });
+
+  catalog: CatalogItem[] = [];
+  units: string[] = [];
+
+  constructor(
+    private fb: FormBuilder,
+    private catalogService: CatalogService,
+    private receiptService: ReceiptService
+  ) {}
+
+  ngOnInit(): void {
+    this.catalogService.getAll().subscribe(items => (this.catalog = items));
+    this.units = ['шт', 'кг', 'л', 'упаковка'];
+
+    this.form.get('productId')!.valueChanges.subscribe(id => this.onProductChange(id));
+
+    this.form.valueChanges.subscribe(v => {
+      const sum = (v.quantity || 0) * (v.unitPrice || 0);
+      this.form.get('totalCost')!.setValue(sum, { emitEvent: false });
+    });
+  }
+
+  onProductChange(id: string | null): void {
+    if (!id) return;
+    this.catalogService.getById(id).subscribe(item => {
+      this.form.patchValue({
+        supplierId: item.supplierId,
+        tnvedCode: item.tnvedCode,
+        writeoffMethod: item.writeoffMethod,
+        unitPrice: item.unitPrice
+      });
+    });
+  }
+
+  onSubmit(): void {
+    if (this.form.valid) {
+      const data = { ...this.form.getRawValue() };
+      this.receiptService.saveReceipt(data).subscribe(() => this.onClose());
+    }
+  }
+
+  onClose(): void {
+    this.close.emit();
+  }
+}

--- a/feedme.client/src/app/services/catalog.service.ts
+++ b/feedme.client/src/app/services/catalog.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+export interface CatalogItem {
+  id: string;
+  name: string;
+  supplierId: string;
+  tnvedCode: string;
+  writeoffMethod: string;
+  unitPrice: number;
+}
+
+@Injectable({ providedIn: 'root' })
+export class CatalogService {
+  private readonly baseUrl = '/api/catalog';
+
+  constructor(private http: HttpClient) {}
+
+  getAll(): Observable<CatalogItem[]> {
+    return this.http.get<CatalogItem[]>(this.baseUrl);
+  }
+
+  getById(id: string): Observable<CatalogItem> {
+    return this.http.get<CatalogItem>(`${this.baseUrl}/${id}`);
+  }
+}

--- a/feedme.client/src/app/services/receipt.service.ts
+++ b/feedme.client/src/app/services/receipt.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class ReceiptService {
+  private readonly baseUrl = '/api/receipts';
+
+  constructor(private http: HttpClient) {}
+
+  saveReceipt(data: any): Observable<void> {
+    return this.http.post<void>(this.baseUrl, data);
+  }
+}


### PR DESCRIPTION
## Summary
- add CatalogService and ReceiptService
- add AddReceiptPopupComponent for creating new receipts
- include test for AddReceiptPopupComponent

## Testing
- `npm test --prefix feedme.client` *(fails: Cannot determine project or target for command)*
- `npm run lint --prefix feedme.client` *(fails: Cannot find "lint" target)*

------
https://chatgpt.com/codex/tasks/task_e_6889240211a48323a982db54c8c17829