### PR TITLE
fix: ensure catalog icons render

### DIFF
--- a/feedme.client/src/app/components/CatalogTableComponent/catalog-table.component.html
+++ b/feedme.client/src/app/components/CatalogTableComponent/catalog-table.component.html
@@ -29,7 +29,7 @@
         <td class="actions-cell">
           <img src="assets/correct.svg" alt="Редактировать" (click)="edit.emit(item)">
           <img src="assets/delete.svg" alt="Удалить" (click)="requestDelete(item)">
-        </td>cd
+        </td>
       </tr>
       <tr *ngIf="paginatedData.length === 0">
         <td [attr.colspan]="columns.length + 1" class="no-data">Нет данных</td>

--- a/feedme.client/src/assets/correct.svg
+++ b/feedme.client/src/assets/correct.svg
@@ -1,37 +1,3 @@
-
-
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M20 6L9 17l-5-5"/>
-
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
-<svg width="800px" height="800px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <title>Adjustment</title>
-    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="Adjustment">
-            <rect id="Rectangle" fill-rule="nonzero" x="0" y="0" width="24" height="24">
-
-</rect>
-            <line x1="4" y1="7" x2="12" y2="7" id="Path" stroke="#0C0310" stroke-width="2" stroke-linecap="round">
-
-</line>
-            <line x1="4" y1="17" x2="6" y2="17" id="Path" stroke="#0C0310" stroke-width="2" stroke-linecap="round">
-
-</line>
-            <line x1="18" y1="7" x2="20" y2="7" id="Path" stroke="#0C0310" stroke-width="2" stroke-linecap="round">
-
-</line>
-            <line x1="13" y1="17" x2="20" y2="17" id="Path" stroke="#0C0310" stroke-width="2" stroke-linecap="round">
-
-</line>
-            <circle id="Oval" stroke="#0C0310" stroke-width="2" stroke-linecap="round" cx="15" cy="7" r="3">
-
-</circle>
-            <circle id="Oval" stroke="#0C0310" stroke-width="2" stroke-linecap="round" cx="9" cy="17" r="3">
-
-</circle>
-        </g>
-    </g>
-
-
+  <polyline points="20 6 9 17 4 12" />
 </svg>

--- a/feedme.client/src/assets/delete.svg
+++ b/feedme.client/src/assets/delete.svg
@@ -1,24 +1,4 @@
-
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M6 6l12 12M6 18L18 6"/>
-
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
-<svg width="800px" height="800px" viewBox="0 -0.5 21 21" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    
-    <title>delete [#1487]</title>
-    <desc>Created with Sketch.</desc>
-    <defs>
-
-</defs>
-    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="Dribbble-Light-Preview" transform="translate(-179.000000, -360.000000)" fill="#000000">
-            <g id="icons" transform="translate(56.000000, 160.000000)">
-                <path d="M130.35,216 L132.45,216 L132.45,208 L130.35,208 L130.35,216 Z M134.55,216 L136.65,216 L136.65,208 L134.55,208 L134.55,216 Z M128.25,218 L138.75,218 L138.75,206 L128.25,206 L128.25,218 Z M130.35,204 L136.65,204 L136.65,202 L130.35,202 L130.35,204 Z M138.75,204 L138.75,200 L128.25,200 L128.25,204 L123,204 L123,206 L126.15,206 L126.15,220 L140.85,220 L140.85,206 L144,206 L144,204 L138.75,204 Z" id="delete-[#1487]">
-
-</path>
-            </g>
-        </g>
-    </g>
-
+  <line x1="18" y1="6" x2="6" y2="18" />
+  <line x1="6" y1="6" x2="18" y2="18" />
 </svg>


### PR DESCRIPTION
## Summary
- remove stray text around catalog action buttons
- replace invalid SVG icons with clean check and cross graphics

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Property 'supplierId' does not exist on type 'CatalogItem')*

------
https://chatgpt.com/codex/tasks/task_e_6893dcdad094832391cf12be51bd5d12