### PR TITLE
feat: simplify supply popup with catalog validation

### DIFF
--- a/feedme.client/src/app/components/popup/popup.component.css
+++ b/feedme.client/src/app/components/popup/popup.component.css
@@ -11,34 +11,58 @@
   z-index: 1000;
 }
 
-/* Основное окно попапа (390x790) */
 .popup-content {
-  width: 390px;
-  height: 790px;
+  width: 500px;
+  min-height: 400px;
   background-color: #fff;
   border-radius: 10px;
   padding: 20px;
-  box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
   position: relative;
   display: flex;
   flex-direction: column;
   overflow-y: auto;
 }
 
-  .popup-content h2 {
-    margin-top: 0;
-    font-size: 22px;
-    text-align: center;
-  }
+.popup-content h2 {
+  margin-top: 0;
+  font-size: 22px;
+  text-align: center;
+}
 
-  /* ГАРАНТИРУЕМ, ЧТО ВНУТРЕННИЙ КОНТЕНТ НЕ ОТРЕЖЕТСЯ */
-  .popup-content form {
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-    flex-grow: 1;
-  }
+.popup-content form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  flex-grow: 1;
+}
 
+.input-container {
+  position: relative;
+}
+
+.suggestions-container {
+  position: absolute;
+  background-color: #fff;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  width: 100%;
+  max-height: 150px;
+  overflow-y: auto;
+  z-index: 2000;
+  top: 100%;
+  left: 0;
+}
+
+.suggestion-item {
+  padding: 10px;
+  cursor: pointer;
+  transition: background-color 0.3s;
+}
+
+.suggestion-item:hover {
+  background-color: #f0f0f0;
+}
 
 .popup-buttons {
   display: flex;
@@ -46,32 +70,32 @@
   margin-top: auto;
 }
 
-  .popup-buttons button {
-    width: 48%;
-    padding: 12px;
-    border: none;
-    border-radius: 6px;
-    cursor: pointer;
-    font-size: 16px;
-  }
+.popup-buttons button {
+  width: 48%;
+  padding: 12px;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 16px;
+}
 
-  .popup-buttons .cancel-btn {
-    background-color: #ccc;
-    color: #000;
-  }
+.popup-buttons .cancel-btn {
+  background-color: #ccc;
+  color: #000;
+}
 
-  .popup-buttons .save-btn {
-    background-color: #007bff;
-    color: white;
-  }
+.popup-buttons .cancel-btn:hover {
+  background-color: #b3b3b3;
+}
 
-  .popup-buttons .cancel-btn:hover {
-    background-color: #b3b3b3;
-  }
+.popup-buttons .save-btn {
+  background-color: #007bff;
+  color: #fff;
+}
 
-  .popup-buttons .save-btn:hover {
-    background-color: #0056b3;
-  }
+.popup-buttons .save-btn:hover {
+  background-color: #0056b3;
+}
 
 .close-btn {
   position: absolute;
@@ -83,215 +107,3 @@
   cursor: pointer;
   color: #777;
 }
-
-/* Тёмная подложка */
-
-/* Основной блок попапа 390×790 */
-.old-popup-content {
-  position: relative;
-  width: 390px;
-  height: 790px;
-  background-color: #fff;
-  border: 2px solid #ccc;
-  border-radius: 8px;
-  padding: 20px;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
-  overflow-y: auto; /* прокрутка, если контент длинный */
-}
-
-/* Кнопка (X) в углу */
-.close-btn {
-  position: absolute;
-  top: 8px;
-  right: 8px;
-  background: none;
-  border: none;
-  font-size: 24px;
-  cursor: pointer;
-}
-
-/* Заголовок */
-.old-popup-content h2 {
-  margin: 0 0 15px;
-  font-size: 20px;
-}
-
-/* Отступы вокруг пар (label + input) */
-.field {
-  margin-bottom: 12px;
-}
-
-  .field label {
-    display: block;
-    margin-bottom: 4px;
-    font-weight: 500;
-  }
-
-  .field input {
-    width: 100%;
-    padding: 6px 8px;
-    border: 1px solid #ccc;
-    border-radius: 4px;
-    box-sizing: border-box;
-  }
-
-/* Блок с кнопками */
-.popup-buttons {
-  display: flex;
-  justify-content: flex-end;
-  gap: 10px;
-  margin-top: 20px;
-}
-
-.cancel-btn,
-.save-btn {
-  padding: 8px 16px;
-  border-radius: 6px;
-  cursor: pointer;
-  border: none;
-  font-size: 14px;
-}
-
-.cancel-btn {
-  background-color: #e0e0e0;
-  color: #333;
-}
-
-  .cancel-btn:hover {
-    background-color: #ccc;
-  }
-
-.save-btn {
-  background-color: #007bff;
-  color: #fff;
-}
-
-  .save-btn:hover {
-    background-color: #0056b3;
-  }
-
-.suggestions-container {
-  position: absolute;
-  background-color: #fff;
-  border: 1px solid #ccc;
-  border-radius: 5px;
-  width: 100%;
-  max-height: 150px;
-  overflow-y: auto;
-  z-index: 2000;
-  top: 100%; /* располагает подсказку строго под input */
-  left: 0;
-}
-
-.suggestion-item {
-  padding: 10px;
-  cursor: pointer;
-  transition: background-color 0.3s;
-}
-
-  .suggestion-item:hover {
-    background-color: #f0f0f0;
-  }
-
-.input-container {
-  position: relative; /* чтобы suggestions-container позиционировался относительно него */
-}
-
-/* Popup Catalog*/
-
-.popup-delete-content {
-  background: #fff;
-  border-radius: 15px;
-  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
-  padding: 30px;
-  width: 400px;
-  text-align: center;
-  position: relative;
-}
-
-.popup-delete-icon {
-  font-size: 40px;
-  margin-bottom: 20px;
-}
-
-.popup-delete-title {
-  font-size: 22px;
-  margin-bottom: 10px;
-}
-
-.popup-delete-text {
-  font-size: 16px;
-  margin-bottom: 25px;
-  color: #555;
-}
-
-.popup-delete-buttons {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
-.btn-delete-confirm,
-.btn-delete-cancel {
-  padding: 12px;
-  border-radius: 8px;
-  font-size: 16px;
-  cursor: pointer;
-  border: none;
-  transition: background-color 0.3s;
-}
-
-.btn-delete-confirm {
-  background-color: #e74c3c; /* красный цвет */
-  color: #fff;
-}
-
-  .btn-delete-confirm:hover {
-    background-color: #c0392b;
-  }
-
-.btn-delete-cancel {
-  background-color: #fff;
-  color: #333;
-  border: 1px solid #ccc;
-}
-
-  .btn-delete-cancel:hover {
-    background-color: #f2f2f2;
-  }
-
-
-
-/*  Попап создания склада*/
-
-.popup-create-storage {
-  width: 250px;
-  height: 150px;
-  background-color: #fff;
-  border-radius: 10px;
-  padding: 15px;
-  box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.2);
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  overflow-y: auto;
-}
-
-  .popup-create-storage h2 {
-    font-size: 18px;
-    margin: 0 0 10px;
-  }
-
-  .popup-create-storage input {
-    width: 100%;
-    padding: 6px;
-    border-radius: 4px;
-    border: 1px solid #ccc;
-    box-sizing: border-box;
-    margin-bottom: 10px;
-  }
-
-  .popup-create-storage .save-btn {
-    padding: 8px;
-    font-size: 14px;
-  }

--- a/feedme.client/src/app/components/popup/popup.component.html
+++ b/feedme.client/src/app/components/popup/popup.component.html
@@ -3,55 +3,58 @@
     <button class="close-btn" (click)="closePopup()">×</button>
     <h2>Добавить товар</h2>
     <form (ngSubmit)="handleSubmit()">
-
-      <div class="form-grid">
-        <div class="input-container">
-          <label>Дата поставки</label>
-          <input type="date" [(ngModel)]="supplyDate" name="supplyDate" required>
-        </div>
-
-        <div class="input-container">
-          <label>Название товара</label>
-          <input type="text" [(ngModel)]="name" (input)="updateSuggestions()" name="name" autocomplete="off" required>
-          <div class="suggestions-container" *ngIf="suggestedNames.length > 0 && !isSuggestionSelected">
-            <div class="suggestion-item" *ngFor="let suggestion of suggestedNames" (click)="handleSuggestionSelect(suggestion)">
-              {{ suggestion.name }}
-            </div>
+      <div class="input-container">
+        <label>Название товара</label>
+        <input
+          type="text"
+          [(ngModel)]="name"
+          (input)="updateSuggestions()"
+          name="name"
+          autocomplete="off"
+          required
+        />
+        <div
+          class="suggestions-container"
+          *ngIf="suggestedNames.length > 0 && !isSuggestionSelected"
+        >
+          <div
+            class="suggestion-item"
+            *ngFor="let suggestion of suggestedNames"
+            (click)="handleSuggestionSelect(suggestion)"
+          >
+            {{ suggestion.name }}
           </div>
         </div>
+      </div>
 
-        <div class="input-container">
-          <label>Категория товара</label>
-          <select [(ngModel)]="category" name="category" required>
-            <option value="">Выберите категорию</option>
-            <option *ngFor="let cat of categories" [value]="cat">{{ cat }}</option>
-          </select>
-        </div>
+      <div class="input-container" *ngIf="isSuggestionSelected">
+        <label>Кол-во товара</label>
+        <input type="number" [(ngModel)]="stock" name="stock" required />
+      </div>
 
-        <div class="input-container">
-          <label>Срок годности</label>
-          <input type="date" [(ngModel)]="expiryDate" name="expiryDate" required>
-        </div>
+      <div class="input-container" *ngIf="isSuggestionSelected">
+        <label>Срок годности</label>
+        <input
+          type="date"
+          [(ngModel)]="expiryDate"
+          name="expiryDate"
+          required
+        />
+      </div>
 
-        <div class="input-container">
-          <label>Цена за единицу</label>
-          <input type="number" [(ngModel)]="unitPrice" name="unitPrice" required>
-        </div>
-
-        <div class="input-container">
-          <label>Общая стоимость</label>
-          <input type="number" [(ngModel)]="totalCost" name="totalCost" required>
-        </div>
-
-        <div class="input-container">
-          <label>Кол-во товара в поставке</label>
-          <input type="number" [(ngModel)]="stock" name="stock" required>
-        </div>
-
-        <div class="popup-buttons">
-          <button type="button" class="cancel-btn" (click)="closePopup()">Отмена</button>
-          <button type="submit" class="save-btn">Сохранить</button>
-        </div>
-</form>
+      <div class="popup-buttons">
+        <button type="button" class="cancel-btn" (click)="closePopup()">
+          Отмена
+        </button>
+        <button
+          *ngIf="isSuggestionSelected"
+          type="submit"
+          class="save-btn"
+          [disabled]="!stock || !expiryDate"
+        >
+          Сохранить
+        </button>
+      </div>
+    </form>
   </div>
 </div>

--- a/feedme.client/src/app/components/popup/popup.component.ts
+++ b/feedme.client/src/app/components/popup/popup.component.ts
@@ -15,17 +15,12 @@ export class PopupComponent implements OnInit {
   @Input() warehouse!: string;
 
   name = '';
-  category = '';
-  expiryDate = '';
-  unitPrice = '';
-  totalCost = '';
   stock = '';
-  supplyDate = '';
+  expiryDate = '';
   isSuggestionSelected = false;
 
   suggestedNames: any[] = [];
   catalogData: any[] = [];
-  categories = ['Заготовка', 'Готовое блюдо', 'Добавка', 'Товар'];
 
   ngOnInit() {
     const savedData = localStorage.getItem(`warehouseCatalog_${this.warehouse}`);
@@ -45,28 +40,22 @@ export class PopupComponent implements OnInit {
 
   handleSuggestionSelect(suggestion: any) {
     this.name = suggestion.name;
-    this.category = suggestion.category;
-    this.stock = suggestion.stock || '';
-    this.unitPrice = suggestion.price || '';
-    this.expiryDate = suggestion.expiryDate || '';
-    this.supplyDate = suggestion.supplyDate || '';
-    this.totalCost = suggestion.totalCost || '';
     this.suggestedNames = [];
     this.isSuggestionSelected = true;
   }
 
   handleSubmit() {
+    if (!this.isSuggestionSelected) {
+      return;
+    }
+
     const id = Date.now().toString();
 
     const newItem = {
       id,
       name: this.name,
-      category: this.category,
       stock: this.stock,
-      unitPrice: this.unitPrice,
       expiryDate: this.expiryDate,
-      supplyDate: this.supplyDate,
-      totalCost: this.totalCost
     };
 
     this.onAddItem.emit(newItem);
@@ -75,13 +64,10 @@ export class PopupComponent implements OnInit {
 
   resetForm() {
     this.name = '';
-    this.category = '';
     this.stock = '';
-    this.unitPrice = '';
     this.expiryDate = '';
-    this.supplyDate = '';
-    this.totalCost = '';
     this.suggestedNames = [];
+    this.isSuggestionSelected = false;
   }
 
   closePopup() {


### PR DESCRIPTION
## Summary
- enlarge supply popup layout and clean styles
- show product name input with catalog suggestions and reveal quantity and expiry fields after selection
- block submission for items absent from catalog

## Testing
- `npm test` *(fails: Found 1 load error)*

------
https://chatgpt.com/codex/tasks/task_e_68974dfb10ec8323895a32152736fd7c