### PR TITLE
Add entrypoint for ASP.NET container startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,5 @@ COPY --from=server-build /out ./
 COPY --from=client-build /build/feedme.client/dist/ ./wwwroot
 
 ENV ASPNETCORE_URLS=http://+:8080
+ENTRYPOINT ["dotnet", "feedme.Server.dll"]
 EXPOSE 8080


### PR DESCRIPTION
## Summary
- configure the final Docker image stage with a dotnet entrypoint so the server starts automatically

## Testing
- not run (Docker not available in container environment)


------
https://chatgpt.com/codex/tasks/task_e_68c9c01c278483239ba6f62d3cbcd3ec