### PR TITLE
style: tighten catalog tabs spacing

### DIFF
--- a/feedme.client/src/app/components/CatalogTableComponent/catalog-table.component.css
+++ b/feedme.client/src/app/components/CatalogTableComponent/catalog-table.component.css
@@ -35,7 +35,7 @@ app-table-controls {
 }
 
 app-catalog-view-switcher {
-  margin-left: 16px;
+  margin-left: 8px;
 }
 
 /* Контейнер для горизонтального скролла */

--- a/feedme.client/src/app/components/catalog-view-switcher/catalog-view-switcher.component.css
+++ b/feedme.client/src/app/components/catalog-view-switcher/catalog-view-switcher.component.css
@@ -5,7 +5,7 @@
 
 .view-switcher button {
   padding: 4px 12px;
-  font-size: 14px;
+  font-size: 16px;
   background: none;
   border: none;
   cursor: pointer;

--- a/feedme.client/src/app/components/catalog/catalog.component.css
+++ b/feedme.client/src/app/components/catalog/catalog.component.css
@@ -1,7 +1,7 @@
 .catalog-header {
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: 8px;
 }
 .tabs button {
   padding: 6px 12px;
@@ -9,6 +9,7 @@
   background: transparent;
   cursor: pointer;
   font-weight: 500;
+  font-size: 16px;
 }
 .tabs button.active {
   border-bottom: 2px solid #007bff;


### PR DESCRIPTION
## Summary
- nudge catalog view toggle closer to search controls
- enlarge tab switcher font for better readability
- shrink catalog header spacing for a tighter layout

## Testing
- `npm test` *(fails: Property 'supplierId' does not exist on type 'CatalogItem')*

------
https://chatgpt.com/codex/tasks/task_e_6893e81d99208323a3e5c8ed37814833