### PR TITLE
Limit supply popup to catalog items

### DIFF
--- a/feedme.client/src/app/components/add-receipt-popup/add-receipt-popup.component.ts
+++ b/feedme.client/src/app/components/add-receipt-popup/add-receipt-popup.component.ts
@@ -57,8 +57,8 @@ export class AddReceiptPopupComponent implements OnInit {
     if (!id) return;
     this.catalogService.getById(id).subscribe(item => {
       this.form.patchValue({
-        supplierId: item.supplierId,
-        tnvedCode: item.tnvedCode,
+        supplierId: item.supplier,
+        tnvedCode: item.tnved,
         writeoffMethod: item.writeoffMethod,
         unitPrice: item.unitPrice
       });

--- a/feedme.client/src/app/components/catalog-new-product-popup/catalog-new-product-popup.component.html
+++ b/feedme.client/src/app/components/catalog-new-product-popup/catalog-new-product-popup.component.html
@@ -127,7 +127,9 @@
       </div>
       <div class="popup-buttons">
         <button type="button" class="cancel-btn" (click)="close()">Отмена</button>
-        <button type="submit" class="save-btn">Сохранить</button>
+        <button type="button" class="save-btn" (click)="onSubmit()" [disabled]="form.invalid">
+          Сохранить
+        </button>
       </div>
     </form>
   </div>

--- a/feedme.client/src/app/components/catalog-new-product-popup/catalog-new-product-popup.component.ts
+++ b/feedme.client/src/app/components/catalog-new-product-popup/catalog-new-product-popup.component.ts
@@ -53,7 +53,6 @@ export type NewProductForm = {
 export class CatalogNewProductPopupComponent {
   @Output() cancel = new EventEmitter<void>();
   @Output() save = new EventEmitter<NewProductFormValues>();
-  @Output() submitForm = new EventEmitter<NewProductFormValues>();
 
   form: FormGroup<NewProductForm>;
 
@@ -111,11 +110,10 @@ export class CatalogNewProductPopupComponent {
     });
   }
   onSubmit(): void {
-    if (this.form.valid) {
-      const data = this.form.getRawValue();
-      this.save.emit(data);
-      this.submitForm.emit(data);
+    if (this.form.invalid) {
+      return;
     }
+    this.save.emit(this.form.getRawValue());
   }
 
   close(): void {

--- a/feedme.client/src/app/components/content/content.component.ts
+++ b/feedme.client/src/app/components/content/content.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { take } from 'rxjs';
 
 import { WarehouseTabsComponent } from '../warehouse-tabs/warehouse-tabs.component';
 import { SupplyControlsComponent } from '../supply-controls/supply-controls.component';
@@ -89,10 +90,13 @@ export class ContentComponent implements OnInit {
       localStorage.setItem(`warehouseStock_${this.selectedTab}`, JSON.stringify(this.stockData));
       this.closeNewProductPopup();
     } else {
-      this.catalogService.create(item).subscribe(created => {
-        this.catalogData.push(created);
-        this.closeNewProductPopup();
-      });
+      this.catalogService
+        .create(item)
+        .pipe(take(1))
+        .subscribe(created => {
+          this.catalogData.push(created);
+          this.closeNewProductPopup();
+        });
     }
   }
 

--- a/feedme.client/src/app/components/new-product/new-product.component.css
+++ b/feedme.client/src/app/components/new-product/new-product.component.css
@@ -12,7 +12,7 @@
 }
 
 .popup-content {
-  width: 390px;
+  width: 500px;
   background-color: #fff;
   border-radius: 10px;
   padding: 20px;

--- a/feedme.client/src/app/components/new-product/new-product.component.html
+++ b/feedme.client/src/app/components/new-product/new-product.component.html
@@ -16,50 +16,25 @@
               </div>
             </div>
           </ng-container>
-
-        </div>
-     
-        <div class="input-container">
-          <label>Категория товара</label>
-          <select formControlName="category" required>
-            <option value="">Выберите категорию</option>
-            <option *ngFor="let cat of categories" [value]="cat">{{ cat }}</option>
-          </select>
         </div>
 
-        <div class="input-container">
-          <label>Количество</label>
-          <input type="number" formControlName="stock" required>
-        </div>
+        <ng-container *ngIf="selectedProduct">
+          <div class="input-container">
+            <label>Количество</label>
+            <input type="number" formControlName="stock" required>
+          </div>
 
-        <div class="input-container">
-          <label>Цена за единицу</label>
-          <input type="number" formControlName="unitPrice" required>
-        </div>
-
-        <div class="input-container">
-          <label>Срок годности</label>
-          <input type="date" formControlName="expiryDate" required>
-        </div>
-
-        <div class="input-container">
-          <label>Ответственный склад</label>
-          <input type="text" formControlName="responsible">
-        </div>
-
-        <div class="input-container">
-          <label>Поставщик</label>
-          <input type="text" formControlName="supplier">
-        </div>
+          <div class="input-container">
+            <label>Срок годности</label>
+            <input type="date" formControlName="expiryDate" required>
+          </div>
+        </ng-container>
       </div>
 
       <div class="popup-buttons">
         <button type="button" class="cancel-btn" (click)="cancel()">Отмена</button>
-
         <button type="submit" class="save-btn" [disabled]="!selectedProduct || form.invalid">Сохранить</button>
-
       </div>
-
     </form>
   </div>
 </div>

--- a/feedme.client/src/app/components/new-product/new-product.component.ts
+++ b/feedme.client/src/app/components/new-product/new-product.component.ts
@@ -5,14 +5,11 @@ import { Observable, of } from 'rxjs';
 import { map, startWith } from 'rxjs/operators';
 import { CatalogItem, CatalogService } from '../../services/catalog.service';
 
-interface FormValues {
+/** Значения формы добавления поставки */
+interface SupplyFormValues {
   productName: string;
-  category: string;
   stock: string;
-  unitPrice: string;
   expiryDate: string;
-  responsible: string;
-  supplier: string;
 }
 
 
@@ -26,7 +23,14 @@ interface FormValues {
 export class NewProductComponent implements OnInit {
   @Output() onCancel = new EventEmitter<void>();
 
-  @Output() onSubmit = new EventEmitter<FormValues & { catalogItem: CatalogItem }>();
+  @Output() onSubmit = new EventEmitter<SupplyFormValues & {
+    catalogItem: CatalogItem;
+    category: string;
+    unitPrice: number;
+    supplier: string;
+    responsible: string;
+  }>();
+
   @Input() warehouse!: string;
 
   constructor(
@@ -34,32 +38,22 @@ export class NewProductComponent implements OnInit {
     private catalogService: CatalogService
   ) {}
 
-  /** Форма добавления товара на склад */
+  /** Форма добавления поставки */
   readonly form = this.fb.group({
     productName: this.fb.nonNullable.control('', Validators.required),
-    category: this.fb.nonNullable.control('', Validators.required),
     stock: this.fb.nonNullable.control('', Validators.required),
-    unitPrice: this.fb.nonNullable.control('', Validators.required),
-    expiryDate: this.fb.nonNullable.control('', Validators.required),
-    responsible: this.fb.nonNullable.control(''),
-    supplier: this.fb.nonNullable.control('')
+    expiryDate: this.fb.nonNullable.control('', Validators.required)
   });
-
-  /** Категории для выбора */
-  readonly categories = ['Заготовка', 'Готовое блюдо', 'Добавка', 'Товар'];
 
   /** Текущий выбранный товар каталога */
   selectedProduct: CatalogItem | null = null;
 
   /** Поток подсказок по названию */
-
   suggestions$!: Observable<CatalogItem[]>;
 
   private catalog: CatalogItem[] = [];
 
   ngOnInit(): void {
-    this.form.patchValue({ responsible: this.warehouse });
-
     this.catalogService.getAll().subscribe(catalog => {
       this.catalog = catalog;
       const nameControl = this.form.get('productName');
@@ -74,7 +68,6 @@ export class NewProductComponent implements OnInit {
     const query = value.trim().toLowerCase();
     if (!query) {
       this.selectedProduct = null;
-      this.form.get('category')!.setValue('');
       return [];
     }
     const matches = this.catalog.filter(item =>
@@ -82,34 +75,36 @@ export class NewProductComponent implements OnInit {
     );
     const exact = matches.find(item => item.name.toLowerCase() === query);
     if (exact) {
-      this.selectSuggestion(exact);
+      this.selectedProduct = exact;
+      this.form.patchValue({ productName: exact.name }, { emitEvent: false });
       return [];
     }
     this.selectedProduct = null;
-    this.form.get('category')!.setValue('');
     return matches;
   }
 
-
   selectSuggestion(item: CatalogItem): void {
     this.selectedProduct = item;
-    this.form.patchValue({
-      productName: item.name,
-      category: item.category
-    });
+    this.form.patchValue({ productName: item.name });
   }
 
   handleSubmit(): void {
     if (!this.selectedProduct || this.form.invalid) {
       return;
     }
-    const data: FormValues & { catalogItem: CatalogItem } = {
-      catalogItem: this.selectedProduct,
-      ...(this.form.getRawValue() as FormValues)
+    const { stock, expiryDate } = this.form.getRawValue();
+    const data = {
+      productName: this.selectedProduct.name,
+      stock,
+      expiryDate,
+      category: this.selectedProduct.category,
+      unitPrice: this.selectedProduct.unitPrice,
+      supplier: this.selectedProduct.supplier,
+      responsible: this.warehouse,
+      catalogItem: this.selectedProduct
     };
     this.onSubmit.emit(data);
     this.form.reset();
-
     this.selectedProduct = null;
   }
 


### PR DESCRIPTION
## Summary
- expand supply popup width for better readability
- show only name, quantity and expiry fields when adding a supply
- align receipt popup with catalog service field names
- enable catalog product creation with a responsive save button
- submit catalog entries once and close the popup on success

## Testing
- `npm ci`
- `npm run lint` *(fails: Cannot find "lint" target for the specified project)*
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_6897517a1588832391a5b4c2bc20db57