### PR TITLE
Replace FontAwesome icons with Angular Material

### DIFF
--- a/feedme.client/package.json
+++ b/feedme.client/package.json
@@ -18,9 +18,8 @@
     "@angular/platform-browser": "^19.2.8",
     "@angular/platform-browser-dynamic": "^19.2.8",
     "@angular/router": "^19.2.8",
-    "@fortawesome/angular-fontawesome": "^1.0.0",
-    "@fortawesome/fontawesome-svg-core": "^6.7.2",
-    "@fortawesome/free-solid-svg-icons": "^6.7.2",
+    "@angular/material": "^19.2.8",
+    "@angular/cdk": "^19.2.8",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.0"

--- a/feedme.client/src/app/components/sidebar/sidebar.component.css
+++ b/feedme.client/src/app/components/sidebar/sidebar.component.css
@@ -37,7 +37,7 @@
     margin-bottom: 20px;
   }
 
-fa-icon {
+mat-icon {
   display: block;
   font-size: 20px;
   margin-bottom: 5px;

--- a/feedme.client/src/app/components/sidebar/sidebar.component.html
+++ b/feedme.client/src/app/components/sidebar/sidebar.component.html
@@ -1,31 +1,31 @@
 <div class="sidebar">
   <ul class="nav-list">
     <li class="nav-item">
-      <fa-icon [icon]="icons.warehouse"></fa-icon>
+      <mat-icon>{{ icons.warehouse }}</mat-icon>
       Главный склад
     </li>
     <li class="nav-item">
-      <fa-icon [icon]="icons.catalog"></fa-icon>
+      <mat-icon>{{ icons.catalog }}</mat-icon>
       Каталог
     </li>
     <li class="nav-item">
-      <fa-icon [icon]="icons.analytics"></fa-icon>
+      <mat-icon>{{ icons.analytics }}</mat-icon>
       Аналитика
     </li>
     <li class="nav-item">
-      <fa-icon [icon]="icons.delivery"></fa-icon>
+      <mat-icon>{{ icons.delivery }}</mat-icon>
       Поставки
     </li>
     <li class="nav-item">
-      <fa-icon [icon]="icons.orders"></fa-icon>
+      <mat-icon>{{ icons.orders }}</mat-icon>
       Заказы
     </li>
     <li class="nav-item">
-      <fa-icon [icon]="icons.settings"></fa-icon>
+      <mat-icon>{{ icons.settings }}</mat-icon>
       Настройки
     </li>
     <li class="nav-item logout">
-      <fa-icon [icon]="icons.logout"></fa-icon>
+      <mat-icon>{{ icons.logout }}</mat-icon>
       Выход
     </li>
   </ul>

--- a/feedme.client/src/app/components/sidebar/sidebar.component.ts
+++ b/feedme.client/src/app/components/sidebar/sidebar.component.ts
@@ -1,47 +1,22 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
-
-// Импорт FontAwesome модуля и ядра иконок
-import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
-import { FaIconLibrary } from '@fortawesome/angular-fontawesome';
-import {
-  faWarehouse,
-  faBoxes,
-  faChartBar,
-  faTruck,
-  faCog,
-  faListAlt,
-  faSignOutAlt
-} from '@fortawesome/free-solid-svg-icons';
+import { MatIconModule } from '@angular/material/icon';
 
 @Component({
   selector: 'app-sidebar',
   standalone: true,
-  imports: [CommonModule, FontAwesomeModule],
+  imports: [CommonModule, MatIconModule],
   templateUrl: './sidebar.component.html',
   styleUrls: ['./sidebar.component.css']
 })
 export class SidebarComponent {
-  icons = {
-    warehouse: faWarehouse,
-    catalog: faBoxes,
-    analytics: faChartBar,
-    delivery: faTruck,
-    orders: faListAlt,
-    settings: faCog,
-    logout: faSignOutAlt
+  readonly icons = {
+    warehouse: 'warehouse',
+    catalog: 'inventory_2',
+    analytics: 'bar_chart',
+    delivery: 'local_shipping',
+    orders: 'list_alt',
+    settings: 'settings',
+    logout: 'logout'
   };
-
-  constructor(private library: FaIconLibrary) {
-    // Обязательно добавь эту строку, чтобы явно зарегистрировать иконки
-    library.addIcons(
-      faWarehouse,
-      faBoxes,
-      faChartBar,
-      faTruck,
-      faListAlt,
-      faCog,
-      faSignOutAlt
-    );
-  }
 }

--- a/feedme.client/src/index.html
+++ b/feedme.client/src/index.html
@@ -6,6 +6,7 @@
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
 <body>
   <app-root></app-root>

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,16 +14,15 @@
       "version": "0.0.1",
       "dependencies": {
         "@angular/animations": "^19.2.8",
+        "@angular/cdk": "^19.2.8",
         "@angular/common": "^19.2.8",
         "@angular/compiler": "^19.2.8",
         "@angular/core": "^19.2.8",
         "@angular/forms": "^19.2.8",
+        "@angular/material": "^19.2.8",
         "@angular/platform-browser": "^19.2.8",
         "@angular/platform-browser-dynamic": "^19.2.8",
         "@angular/router": "^19.2.8",
-        "@fortawesome/angular-fontawesome": "^1.0.0",
-        "@fortawesome/fontawesome-svg-core": "^6.7.2",
-        "@fortawesome/free-solid-svg-icons": "^6.7.2",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.15.0"
@@ -518,6 +517,21 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/@angular/cdk": {
+      "version": "19.2.19",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-19.2.19.tgz",
+      "integrity": "sha512-PCpJagurPBqciqcq4Z8+3OtKLb7rSl4w/qBJoIMua8CgnrjvA1i+SWawhdtfI1zlY8FSwhzLwXV0CmWWfFzQPg==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.1.2",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "^19.0.0 || ^20.0.0",
+        "@angular/core": "^19.0.0 || ^20.0.0",
+        "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
     "node_modules/@angular/cli": {
       "version": "19.2.15",
       "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-19.2.15.tgz",
@@ -688,6 +702,23 @@
         "@angular/common": "19.2.14",
         "@angular/core": "19.2.14",
         "@angular/platform-browser": "19.2.14",
+        "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
+    "node_modules/@angular/material": {
+      "version": "19.2.19",
+      "resolved": "https://registry.npmjs.org/@angular/material/-/material-19.2.19.tgz",
+      "integrity": "sha512-auIE6JUzTIA3LyYklh9J/T7u64crmphxUBgAa0zcOMDog6SYfwbNe9YeLQqua5ek4OUAOdK/BHHfVl5W5iaUoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/cdk": "19.2.19",
+        "@angular/common": "^19.0.0 || ^20.0.0",
+        "@angular/core": "^19.0.0 || ^20.0.0",
+        "@angular/forms": "^19.0.0 || ^20.0.0",
+        "@angular/platform-browser": "^19.0.0 || ^20.0.0",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
@@ -2884,52 +2915,6 @@
       ],
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@fortawesome/angular-fontawesome": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/angular-fontawesome/-/angular-fontawesome-1.0.0.tgz",
-      "integrity": "sha512-EC2fYuXIuw2ld1kzJi+zysWus6OeGGfLQtbh0hW9zyyq5aBo8ZJkcJKBsVQ8E6Mg7nHyTWaXn+sdcXTPDWz+UQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@fortawesome/fontawesome-svg-core": "^6.7.1",
-        "tslib": "^2.8.1"
-      },
-      "peerDependencies": {
-        "@angular/core": "^19.0.0"
-      }
-    },
-    "node_modules/@fortawesome/fontawesome-common-types": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.7.2.tgz",
-      "integrity": "sha512-Zs+YeHUC5fkt7Mg1l6XTniei3k4bwG/yo3iFUtZWd/pMx9g3fdvkSK9E0FOC+++phXOka78uJcYb8JaFkW52Xg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@fortawesome/fontawesome-svg-core": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.2.tgz",
-      "integrity": "sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==",
-      "license": "MIT",
-      "dependencies": {
-        "@fortawesome/fontawesome-common-types": "6.7.2"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@fortawesome/free-solid-svg-icons": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.7.2.tgz",
-      "integrity": "sha512-GsBrnOzU8uj0LECDfD5zomZJIjrPhIlWU82AHwa2s40FKH+kcxQaBvBo3Z4TxyZHIyX8XTDxsyA33/Vx9eFuQA==",
-      "license": "(CC-BY-4.0 AND MIT)",
-      "dependencies": {
-        "@fortawesome/fontawesome-common-types": "6.7.2"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/@inquirer/checkbox": {
@@ -11210,7 +11195,6 @@
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
       "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"
@@ -11251,7 +11235,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"


### PR DESCRIPTION
## Summary
- switch to Angular Material icons
- load Material Icons font in index.html
- remove FontAwesome dependency and code

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser)*

------
https://chatgpt.com/codex/tasks/task_e_688a5fc95d14832397dcb6acb859c9fd