### PR TITLE
feat: enforce catalog selection for new stock items

### DIFF
--- a/feedme.client/src/app/components/add-receipt-popup/add-receipt-popup.component.html
+++ b/feedme.client/src/app/components/add-receipt-popup/add-receipt-popup.component.html
@@ -1,5 +1,5 @@
-<div class="popup-backdrop" (click)="onClose()">
-  <div class="popup-content" (click)="$event.stopPropagation()">
+<div class="popup-backdrop">
+  <div class="popup-content">
     <h2>Новая поставка</h2>
     <form [formGroup]="form" (ngSubmit)="onSubmit()">
 

--- a/feedme.client/src/app/components/catalog-new-product-popup/catalog-new-product-popup.component.html
+++ b/feedme.client/src/app/components/catalog-new-product-popup/catalog-new-product-popup.component.html
@@ -1,5 +1,5 @@
-<div class="popup-backdrop" (click)="close()">
-  <div class="popup-content" (click)="$event.stopPropagation()">
+<div class="popup-backdrop">
+  <div class="popup-content">
     <button class="close-btn" type="button" (click)="close()">×</button>
     <h2>Новый товар</h2>
     <form [formGroup]="form" (ngSubmit)="onSubmit()">

--- a/feedme.client/src/app/components/confirm-delete-popup/confirm-delete-popup.component.html
+++ b/feedme.client/src/app/components/confirm-delete-popup/confirm-delete-popup.component.html
@@ -1,5 +1,5 @@
-<div class="popup-backdrop" (click)="onCancel()">
-  <div class="popup-delete-content" (click)="$event.stopPropagation()">
+<div class="popup-backdrop">
+  <div class="popup-delete-content">
     <h2 class="popup-delete-title">{{ title }}</h2>
     <p class="popup-delete-text">{{ message }}</p>
     <div class="popup-delete-buttons">

--- a/feedme.client/src/app/components/edit-stock-popup/edit-stock-popup.component.html
+++ b/feedme.client/src/app/components/edit-stock-popup/edit-stock-popup.component.html
@@ -1,5 +1,5 @@
-<div class="popup-backdrop" (click)="handleClose()">
-  <div class="popup-content" (click)="$event.stopPropagation()">
+<div class="popup-backdrop">
+  <div class="popup-content">
     <button class="close-btn" (click)="handleClose()">×</button>
     <h2>Изменить остаток</h2>
     <div class="input-container">

--- a/feedme.client/src/app/components/new-product/new-product.component.css
+++ b/feedme.client/src/app/components/new-product/new-product.component.css
@@ -62,3 +62,31 @@
   cursor: pointer;
   color: #777;
 }
+
+/* Подсказки каталога */
+.input-container {
+  position: relative;
+}
+
+.suggestions-container {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  width: 100%;
+  max-height: 150px;
+  overflow-y: auto;
+  background-color: #fff;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  z-index: 2000;
+}
+
+.suggestion-item {
+  padding: 10px;
+  cursor: pointer;
+  transition: background-color 0.3s;
+}
+
+.suggestion-item:hover {
+  background-color: #f0f0f0;
+}

--- a/feedme.client/src/app/components/new-product/new-product.component.html
+++ b/feedme.client/src/app/components/new-product/new-product.component.html
@@ -6,7 +6,17 @@
       <div class="form-grid">
         <div class="input-container">
           <label>Название товара</label>
-          <input type="text" [(ngModel)]="productName" name="productName" required>
+          <input type="text"
+                 [(ngModel)]="productName"
+                 name="productName"
+                 (input)="updateSuggestions()"
+                 autocomplete="off"
+                 required>
+          <div class="suggestions-container" *ngIf="suggestions.length">
+            <div class="suggestion-item" *ngFor="let item of suggestions" (click)="selectSuggestion(item)">
+              {{ item.name }}
+            </div>
+          </div>
         </div>
 
         <div class="input-container">
@@ -45,7 +55,7 @@
 
       <div class="popup-buttons">
         <button type="button" class="cancel-btn" (click)="cancel()">Отмена</button>
-        <button type="submit" class="save-btn">Сохранить</button>
+        <button type="submit" class="save-btn" [disabled]="!selectedProduct">Сохранить</button>
       </div>
 
     </form>

--- a/feedme.client/src/app/components/new-product/new-product.component.ts
+++ b/feedme.client/src/app/components/new-product/new-product.component.ts
@@ -1,6 +1,7 @@
-import { Component, Output, EventEmitter } from '@angular/core';
+import { Component, Output, EventEmitter, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { WarehouseService } from '../../services/warehouse.service';
 
 @Component({
   selector: 'app-new-product',
@@ -9,35 +10,71 @@ import { FormsModule } from '@angular/forms';
   templateUrl: './new-product.component.html',
   styleUrls: ['./new-product.component.css']
 })
-export class NewProductComponent {
+export class NewProductComponent implements OnInit {
   @Output() onCancel = new EventEmitter<void>();
   @Output() onSubmit = new EventEmitter<any>();
 
-  productName: string = '';
-  category: string = '';
-  stock: string = '';
-  unitPrice: string = '';
-  expiryDate: string = '';
-  responsible: string = '';
-  supplier: string = '';
+  productName = '';
+  category = '';
+  stock = '';
+  unitPrice = '';
+  expiryDate = '';
+  responsible = '';
+  supplier = '';
 
-  categories: string[] = ['Заготовка', 'Готовое блюдо', 'Добавка', 'Товар'];
+  /** Данные каталога */
+  private catalog: any[] = [];
+  /** Подсказки по названию */
+  suggestions: any[] = [];
+  /** Выбранный товар каталога */
+  selectedProduct: any | null = null;
 
-  handleSubmit() {
+  readonly categories = ['Заготовка', 'Готовое блюдо', 'Добавка', 'Товар'];
+
+  constructor(private warehouseService: WarehouseService) {}
+
+  ngOnInit(): void {
+    this.catalog = this.warehouseService.getCatalog();
+  }
+
+  updateSuggestions(): void {
+    const query = this.productName.trim().toLowerCase();
+    this.selectedProduct = null;
+    if (!query) {
+      this.suggestions = [];
+      return;
+    }
+    this.suggestions = this.catalog.filter(item =>
+      item.name.toLowerCase().includes(query)
+    );
+  }
+
+  selectSuggestion(item: any): void {
+    this.selectedProduct = item;
+    this.productName = item.name;
+    this.category = item.category;
+    this.suggestions = [];
+  }
+
+  handleSubmit(): void {
+    if (!this.selectedProduct) return;
+
     const formData = {
-      productName: this.productName,
-      category: this.category,
+      catalogItem: this.selectedProduct,
+      productName: this.selectedProduct.name,
+      category: this.selectedProduct.category,
       stock: this.stock,
       unitPrice: this.unitPrice,
       expiryDate: this.expiryDate,
       responsible: this.responsible,
       supplier: this.supplier
     };
+
     this.onSubmit.emit(formData);
     this.resetForm();
   }
 
-  resetForm() {
+  resetForm(): void {
     this.productName = '';
     this.category = '';
     this.stock = '';
@@ -45,9 +82,11 @@ export class NewProductComponent {
     this.expiryDate = '';
     this.responsible = '';
     this.supplier = '';
+    this.suggestions = [];
+    this.selectedProduct = null;
   }
 
-  cancel() {
+  cancel(): void {
     this.onCancel.emit();
   }
 }

--- a/feedme.client/src/app/components/popup/popup.component.html
+++ b/feedme.client/src/app/components/popup/popup.component.html
@@ -1,5 +1,5 @@
-<div class="popup-backdrop" (click)="closePopup()">
-  <div class="popup-content" (click)="$event.stopPropagation()">
+<div class="popup-backdrop">
+  <div class="popup-content">
     <button class="close-btn" (click)="closePopup()">×</button>
     <h2>Добавить товар</h2>
     <form (ngSubmit)="handleSubmit()">


### PR DESCRIPTION
## Summary
- require choosing products from catalog when adding to warehouse
- carry full catalog data into warehouse entries
- stop popups from closing when clicking outside

## Testing
- `npm install`
- `npm test` *(fails: ChromeHeadless binary missing)*

------
https://chatgpt.com/codex/tasks/task_e_688ead0c09e08323ac2c340de783cd3d