### PR TITLE
Limit supply popup to catalog items

### DIFF
--- a/feedme.client/src/app/components/add-receipt-popup/add-receipt-popup.component.ts
+++ b/feedme.client/src/app/components/add-receipt-popup/add-receipt-popup.component.ts
@@ -57,8 +57,8 @@ export class AddReceiptPopupComponent implements OnInit {
     if (!id) return;
     this.catalogService.getById(id).subscribe(item => {
       this.form.patchValue({
-        supplierId: item.supplierId,
-        tnvedCode: item.tnvedCode,
+        supplierId: item.supplier,
+        tnvedCode: item.tnved,
         writeoffMethod: item.writeoffMethod,
         unitPrice: item.unitPrice
       });

--- a/feedme.client/src/app/components/new-product/new-product.component.css
+++ b/feedme.client/src/app/components/new-product/new-product.component.css
@@ -12,7 +12,7 @@
 }
 
 .popup-content {
-  width: 390px;
+  width: 500px;
   background-color: #fff;
   border-radius: 10px;
   padding: 20px;

--- a/feedme.client/src/app/components/new-product/new-product.component.html
+++ b/feedme.client/src/app/components/new-product/new-product.component.html
@@ -16,50 +16,25 @@
               </div>
             </div>
           </ng-container>
-
-        </div>
-     
-        <div class="input-container">
-          <label>Категория товара</label>
-          <select formControlName="category" required>
-            <option value="">Выберите категорию</option>
-            <option *ngFor="let cat of categories" [value]="cat">{{ cat }}</option>
-          </select>
         </div>
 
-        <div class="input-container">
-          <label>Количество</label>
-          <input type="number" formControlName="stock" required>
-        </div>
+        <ng-container *ngIf="selectedProduct">
+          <div class="input-container">
+            <label>Количество</label>
+            <input type="number" formControlName="stock" required>
+          </div>
 
-        <div class="input-container">
-          <label>Цена за единицу</label>
-          <input type="number" formControlName="unitPrice" required>
-        </div>
-
-        <div class="input-container">
-          <label>Срок годности</label>
-          <input type="date" formControlName="expiryDate" required>
-        </div>
-
-        <div class="input-container">
-          <label>Ответственный склад</label>
-          <input type="text" formControlName="responsible">
-        </div>
-
-        <div class="input-container">
-          <label>Поставщик</label>
-          <input type="text" formControlName="supplier">
-        </div>
+          <div class="input-container">
+            <label>Срок годности</label>
+            <input type="date" formControlName="expiryDate" required>
+          </div>
+        </ng-container>
       </div>
 
       <div class="popup-buttons">
         <button type="button" class="cancel-btn" (click)="cancel()">Отмена</button>
-
         <button type="submit" class="save-btn" [disabled]="!selectedProduct || form.invalid">Сохранить</button>
-
       </div>
-
     </form>
   </div>
 </div>

--- a/feedme.client/src/app/components/new-product/new-product.component.ts
+++ b/feedme.client/src/app/components/new-product/new-product.component.ts
@@ -5,14 +5,11 @@ import { Observable, of } from 'rxjs';
 import { map, startWith } from 'rxjs/operators';
 import { CatalogItem, CatalogService } from '../../services/catalog.service';
 
-interface FormValues {
+/** Значения формы добавления поставки */
+interface SupplyFormValues {
   productName: string;
-  category: string;
   stock: string;
-  unitPrice: string;
   expiryDate: string;
-  responsible: string;
-  supplier: string;
 }
 
 
@@ -26,7 +23,14 @@ interface FormValues {
 export class NewProductComponent implements OnInit {
   @Output() onCancel = new EventEmitter<void>();
 
-  @Output() onSubmit = new EventEmitter<FormValues & { catalogItem: CatalogItem }>();
+  @Output() onSubmit = new EventEmitter<SupplyFormValues & {
+    catalogItem: CatalogItem;
+    category: string;
+    unitPrice: number;
+    supplier: string;
+    responsible: string;
+  }>();
+
   @Input() warehouse!: string;
 
   constructor(
@@ -34,32 +38,22 @@ export class NewProductComponent implements OnInit {
     private catalogService: CatalogService
   ) {}
 
-  /** Форма добавления товара на склад */
+  /** Форма добавления поставки */
   readonly form = this.fb.group({
     productName: this.fb.nonNullable.control('', Validators.required),
-    category: this.fb.nonNullable.control('', Validators.required),
     stock: this.fb.nonNullable.control('', Validators.required),
-    unitPrice: this.fb.nonNullable.control('', Validators.required),
-    expiryDate: this.fb.nonNullable.control('', Validators.required),
-    responsible: this.fb.nonNullable.control(''),
-    supplier: this.fb.nonNullable.control('')
+    expiryDate: this.fb.nonNullable.control('', Validators.required)
   });
-
-  /** Категории для выбора */
-  readonly categories = ['Заготовка', 'Готовое блюдо', 'Добавка', 'Товар'];
 
   /** Текущий выбранный товар каталога */
   selectedProduct: CatalogItem | null = null;
 
   /** Поток подсказок по названию */
-
   suggestions$!: Observable<CatalogItem[]>;
 
   private catalog: CatalogItem[] = [];
 
   ngOnInit(): void {
-    this.form.patchValue({ responsible: this.warehouse });
-
     this.catalogService.getAll().subscribe(catalog => {
       this.catalog = catalog;
       const nameControl = this.form.get('productName');
@@ -74,7 +68,6 @@ export class NewProductComponent implements OnInit {
     const query = value.trim().toLowerCase();
     if (!query) {
       this.selectedProduct = null;
-      this.form.get('category')!.setValue('');
       return [];
     }
     const matches = this.catalog.filter(item =>
@@ -82,34 +75,36 @@ export class NewProductComponent implements OnInit {
     );
     const exact = matches.find(item => item.name.toLowerCase() === query);
     if (exact) {
-      this.selectSuggestion(exact);
+      this.selectedProduct = exact;
+      this.form.patchValue({ productName: exact.name }, { emitEvent: false });
       return [];
     }
     this.selectedProduct = null;
-    this.form.get('category')!.setValue('');
     return matches;
   }
 
-
   selectSuggestion(item: CatalogItem): void {
     this.selectedProduct = item;
-    this.form.patchValue({
-      productName: item.name,
-      category: item.category
-    });
+    this.form.patchValue({ productName: item.name });
   }
 
   handleSubmit(): void {
     if (!this.selectedProduct || this.form.invalid) {
       return;
     }
-    const data: FormValues & { catalogItem: CatalogItem } = {
-      catalogItem: this.selectedProduct,
-      ...(this.form.getRawValue() as FormValues)
+    const { stock, expiryDate } = this.form.getRawValue();
+    const data = {
+      productName: this.selectedProduct.name,
+      stock,
+      expiryDate,
+      category: this.selectedProduct.category,
+      unitPrice: this.selectedProduct.unitPrice,
+      supplier: this.selectedProduct.supplier,
+      responsible: this.warehouse,
+      catalogItem: this.selectedProduct
     };
     this.onSubmit.emit(data);
     this.form.reset();
-
     this.selectedProduct = null;
   }
 


### PR DESCRIPTION
## Summary
- expand supply popup width for better readability
- show only name, quantity and expiry fields when adding a supply
- align receipt popup with catalog service field names

## Testing
- `npm ci`
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Command '/usr/bin/chromium-browser' requires the chromium snap to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_6897517a1588832391a5b4c2bc20db57