### PR TITLE
Fix karma to run headless

### DIFF
--- a/feedme.client/karma.conf.js
+++ b/feedme.client/karma.conf.js
@@ -33,10 +33,16 @@
     port: 9876,
     colors: true,
     logLevel: config.LOG_INFO,
-    autoWatch: true,
-    browsers: ['Chrome'],
-    singleRun: false,
-    restartOnFileChange: true,
+    autoWatch: false,
+    customLaunchers: {
+      ChromeHeadlessNoSandbox: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox']
+      }
+    },
+    browsers: ['ChromeHeadlessNoSandbox'],
+    singleRun: true,
+    restartOnFileChange: false,
     listenAddress: 'localhost',
     hostname: 'localhost'
   });


### PR DESCRIPTION
## Summary
- configure Karma to use ChromeHeadless with no sandbox

## Testing
- `npm run build`
- `npm test` *(fails: Chrome not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688a6861bab8832382f35419e6e00126