### PR TITLE
feat: persist catalog on server

### DIFF
--- a/feedme.Server/Controllers/CatalogController.cs
+++ b/feedme.Server/Controllers/CatalogController.cs
@@ -1,0 +1,35 @@
+using feedme.Server.Models;
+using feedme.Server.Repositories;
+using Microsoft.AspNetCore.Mvc;
+
+namespace feedme.Server.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class CatalogController : ControllerBase
+{
+    private readonly ICatalogRepository _repository;
+
+    public CatalogController(ICatalogRepository repository)
+    {
+        _repository = repository;
+    }
+
+    [HttpGet]
+    public ActionResult<IEnumerable<CatalogItem>> Get()
+        => Ok(_repository.GetAll());
+
+    [HttpGet("{id}")]
+    public ActionResult<CatalogItem> GetById(string id)
+    {
+        var item = _repository.GetById(id);
+        return item is null ? NotFound() : Ok(item);
+    }
+
+    [HttpPost]
+    public ActionResult<CatalogItem> Create([FromBody] CatalogItem item)
+    {
+        var created = _repository.Add(item);
+        return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
+    }
+}

--- a/feedme.Server/Models/CatalogItem.cs
+++ b/feedme.Server/Models/CatalogItem.cs
@@ -1,0 +1,28 @@
+namespace feedme.Server.Models;
+
+public class CatalogItem
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+    public string Name { get; set; } = string.Empty;
+    public string Type { get; set; } = string.Empty;
+    public string Code { get; set; } = string.Empty;
+    public string Category { get; set; } = string.Empty;
+    public string Unit { get; set; } = string.Empty;
+    public double Weight { get; set; }
+    public string WriteoffMethod { get; set; } = string.Empty;
+    public string Allergens { get; set; } = string.Empty;
+    public bool PackagingRequired { get; set; }
+    public bool SpoilsAfterOpening { get; set; }
+    public string Supplier { get; set; } = string.Empty;
+    public int DeliveryTime { get; set; }
+    public double CostEstimate { get; set; }
+    public string TaxRate { get; set; } = string.Empty;
+    public double UnitPrice { get; set; }
+    public double SalePrice { get; set; }
+    public string Tnved { get; set; } = string.Empty;
+    public bool IsMarked { get; set; }
+    public bool IsAlcohol { get; set; }
+    public string AlcoholCode { get; set; } = string.Empty;
+    public double AlcoholStrength { get; set; }
+    public double AlcoholVolume { get; set; }
+}

--- a/feedme.Server/Program.cs
+++ b/feedme.Server/Program.cs
@@ -1,3 +1,4 @@
+using feedme.Server.Repositories;
 using Microsoft.AspNetCore.Authentication.Negotiate;
 
 namespace feedme.Server;
@@ -12,6 +13,7 @@ public class Program
         // Add services to the container.
 
         builder.Services.AddControllers();
+        builder.Services.AddSingleton<ICatalogRepository, InMemoryCatalogRepository>();
         // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
         builder.Services.AddOpenApi();
 

--- a/feedme.Server/Repositories/ICatalogRepository.cs
+++ b/feedme.Server/Repositories/ICatalogRepository.cs
@@ -1,0 +1,10 @@
+using feedme.Server.Models;
+
+namespace feedme.Server.Repositories;
+
+public interface ICatalogRepository
+{
+    IEnumerable<CatalogItem> GetAll();
+    CatalogItem? GetById(string id);
+    CatalogItem Add(CatalogItem item);
+}

--- a/feedme.Server/Repositories/InMemoryCatalogRepository.cs
+++ b/feedme.Server/Repositories/InMemoryCatalogRepository.cs
@@ -1,0 +1,19 @@
+using feedme.Server.Models;
+
+namespace feedme.Server.Repositories;
+
+public class InMemoryCatalogRepository : ICatalogRepository
+{
+    private readonly List<CatalogItem> _items = new();
+
+    public IEnumerable<CatalogItem> GetAll() => _items;
+
+    public CatalogItem? GetById(string id) => _items.FirstOrDefault(i => i.Id == id);
+
+    public CatalogItem Add(CatalogItem item)
+    {
+        item.Id = Guid.NewGuid().ToString();
+        _items.Add(item);
+        return item;
+    }
+}

--- a/feedme.client/src/app/components/catalog/catalog.component.ts
+++ b/feedme.client/src/app/components/catalog/catalog.component.ts
@@ -1,9 +1,9 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { FilterPipe } from '../../pipes/filter.pipe';
 import { NewProductFormValues } from '../catalog-new-product-popup/catalog-new-product-popup.component';
-
+import { CatalogService, CatalogItem } from '../../services/catalog.service';
 
 @Component({
   selector: 'app-catalog',
@@ -12,36 +12,22 @@ import { NewProductFormValues } from '../catalog-new-product-popup/catalog-new-p
   templateUrl: './catalog.component.html',
   styleUrls: ['./catalog.component.css']
 })
-export class CatalogComponent {
+export class CatalogComponent implements OnInit {
   activeTab: 'info' | 'logistics' = 'info';
   filter = '';
 
-  catalogData: any[] = [
-    {
-      id: '0001',
-      category: 'Заготовка',
-      name: 'Банка Coca-cola',
-      stock: '25шт',
-      price: '$4.95',
-      warehouse: 'Главный склад',
-      expiryDate: '20/12/2025',
-      supplier: 'ООО Рога и Копыта',
-    },
-    {
-      id: '0002',
-      category: 'Готовое блюдо',
-      name: 'Курица-гриль',
-      stock: '40кг',
-      price: '$8.95',
-      warehouse: 'Склад на кухне',
-      expiryDate: '28/02/2025',
-      supplier: 'ООО Рога и Копыта',
-    },
-  ];
+  catalogData: CatalogItem[] = [];
+
+  constructor(private catalogService: CatalogService) {}
+
+  ngOnInit(): void {
+    this.catalogService.getAll().subscribe(data => (this.catalogData = data));
+  }
 
   /** Добавляет новый товар в каталог */
   addProduct(item: NewProductFormValues): void {
-    const newItem = { id: Date.now().toString(), ...item };
-    this.catalogData.push(newItem);
+    this.catalogService.create(item).subscribe(created => {
+      this.catalogData.push(created);
+    });
   }
 }

--- a/feedme.client/src/app/services/catalog.service.ts
+++ b/feedme.client/src/app/services/catalog.service.ts
@@ -5,10 +5,27 @@ import { Observable } from 'rxjs';
 export interface CatalogItem {
   id: string;
   name: string;
-  supplierId: string;
-  tnvedCode: string;
+  type: string;
+  code: string;
+  category: string;
+  unit: string;
+  weight: number;
   writeoffMethod: string;
+  allergens: string;
+  packagingRequired: boolean;
+  spoilsAfterOpening: boolean;
+  supplier: string;
+  deliveryTime: number;
+  costEstimate: number;
+  taxRate: string;
   unitPrice: number;
+  salePrice: number;
+  tnved: string;
+  isMarked: boolean;
+  isAlcohol: boolean;
+  alcoholCode: string;
+  alcoholStrength: number;
+  alcoholVolume: number;
 }
 
 @Injectable({ providedIn: 'root' })
@@ -23,5 +40,9 @@ export class CatalogService {
 
   getById(id: string): Observable<CatalogItem> {
     return this.http.get<CatalogItem>(`${this.baseUrl}/${id}`);
+  }
+
+  create(item: Omit<CatalogItem, 'id'>): Observable<CatalogItem> {
+    return this.http.post<CatalogItem>(this.baseUrl, item);
   }
 }

--- a/feedme.client/src/app/services/warehouse.service.ts
+++ b/feedme.client/src/app/services/warehouse.service.ts
@@ -4,7 +4,6 @@ import { Injectable } from '@angular/core';
 export class WarehouseService {
   private suppliesKey(tab: string) { return `warehouseSupplies_${tab}`; }
   private stockKey(tab: string) { return `warehouseStock_${tab}`; }
-  private catalogKey = 'catalogData';
 
   getSupplies(tab: string): any[] {
     return JSON.parse(localStorage.getItem(this.suppliesKey(tab)) || '[]');
@@ -26,13 +25,4 @@ export class WarehouseService {
     localStorage.setItem(this.stockKey(tab), JSON.stringify(arr));
   }
 
-  getCatalog(): any[] {
-    return JSON.parse(localStorage.getItem(this.catalogKey) || '[]');
-  }
-
-  addCatalog(item: any): void {
-    const arr = this.getCatalog();
-    arr.push(item);
-    localStorage.setItem(this.catalogKey, JSON.stringify(arr));
-  }
 }


### PR DESCRIPTION
## Summary
- add server-side catalog API backed by in-memory repository
- switch client catalog logic to use API instead of local storage
- drop unused local catalog storage helpers

## Testing
- `npm test` *(fails: sh: 1: ng: not found)*
- `dotnet build` *(fails: current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6893d1e10610832396a3cd75462bfa6b