### PR TITLE
Add catalog view switcher tabs

### DIFF
--- a/feedme.client/src/app/components/CatalogTableComponent/catalog-table.component.css
+++ b/feedme.client/src/app/components/CatalogTableComponent/catalog-table.component.css
@@ -34,6 +34,10 @@ app-table-controls {
   flex: 1;
 }
 
+app-catalog-view-switcher {
+  margin-left: 16px;
+}
+
 /* Контейнер для горизонтального скролла */
 .table-container {
   overflow-x: auto;

--- a/feedme.client/src/app/components/CatalogTableComponent/catalog-table.component.html
+++ b/feedme.client/src/app/components/CatalogTableComponent/catalog-table.component.html
@@ -5,6 +5,7 @@
                       (searchQueryChange)="onSearchChange($event)"
                       (rowsPerPageChange)="onRowsChange($event)">
   </app-table-controls>
+  <app-catalog-view-switcher [view]="viewMode" (viewChange)="onViewChange($event)"></app-catalog-view-switcher>
   <button class="add-button" (click)="addSupply()">+ Новый товар</button>
 </div>
 

--- a/feedme.client/src/app/components/CatalogTableComponent/catalog-table.component.ts
+++ b/feedme.client/src/app/components/CatalogTableComponent/catalog-table.component.ts
@@ -2,17 +2,26 @@ import { Component, Input, Output, EventEmitter, OnChanges, SimpleChanges } from
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { TableControlsComponent } from '../table-controls/table-controls.component';
+import { CatalogViewSwitcherComponent } from '../catalog-view-switcher/catalog-view-switcher.component';
 
 @Component({
   selector: 'app-catalog-table',
   standalone: true,
-  imports: [CommonModule, FormsModule, TableControlsComponent],
+  imports: [
+    CommonModule,
+    FormsModule,
+    TableControlsComponent,
+    CatalogViewSwitcherComponent
+  ],
   templateUrl: './catalog-table.component.html',
   styleUrls: ['./catalog-table.component.css']
 })
 export class CatalogTableComponent implements OnChanges {
   /** Входные данные для каталога */
   @Input() data: any[] = [];
+
+  /** Режим отображения таблицы */
+  viewMode: 'info' | 'logistics' = 'info';
 
   @Output() onAddSupply = new EventEmitter<void>(); 
   /** Управление фильтрацией и пагинацией */
@@ -78,6 +87,10 @@ export class CatalogTableComponent implements OnChanges {
   }
 
   addSupply(): void { this.onAddSupply.emit() }
+
+  onViewChange(view: 'info' | 'logistics'): void {
+    this.viewMode = view;
+  }
   /** Навигация по страницам */
   prevPage(): void {
     if (this.currentPage > 1) this.currentPage--;

--- a/feedme.client/src/app/components/catalog-view-switcher/catalog-view-switcher.component.css
+++ b/feedme.client/src/app/components/catalog-view-switcher/catalog-view-switcher.component.css
@@ -1,0 +1,19 @@
+.view-switcher {
+  display: flex;
+  gap: 12px;
+}
+
+.view-switcher button {
+  padding: 4px 12px;
+  font-size: 14px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: #555;
+}
+
+.view-switcher button.active {
+  color: #4F6BD1;
+  font-weight: 600;
+  border-bottom: 2px solid #4F6BD1;
+}

--- a/feedme.client/src/app/components/catalog-view-switcher/catalog-view-switcher.component.html
+++ b/feedme.client/src/app/components/catalog-view-switcher/catalog-view-switcher.component.html
@@ -1,0 +1,8 @@
+<div class="view-switcher">
+  <button (click)="select('info')" [class.active]="view === 'info'">
+    Основная информация
+  </button>
+  <button (click)="select('logistics')" [class.active]="view === 'logistics'">
+    Закупка и логистика
+  </button>
+</div>

--- a/feedme.client/src/app/components/catalog-view-switcher/catalog-view-switcher.component.ts
+++ b/feedme.client/src/app/components/catalog-view-switcher/catalog-view-switcher.component.ts
@@ -1,0 +1,21 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-catalog-view-switcher',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './catalog-view-switcher.component.html',
+  styleUrls: ['./catalog-view-switcher.component.css']
+})
+export class CatalogViewSwitcherComponent {
+  @Input() view: 'info' | 'logistics' = 'info';
+  @Output() viewChange = new EventEmitter<'info' | 'logistics'>();
+
+  select(view: 'info' | 'logistics'): void {
+    if (this.view !== view) {
+      this.view = view;
+      this.viewChange.emit(this.view);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add new `CatalogViewSwitcherComponent` to switch catalog views
- integrate the new tabs into `CatalogTableComponent`
- style tab placement next to the search bar

## Testing
- `npm test` *(fails: No binary for ChromeHeadless)*
- `npm run lint` *(fails: ng lint not configured)*
- `npx ng build`


------
https://chatgpt.com/codex/tasks/task_e_688bf4ab3e4083239de990c79a80ddf8