### PR TITLE
Add catalog view switcher tabs

### DIFF
--- a/feedme.client/src/app/components/CatalogTableComponent/catalog-table.component.css
+++ b/feedme.client/src/app/components/CatalogTableComponent/catalog-table.component.css
@@ -34,6 +34,10 @@ app-table-controls {
   flex: 1;
 }
 
+app-catalog-view-switcher {
+  margin-left: 16px;
+}
+
 /* Контейнер для горизонтального скролла */
 .table-container {
   overflow-x: auto;

--- a/feedme.client/src/app/components/CatalogTableComponent/catalog-table.component.html
+++ b/feedme.client/src/app/components/CatalogTableComponent/catalog-table.component.html
@@ -5,6 +5,7 @@
                       (searchQueryChange)="onSearchChange($event)"
                       (rowsPerPageChange)="onRowsChange($event)">
   </app-table-controls>
+  <app-catalog-view-switcher [view]="viewMode" (viewChange)="onViewChange($event)"></app-catalog-view-switcher>
   <button class="add-button" (click)="addSupply()">+ Новый товар</button>
 </div>
 
@@ -13,29 +14,15 @@
   <table class="catalog-table">
     <thead>
       <tr>
-        <th>Название</th>
-        <th>Категория</th>
-        <th>НДС</th>
-        <th>Единица измерения</th>
-        <th>Цена за единицуя</th>
-        <th>Описание</th>
-        <th>Требует фасовки</th>
-        <th>Портится после вскрытия</th>
+        <th *ngFor="let col of columns">{{ col.label }}</th>
       </tr>
     </thead>
     <tbody>
       <tr *ngFor="let item of paginatedData">
-        <td>{{ item.productName }}</td>
-        <td>{{ item.category }}</td>
-        <td>{{ item.taxRate }}</td>
-        <td>{{ item.unit }}</td>
-        <td>{{ item.unitPrice }}</td>
-        <td>{{ item.description }}</td>
-        <td>{{ item.requiresPackaging }}</td>
-        <td>{{ item.supplier }}</td>
+        <td *ngFor="let col of columns">{{ format(item[col.key]) }}</td>
       </tr>
       <tr *ngIf="paginatedData.length === 0">
-        <td colspan="8" class="no-data">Нет данных</td>
+        <td [attr.colspan]="columns.length" class="no-data">Нет данных</td>
       </tr>
     </tbody>
   </table>

--- a/feedme.client/src/app/components/CatalogTableComponent/catalog-table.component.ts
+++ b/feedme.client/src/app/components/CatalogTableComponent/catalog-table.component.ts
@@ -2,11 +2,19 @@ import { Component, Input, Output, EventEmitter, OnChanges, SimpleChanges } from
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { TableControlsComponent } from '../table-controls/table-controls.component';
+import { CatalogViewSwitcherComponent } from '../catalog-view-switcher/catalog-view-switcher.component';
+import { FilterPipe } from '../../pipes/filter.pipe';
 
 @Component({
   selector: 'app-catalog-table',
   standalone: true,
-  imports: [CommonModule, FormsModule, TableControlsComponent],
+  imports: [
+    CommonModule,
+    FormsModule,
+    TableControlsComponent,
+    CatalogViewSwitcherComponent,
+    FilterPipe
+  ],
   templateUrl: './catalog-table.component.html',
   styleUrls: ['./catalog-table.component.css']
 })
@@ -14,50 +22,73 @@ export class CatalogTableComponent implements OnChanges {
   /** Входные данные для каталога */
   @Input() data: any[] = [];
 
+  /** Режим отображения таблицы */
+  viewMode: 'info' | 'logistics' = 'info';
+
   @Output() onAddSupply = new EventEmitter<void>(); 
   /** Управление фильтрацией и пагинацией */
   searchQuery: string = '';
   rowsPerPage: number = 10;
   currentPage: number = 1;
-  filteredData: any[] = [];
 
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes['data']) {
-      this.applyFilters();
-    }
+  /** Колонки для режима "Основная информация" */
+  readonly infoColumns = [
+    { label: 'Название товара', key: 'name' },
+    { label: 'Тип номенклатуры', key: 'type' },
+    { label: 'Номенклатурный код', key: 'code' },
+    { label: 'Категория', key: 'category' },
+    { label: 'Единица измерения (базовая)', key: 'unit' },
+    { label: 'Вес/объём единицы', key: 'weight' },
+    { label: 'Метод списания', key: 'writeoffMethod' },
+    { label: 'Аллергены', key: 'allergens' },
+    { label: 'Требует фасовки', key: 'packagingRequired' },
+    { label: 'Портится после вскрытия', key: 'spoilsAfterOpening' },
+  ];
+
+  /** Колонки для режима "Закупка и логистика" */
+  readonly logisticsColumns = [
+    { label: 'Поставщик (основной)', key: 'supplier' },
+    { label: 'Срок поставки (дней)', key: 'deliveryTime' },
+    { label: 'Оценочная себестоимость', key: 'costEstimate' },
+    { label: 'Ставка НДС', key: 'taxRate' },
+    { label: 'Цена за единицу', key: 'unitPrice' },
+    { label: 'Код ТН ВЭД', key: 'tnved' },
+    { label: 'Маркируемый товар', key: 'isMarked' },
+    { label: 'Алкогольная продукция', key: 'isAlcohol' },
+  ];
+
+  /** Текущие колонки по выбранному режиму */
+  get columns() {
+    return this.viewMode === 'info' ? this.infoColumns : this.logisticsColumns;
   }
 
-  /** Убираем пустые записи и применяем поиск */
-  private applyFilters(): void {
-    // 1) отбрасываем полностью пустые объекты
-    const nonEmpty = this.data.filter(item =>
-      !!(item.id?.toString().trim()) ||
-      !!(item.category?.toString().trim()) ||
-      !!(item.name?.toString().trim()) ||
-      !!(item.stock?.toString().trim()) ||
-      !!(item.totalCost?.toString().trim()) ||
-      !!(item.warehouse?.toString().trim()) ||
-      !!(item.expiryDate?.toString().trim()) ||
-      !!(item.perishableAfterOpening?.toString().trim())
-    );
+  /** Приведение значения для отображения */
+  format(value: any): string {
+    if (typeof value === 'boolean') {
+      return value ? 'Да' : 'Нет';
+    }
+    return value ?? '';
+  }
 
-    // 2) поиск
-    const q = this.searchQuery.toLowerCase();
-    this.filteredData = nonEmpty.filter(item =>
-      (item.id || '').toString().toLowerCase().includes(q) ||
-      (item.category || '').toLowerCase().includes(q) ||
-      (item.name || '').toLowerCase().includes(q) ||
-      (item.warehouse || '').toLowerCase().includes(q)
-    );
-
-    // 3) сброс страницы
+  ngOnChanges(_: SimpleChanges): void {
     this.currentPage = 1;
+  }
+
+  /** Фильтрованные данные по поисковому запросу */
+  get filteredData(): any[] {
+    const q = this.searchQuery.toLowerCase();
+    if (!q) return this.data;
+    return this.data.filter(item =>
+      Object.values(item).some(val =>
+        val && val.toString().toLowerCase().includes(q)
+      )
+    );
   }
 
   /** Обновление поискового запроса */
   onSearchChange(query: string): void {
     this.searchQuery = query;
-    this.applyFilters();
+    this.currentPage = 1;
   }
 
   /** Обновление количества строк на странице */
@@ -78,6 +109,10 @@ export class CatalogTableComponent implements OnChanges {
   }
 
   addSupply(): void { this.onAddSupply.emit() }
+
+  onViewChange(view: 'info' | 'logistics'): void {
+    this.viewMode = view;
+  }
   /** Навигация по страницам */
   prevPage(): void {
     if (this.currentPage > 1) this.currentPage--;

--- a/feedme.client/src/app/components/catalog-view-switcher/catalog-view-switcher.component.css
+++ b/feedme.client/src/app/components/catalog-view-switcher/catalog-view-switcher.component.css
@@ -1,0 +1,19 @@
+.view-switcher {
+  display: flex;
+  gap: 12px;
+}
+
+.view-switcher button {
+  padding: 4px 12px;
+  font-size: 14px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: #555;
+}
+
+.view-switcher button.active {
+  color: #4F6BD1;
+  font-weight: 600;
+  border-bottom: 2px solid #4F6BD1;
+}

--- a/feedme.client/src/app/components/catalog-view-switcher/catalog-view-switcher.component.html
+++ b/feedme.client/src/app/components/catalog-view-switcher/catalog-view-switcher.component.html
@@ -1,0 +1,8 @@
+<div class="view-switcher">
+  <button (click)="select('info')" [class.active]="view === 'info'">
+    Основная информация
+  </button>
+  <button (click)="select('logistics')" [class.active]="view === 'logistics'">
+    Закупка и логистика
+  </button>
+</div>

--- a/feedme.client/src/app/components/catalog-view-switcher/catalog-view-switcher.component.ts
+++ b/feedme.client/src/app/components/catalog-view-switcher/catalog-view-switcher.component.ts
@@ -1,0 +1,21 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-catalog-view-switcher',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './catalog-view-switcher.component.html',
+  styleUrls: ['./catalog-view-switcher.component.css']
+})
+export class CatalogViewSwitcherComponent {
+  @Input() view: 'info' | 'logistics' = 'info';
+  @Output() viewChange = new EventEmitter<'info' | 'logistics'>();
+
+  select(view: 'info' | 'logistics'): void {
+    if (this.view !== view) {
+      this.view = view;
+      this.viewChange.emit(this.view);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add new `CatalogViewSwitcherComponent` to switch catalog views
- integrate the new tabs into `CatalogTableComponent`
- style tab placement next to the search bar
- display different column sets for "Основная информация" and "Закупка и логистика" modes

## Testing
- `npm test` *(fails: Could not find '@angular-devkit/build-angular:karma')*
- `npm run lint` *(fails: Cannot find "lint" target)*
- `npx ng build` *(fails: Angular CLI outside a workspace)*

------
https://chatgpt.com/codex/tasks/task_e_688bf4ab3e4083239de990c79a80ddf8