### PR TITLE
fix: correct proxy configuration

### DIFF
--- a/feedme.client/src/proxy.conf.js
+++ b/feedme.client/src/proxy.conf.js
@@ -6,14 +6,21 @@ const httpTarget = env['services__feedme-server__http__0'];
 // Prefer the HTTP endpoint to avoid TLS issues when no certificates are configured
 const target = httpTarget ?? httpsTarget ?? 'http://localhost:5016';
 
-const PROXY_CONFIG = [
-  {
-    context: ['/api', '/api/**'],
+/**
+ * Development server proxy configuration.
+ *
+ * Exporting an object keyed by context strings avoids "Invalid context" errors
+ * from http-proxy-middleware, which expects each property name to be a valid
+ * path used when matching requests for proxying. The configuration below
+ * proxies any call starting with `/api` to the backend server defined by the
+ * `target` variable.
+ */
+const PROXY_CONFIG = {
+  '/api': {
     target,
     secure: false,
     logLevel: 'error',
   },
-];
-
+};
 
 module.exports = PROXY_CONFIG;


### PR DESCRIPTION
## Summary
- adjust Angular dev-server proxy config to use object syntax and prevent "Invalid context" errors

## Testing
- `npm test` *(fails: ChromeHeadless cannot start, requires chromium snap)*

------
https://chatgpt.com/codex/tasks/task_e_689bc9373bd88323bfed4f56586e9281