### PR TITLE
feat: isolate catalog by warehouse

### DIFF
--- a/feedme.client/src/app/components/content/content.component.html
+++ b/feedme.client/src/app/components/content/content.component.html
@@ -8,8 +8,9 @@
 </app-supply-controls>
 
 <app-new-product *ngIf="showPopup && selectedSupply !== 'catalog'"
-                 (onSubmit)="onNewProductSubmit($event)"
-                 (onCancel)="showPopup = false">
+                [warehouse]="selectedTab"
+                (onSubmit)="onNewProductSubmit($event)"
+                (onCancel)="showPopup = false">
 </app-new-product>
 
 <app-catalog-new-product-popup *ngIf="showPopup && selectedSupply === 'catalog'"

--- a/feedme.client/src/app/components/content/content.component.ts
+++ b/feedme.client/src/app/components/content/content.component.ts
@@ -51,7 +51,7 @@ export class ContentComponent implements OnInit {
   private loadAllData(): void {
     this.supplyData = JSON.parse(localStorage.getItem(`warehouseSupplies_${this.selectedTab}`) || '[]');
     this.stockData = JSON.parse(localStorage.getItem(`warehouseStock_${this.selectedTab}`) || '[]');
-    this.catalogData = JSON.parse(localStorage.getItem('catalogData') || '[]');
+    this.catalogData = JSON.parse(localStorage.getItem(`warehouseCatalog_${this.selectedTab}`) || '[]');
   }
 
   /** Смена вкладки склада */
@@ -83,7 +83,7 @@ export class ContentComponent implements OnInit {
       localStorage.setItem(`warehouseStock_${this.selectedTab}`, JSON.stringify(this.stockData));
     } else {
       this.catalogData.push(item);
-      localStorage.setItem('catalogData', JSON.stringify(this.catalogData));
+      localStorage.setItem(`warehouseCatalog_${this.selectedTab}`, JSON.stringify(this.catalogData));
     }
     this.closeNewProductPopup();
   }
@@ -102,6 +102,6 @@ export class ContentComponent implements OnInit {
 
   onCatalogRemove(item: any): void {
     this.catalogData = this.catalogData.filter(i => i !== item);
-    localStorage.setItem('catalogData', JSON.stringify(this.catalogData));
+    localStorage.setItem(`warehouseCatalog_${this.selectedTab}`, JSON.stringify(this.catalogData));
   }
 }

--- a/feedme.client/src/app/components/new-product/new-product.component.ts
+++ b/feedme.client/src/app/components/new-product/new-product.component.ts
@@ -1,5 +1,5 @@
 
-import { Component, EventEmitter, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, OnInit, Output, Input } from '@angular/core';
 
 import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
@@ -18,6 +18,7 @@ import { map, startWith } from 'rxjs/operators';
 export class NewProductComponent implements OnInit {
   @Output() onCancel = new EventEmitter<void>();
   @Output() onSubmit = new EventEmitter<any>();
+  @Input() warehouse!: string;
 
 
   /** Форма добавления товара на склад */
@@ -45,7 +46,7 @@ export class NewProductComponent implements OnInit {
 
   ngOnInit(): void {
 
-    const catalog = this.warehouseService.getCatalog();
+    const catalog = this.warehouseService.getCatalog(this.warehouse);
     const nameControl = this.form.get('productName');
     this.suggestions$ = (nameControl ? nameControl.valueChanges : of('')).pipe(
       startWith(''),

--- a/feedme.client/src/app/components/popup/popup.component.ts
+++ b/feedme.client/src/app/components/popup/popup.component.ts
@@ -1,4 +1,4 @@
-import { Component, Output, EventEmitter, OnInit } from '@angular/core';
+import { Component, Output, EventEmitter, OnInit, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 
@@ -12,6 +12,7 @@ import { FormsModule } from '@angular/forms';
 export class PopupComponent implements OnInit {
   @Output() onClose = new EventEmitter<void>();
   @Output() onAddItem = new EventEmitter<any>();
+  @Input() warehouse!: string;
 
   name = '';
   category = '';
@@ -27,7 +28,7 @@ export class PopupComponent implements OnInit {
   categories = ['Заготовка', 'Готовое блюдо', 'Добавка', 'Товар'];
 
   ngOnInit() {
-    const savedData = localStorage.getItem('catalogData');
+    const savedData = localStorage.getItem(`warehouseCatalog_${this.warehouse}`);
     this.catalogData = savedData ? JSON.parse(savedData) : [];
   }
 

--- a/feedme.client/src/app/services/warehouse.service.ts
+++ b/feedme.client/src/app/services/warehouse.service.ts
@@ -4,7 +4,7 @@ import { Injectable } from '@angular/core';
 export class WarehouseService {
   private suppliesKey(tab: string) { return `warehouseSupplies_${tab}`; }
   private stockKey(tab: string) { return `warehouseStock_${tab}`; }
-  private catalogKey = 'catalogData';
+  private catalogKey(tab: string) { return `warehouseCatalog_${tab}`; }
 
   getSupplies(tab: string): any[] {
     return JSON.parse(localStorage.getItem(this.suppliesKey(tab)) || '[]');
@@ -26,13 +26,7 @@ export class WarehouseService {
     localStorage.setItem(this.stockKey(tab), JSON.stringify(arr));
   }
 
-  getCatalog(): any[] {
-    return JSON.parse(localStorage.getItem(this.catalogKey) || '[]');
-  }
-
-  addCatalog(item: any): void {
-    const arr = this.getCatalog();
-    arr.push(item);
-    localStorage.setItem(this.catalogKey, JSON.stringify(arr));
+  getCatalog(tab: string): any[] {
+    return JSON.parse(localStorage.getItem(this.catalogKey(tab)) || '[]');
   }
 }


### PR DESCRIPTION
## Summary
- scope catalog storage per warehouse so each tab maintains independent entries
- load and persist catalog data for selected warehouse
- allow new product and popup components to reference warehouse-specific catalogs

## Testing
- `npm test` *(fails: ChromeHeadless binary missing)*
- `npm run lint` *(fails: Angular CLI lint builder not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893d149fa988323a3dc248e437afe6c