### PR TITLE
feat: log catalog add errors

### DIFF
--- a/feedme.client/src/app/components/catalog/catalog.component.ts
+++ b/feedme.client/src/app/components/catalog/catalog.component.ts
@@ -34,9 +34,12 @@ export class CatalogComponent implements OnInit {
     this.catalogService
       .create(item)
       .pipe(take(1))
-      .subscribe(created => {
-        const updated = [...this.catalogDataSubject.value, created];
-        this.catalogDataSubject.next(updated);
+      .subscribe({
+        next: created => {
+          const updated = [...this.catalogDataSubject.value, created];
+          this.catalogDataSubject.next(updated);
+        },
+        error: err => console.error('Ошибка при добавлении товара в каталог', err)
       });
   }
 }

--- a/feedme.client/src/app/components/content/content.component.ts
+++ b/feedme.client/src/app/components/content/content.component.ts
@@ -93,9 +93,12 @@ export class ContentComponent implements OnInit {
       this.catalogService
         .create(item)
         .pipe(take(1))
-        .subscribe(created => {
-          this.catalogData.push(created);
-          this.closeNewProductPopup();
+        .subscribe({
+          next: created => {
+            this.catalogData = [...this.catalogData, created];
+            this.closeNewProductPopup();
+          },
+          error: err => console.error('Ошибка при добавлении товара в каталог', err)
         });
     }
   }


### PR DESCRIPTION
## Summary
- add error logging when catalog item creation fails
- fix catalog table update after creating item

## Testing
- `CHROME_BIN=$(which chromium-browser) npm test` *(fails: ChromeHeadless requires snap chromium)*
- `dotnet test` *(fails: .NET SDK 8.0 doesn't support target .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6899d23a6eb483238f973c829072765e