### PR TITLE
feat: format catalog flags

### DIFF
--- a/feedme.client/src/app/app.component.spec.ts
+++ b/feedme.client/src/app/app.component.spec.ts
@@ -1,13 +1,26 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { AppComponent } from './app.component';
+import { CatalogItem, CatalogService } from './services/catalog.service';
+import { of } from 'rxjs';
 
 describe('AppComponent', () => {
   let component: AppComponent;
   let fixture: ComponentFixture<AppComponent>;
 
+  let catalogService: jasmine.SpyObj<CatalogService>;
+
   beforeEach(async () => {
+    catalogService = jasmine.createSpyObj<CatalogService>(
+      'CatalogService',
+      ['getAll', 'create', 'getById']
+    );
+    catalogService.getAll.and.returnValue(of([]));
+    catalogService.create.and.returnValue(of({} as CatalogItem));
+    catalogService.getById.and.returnValue(of({} as CatalogItem));
+
     await TestBed.configureTestingModule({
-      imports: [AppComponent]
+      imports: [AppComponent],
+      providers: [{ provide: CatalogService, useValue: catalogService }]
     }).compileComponents();
   });
 

--- a/feedme.client/src/app/components/catalog/catalog.component.html
+++ b/feedme.client/src/app/components/catalog/catalog.component.html
@@ -33,7 +33,10 @@
         <td>{{ item.weight }}</td>
         <td>{{ item.writeoffMethod }}</td>
         <td>{{ item.allergens }}</td>
-        <td>{{ item.flags }}</td>
+        <td>
+          <div>Требует фасовки: {{ item.packagingRequired | booleanLabel }}</div>
+          <div>Портится после вскрытия: {{ item.spoilsAfterOpening | booleanLabel }}</div>
+        </td>
       </tr>
     </tbody>
   </table>

--- a/feedme.client/src/app/components/catalog/catalog.component.spec.ts
+++ b/feedme.client/src/app/components/catalog/catalog.component.spec.ts
@@ -1,0 +1,99 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { of } from 'rxjs';
+
+import { CatalogComponent } from './catalog.component';
+import { CatalogService, CatalogItem } from '../../services/catalog.service';
+
+describe('CatalogComponent', () => {
+  let fixture: ComponentFixture<CatalogComponent>;
+  let component: CatalogComponent;
+  let catalogService: jasmine.SpyObj<CatalogService>;
+
+  const mockItems: CatalogItem[] = [
+    {
+      id: '1',
+      name: 'Сыр',
+      type: 'Продукт',
+      code: '100',
+      category: 'Молочная продукция',
+      unit: 'кг',
+      weight: 1,
+      writeoffMethod: 'FIFO',
+      allergens: 'Молоко',
+      packagingRequired: true,
+      spoilsAfterOpening: false,
+      supplier: 'Поставщик А',
+      deliveryTime: 2,
+      costEstimate: 450,
+      taxRate: '10%',
+      unitPrice: 500,
+      salePrice: 650,
+      tnved: '0406',
+      isMarked: true,
+      isAlcohol: false,
+      alcoholCode: '',
+      alcoholStrength: 0,
+      alcoholVolume: 0,
+    },
+    {
+      id: '2',
+      name: 'Оливковое масло',
+      type: 'Продукт',
+      code: '200',
+      category: 'Масла',
+      unit: 'л',
+      weight: 1,
+      writeoffMethod: 'FIFO',
+      allergens: 'Нет',
+      packagingRequired: false,
+      spoilsAfterOpening: true,
+      supplier: 'Поставщик Б',
+      deliveryTime: 5,
+      costEstimate: 300,
+      taxRate: '10%',
+      unitPrice: 350,
+      salePrice: 450,
+      tnved: '1509',
+      isMarked: false,
+      isAlcohol: false,
+      alcoholCode: '',
+      alcoholStrength: 0,
+      alcoholVolume: 0,
+    },
+  ];
+
+  beforeEach(async () => {
+    catalogService = jasmine.createSpyObj<CatalogService>('CatalogService', ['getAll', 'create', 'getById']);
+    catalogService.getAll.and.returnValue(of(mockItems));
+    catalogService.create.and.returnValue(of(mockItems[0]));
+
+    await TestBed.configureTestingModule({
+      imports: [CatalogComponent],
+      providers: [{ provide: CatalogService, useValue: catalogService }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CatalogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('создаётся', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('отображает форматированные флаги для каждого товара', () => {
+    fixture.detectChanges();
+
+    const rows = fixture.debugElement.queryAll(By.css('tbody tr'));
+    expect(rows.length).toBe(mockItems.length);
+
+    const firstFlagCellText = rows[0].query(By.css('td:nth-child(9)'))!.nativeElement.textContent;
+    expect(firstFlagCellText).toContain('Требует фасовки: Да');
+    expect(firstFlagCellText).toContain('Портится после вскрытия: Нет');
+
+    const secondFlagCellText = rows[1].query(By.css('td:nth-child(9)'))!.nativeElement.textContent;
+    expect(secondFlagCellText).toContain('Требует фасовки: Нет');
+    expect(secondFlagCellText).toContain('Портится после вскрытия: Да');
+  });
+});

--- a/feedme.client/src/app/components/catalog/catalog.component.ts
+++ b/feedme.client/src/app/components/catalog/catalog.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, inject } from '@angular/core';
+import { Component, OnInit, Pipe, PipeTransform, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 
@@ -8,10 +8,24 @@ import { FilterPipe } from '../../pipes/filter.pipe';
 import { NewProductFormValues } from '../catalog-new-product-popup/catalog-new-product-popup.component';
 import { CatalogItem, CatalogService } from '../../services/catalog.service';
 
+@Pipe({
+  name: 'booleanLabel',
+  standalone: true,
+})
+export class BooleanLabelPipe implements PipeTransform {
+  transform(value: boolean | null | undefined): string {
+    if (value === null || value === undefined) {
+      return '—';
+    }
+
+    return value ? 'Да' : 'Нет';
+  }
+}
+
 @Component({
   selector: 'app-catalog',
   standalone: true,
-  imports: [CommonModule, FormsModule, FilterPipe],
+  imports: [CommonModule, FormsModule, FilterPipe, BooleanLabelPipe],
   templateUrl: './catalog.component.html',
   styleUrls: ['./catalog.component.css']
 })


### PR DESCRIPTION
## Summary
- add a reusable booleanLabel pipe inside the catalog component to format boolean flags
- render packaging and spoilage flags explicitly in the catalog table
- cover the new presentation with unit tests and stub catalog service dependencies in existing specs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68caeaa563908323a5cd47553dc7de89