### PR TITLE
Add missing stylesheet for wrapper

### DIFF
--- a/feedme.client/src/app/components/info-cards-wrapper/info-cards-wrapper.component.css
+++ b/feedme.client/src/app/components/info-cards-wrapper/info-cards-wrapper.component.css
@@ -1,0 +1,12 @@
+:host {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(0, 0, 0, 0.3);
+  z-index: 1000;
+}


### PR DESCRIPTION
## Summary
- fix build errors by adding a stylesheet for InfoCardsWrapper component

## Testing
- `npm run build`
- `npm test` *(fails: Cannot determine project or target for command)*

------
https://chatgpt.com/codex/tasks/task_e_688943e709008323a40e475d78ee5d83