### PR TITLE
Limit supply popup to catalog items

### DIFF
--- a/feedme.client/src/app/components/add-receipt-popup/add-receipt-popup.component.ts
+++ b/feedme.client/src/app/components/add-receipt-popup/add-receipt-popup.component.ts
@@ -57,8 +57,8 @@ export class AddReceiptPopupComponent implements OnInit {
     if (!id) return;
     this.catalogService.getById(id).subscribe(item => {
       this.form.patchValue({
-        supplierId: item.supplierId,
-        tnvedCode: item.tnvedCode,
+        supplierId: item.supplier,
+        tnvedCode: item.tnved,
         writeoffMethod: item.writeoffMethod,
         unitPrice: item.unitPrice
       });

--- a/feedme.client/src/app/components/catalog-new-product-popup/catalog-new-product-popup.component.html
+++ b/feedme.client/src/app/components/catalog-new-product-popup/catalog-new-product-popup.component.html
@@ -127,7 +127,9 @@
       </div>
       <div class="popup-buttons">
         <button type="button" class="cancel-btn" (click)="close()">Отмена</button>
-        <button type="submit" class="save-btn">Сохранить</button>
+        <button type="submit" class="save-btn" [disabled]="form.invalid">
+          Сохранить
+        </button>
       </div>
     </form>
   </div>

--- a/feedme.client/src/app/components/catalog-new-product-popup/catalog-new-product-popup.component.ts
+++ b/feedme.client/src/app/components/catalog-new-product-popup/catalog-new-product-popup.component.ts
@@ -53,7 +53,6 @@ export type NewProductForm = {
 export class CatalogNewProductPopupComponent {
   @Output() cancel = new EventEmitter<void>();
   @Output() save = new EventEmitter<NewProductFormValues>();
-  @Output() submitForm = new EventEmitter<NewProductFormValues>();
 
   form: FormGroup<NewProductForm>;
 
@@ -111,11 +110,11 @@ export class CatalogNewProductPopupComponent {
     });
   }
   onSubmit(): void {
-    if (this.form.valid) {
-      const data = this.form.getRawValue();
-      this.save.emit(data);
-      this.submitForm.emit(data);
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
     }
+    this.save.emit(this.form.getRawValue());
   }
 
   close(): void {

--- a/feedme.client/src/app/components/content/content.component.ts
+++ b/feedme.client/src/app/components/content/content.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { take } from 'rxjs';
 
 import { WarehouseTabsComponent } from '../warehouse-tabs/warehouse-tabs.component';
 import { SupplyControlsComponent } from '../supply-controls/supply-controls.component';
@@ -89,10 +90,13 @@ export class ContentComponent implements OnInit {
       localStorage.setItem(`warehouseStock_${this.selectedTab}`, JSON.stringify(this.stockData));
       this.closeNewProductPopup();
     } else {
-      this.catalogService.create(item).subscribe(created => {
-        this.catalogData.push(created);
-        this.closeNewProductPopup();
-      });
+      this.catalogService
+        .create(item)
+        .pipe(take(1))
+        .subscribe(created => {
+          this.catalogData.push(created);
+          this.closeNewProductPopup();
+        });
     }
   }
 

--- a/feedme.client/src/app/components/new-product/new-product.component.css
+++ b/feedme.client/src/app/components/new-product/new-product.component.css
@@ -12,7 +12,7 @@
 }
 
 .popup-content {
-  width: 390px;
+  width: 500px;
   background-color: #fff;
   border-radius: 10px;
   padding: 20px;

--- a/feedme.client/src/app/components/new-product/new-product.component.html
+++ b/feedme.client/src/app/components/new-product/new-product.component.html
@@ -16,50 +16,25 @@
               </div>
             </div>
           </ng-container>
-
-        </div>
-     
-        <div class="input-container">
-          <label>Категория товара</label>
-          <select formControlName="category" required>
-            <option value="">Выберите категорию</option>
-            <option *ngFor="let cat of categories" [value]="cat">{{ cat }}</option>
-          </select>
         </div>
 
-        <div class="input-container">
-          <label>Количество</label>
-          <input type="number" formControlName="stock" required>
-        </div>
+        <ng-container *ngIf="selectedProduct">
+          <div class="input-container">
+            <label>Количество</label>
+            <input type="number" formControlName="stock" required>
+          </div>
 
-        <div class="input-container">
-          <label>Цена за единицу</label>
-          <input type="number" formControlName="unitPrice" required>
-        </div>
-
-        <div class="input-container">
-          <label>Срок годности</label>
-          <input type="date" formControlName="expiryDate" required>
-        </div>
-
-        <div class="input-container">
-          <label>Ответственный склад</label>
-          <input type="text" formControlName="responsible">
-        </div>
-
-        <div class="input-container">
-          <label>Поставщик</label>
-          <input type="text" formControlName="supplier">
-        </div>
+          <div class="input-container">
+            <label>Срок годности</label>
+            <input type="date" formControlName="expiryDate" required>
+          </div>
+        </ng-container>
       </div>
 
       <div class="popup-buttons">
         <button type="button" class="cancel-btn" (click)="cancel()">Отмена</button>
-
         <button type="submit" class="save-btn" [disabled]="!selectedProduct || form.invalid">Сохранить</button>
-
       </div>
-
     </form>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- expand supply popup width for better readability
- show only name, quantity and expiry fields when adding a supply
- align receipt popup with catalog service field names
- enable catalog product creation with a responsive save button
- submit catalog entries once and close the popup on success
- ensure catalog popup save button triggers form submission and validation
- pre-initialize supply suggestions and load catalog once for immediate matches

## Testing
- `npm ci`
- `npm run lint` *(fails: Cannot find "lint" target for the specified project)*
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_6897517a1588832391a5b4c2bc20db57