### PR TITLE
fix: update proxy config for dev server

### DIFF
--- a/feedme.client/src/proxy.conf.js
+++ b/feedme.client/src/proxy.conf.js
@@ -6,14 +6,20 @@ const httpTarget = env['services__feedme-server__http__0'];
 // Prefer the HTTP endpoint to avoid TLS issues when no certificates are configured
 const target = httpTarget ?? httpsTarget ?? 'http://localhost:5016';
 
-const PROXY_CONFIG = [
-  {
-    context: ['/api', '/api/**'],
+/**
+ * Proxy configuration for the development server.
+ *
+ * The `http-proxy-middleware` package used by `webpack-dev-server` expects the
+ * configuration to be an object where each key represents a path to proxy. The
+ * previous array-based format caused an "Invalid context" error because the
+ * middleware could not determine which routes to match.
+ */
+const PROXY_CONFIG = {
+  '/api': {
     target,
     secure: false,
     logLevel: 'error',
   },
-];
-
+};
 
 module.exports = PROXY_CONFIG;


### PR DESCRIPTION
## Summary
- switch Angular dev server proxy configuration to object format

## Testing
- `npx ng test --watch=false` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_689d242058d88323b606631084d25f09