### PR TITLE
feat: proxy api requests and show save errors

### DIFF
--- a/feedme.client/angular.json
+++ b/feedme.client/angular.json
@@ -46,7 +46,8 @@
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
-            "buildTarget": "feedme:build"
+            "buildTarget": "feedme:build",
+            "proxyConfig": "src/proxy.conf.js"
           },
           "configurations": {
             "production": {

--- a/feedme.client/src/app/components/catalog-new-product-popup/catalog-new-product-popup.component.css
+++ b/feedme.client/src/app/components/catalog-new-product-popup/catalog-new-product-popup.component.css
@@ -29,6 +29,11 @@
     text-align: center;
     margin-bottom: 16px;
   }
+.error-message {
+  color: #dc3545;
+  text-align: center;
+  margin-bottom: 16px;
+}
 .form-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);

--- a/feedme.client/src/app/components/catalog-new-product-popup/catalog-new-product-popup.component.html
+++ b/feedme.client/src/app/components/catalog-new-product-popup/catalog-new-product-popup.component.html
@@ -2,6 +2,7 @@
   <div class="popup-content">
     <button class="close-btn" type="button" (click)="close()">×</button>
     <h2>Новый товар</h2>
+    <p class="error-message" *ngIf="errorMessage">{{ errorMessage }}</p>
     <form [formGroup]="form" (ngSubmit)="onSubmit()">
       <div class="section">
         <h3 class="section-title">Основная информация</h3>

--- a/feedme.client/src/app/components/catalog-new-product-popup/catalog-new-product-popup.component.ts
+++ b/feedme.client/src/app/components/catalog-new-product-popup/catalog-new-product-popup.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import {
   ReactiveFormsModule,
@@ -51,6 +51,7 @@ export type NewProductForm = {
   styleUrls: ['./catalog-new-product-popup.component.css']
 })
 export class CatalogNewProductPopupComponent {
+  @Input() errorMessage: string | null = null;
   @Output() cancel = new EventEmitter<void>();
   @Output() save = new EventEmitter<NewProductFormValues>();
 

--- a/feedme.client/src/app/components/catalog/catalog.component.css
+++ b/feedme.client/src/app/components/catalog/catalog.component.css
@@ -15,6 +15,10 @@
   border-bottom: 2px solid #007bff;
   color: #007bff;
 }
+.error-message {
+  color: #dc3545;
+  margin-top: 8px;
+}
 .catalog-table {
   width: 100%;
   border-collapse: collapse;

--- a/feedme.client/src/app/components/catalog/catalog.component.html
+++ b/feedme.client/src/app/components/catalog/catalog.component.html
@@ -5,6 +5,7 @@
     <button (click)="activeTab='logistics'" [class.active]="activeTab==='logistics'">Закупка и логистика</button>
   </div>
 </div>
+<div class="error-message" *ngIf="saveError">{{ saveError }}</div>
 
 <div *ngIf="activeTab==='info'">
   <table class="catalog-table">

--- a/feedme.client/src/app/components/catalog/catalog.component.ts
+++ b/feedme.client/src/app/components/catalog/catalog.component.ts
@@ -19,6 +19,7 @@ export class CatalogComponent implements OnInit {
 
   private readonly catalogDataSubject = new BehaviorSubject<CatalogItem[]>([]);
   readonly catalogData$ = this.catalogDataSubject.asObservable();
+  saveError: string | null = null;
 
   constructor(private catalogService: CatalogService) {}
 
@@ -38,8 +39,11 @@ export class CatalogComponent implements OnInit {
         next: created => {
           const updated = [...this.catalogDataSubject.value, created];
           this.catalogDataSubject.next(updated);
+          this.saveError = null;
         },
-        error: err => console.error('Ошибка при добавлении товара в каталог', err)
+        error: () => {
+          this.saveError = 'Не удалось сохранить товар. Попробуйте ещё раз.';
+        }
       });
   }
 }

--- a/feedme.client/src/app/components/content/content.component.html
+++ b/feedme.client/src/app/components/content/content.component.html
@@ -15,7 +15,8 @@
 
 <app-catalog-new-product-popup *ngIf="showPopup && selectedSupply === 'catalog'"
                                (save)="onNewProductSubmit($event)"
-                               (cancel)="closeNewProductPopup()">
+                               (cancel)="closeNewProductPopup()"
+                               [errorMessage]="saveError">
 </app-catalog-new-product-popup>
 
 <app-info-cards-wrapper *ngIf="selectedSupply !== 'catalog' && selectedItem"

--- a/feedme.client/src/app/components/content/content.component.ts
+++ b/feedme.client/src/app/components/content/content.component.ts
@@ -44,6 +44,7 @@ export class ContentComponent implements OnInit {
 
   selectedItem: any = null;
   showPopup = false;
+  saveError: string | null = null;
 
   constructor(private catalogService: CatalogService) {}
 
@@ -73,10 +74,12 @@ export class ContentComponent implements OnInit {
 
   /** Открыть попап добавления */
   openNewProductPopup(): void {
+    this.saveError = null;
     this.showPopup = true;
   }
   closeNewProductPopup(): void {
     this.showPopup = false;
+    this.saveError = null;
   }
 
   /** Получить новые данные из формы */
@@ -97,8 +100,11 @@ export class ContentComponent implements OnInit {
           next: created => {
             this.catalogData = [...this.catalogData, created];
             this.closeNewProductPopup();
+            this.saveError = null;
           },
-          error: err => console.error('Ошибка при добавлении товара в каталог', err)
+          error: () => {
+            this.saveError = 'Не удалось сохранить товар. Попробуйте ещё раз.';
+          }
         });
     }
   }

--- a/feedme.client/src/proxy.conf.js
+++ b/feedme.client/src/proxy.conf.js
@@ -1,11 +1,14 @@
 const { env } = require('process');
 
-const target = env["services__feedme-server__https__0"] ?? 'https://localhost:7221';
+const httpsTarget = env['services__feedme-server__https__0'];
+const httpTarget = env['services__feedme-server__http__0'];
+const target = httpsTarget ?? httpTarget ?? 'https://localhost:7221';
 
 const PROXY_CONFIG = [
   {
     context: [
       "/weatherforecast",
+      "/api",
     ],
     target,
     secure: false


### PR DESCRIPTION
## Summary
- proxy /api requests to backend
- surface save failures with user-friendly error messages
- enable API proxy during development

## Testing
- `npm test` *(fails: No binary for ChromeHeadless browser on your platform)*
- `npm run lint` *(fails: Cannot find "lint" target)*

------
https://chatgpt.com/codex/tasks/task_e_689a2bfa639483238ca55143d5df4753