### PR TITLE
Add receipts API with repository and tests

### DIFF
--- a/feedme.Server.Tests/ReceiptsApiTests.cs
+++ b/feedme.Server.Tests/ReceiptsApiTests.cs
@@ -1,0 +1,89 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Linq;
+using feedme.Server.Models;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+using feedme.Server;
+
+namespace feedme.Server.Tests;
+
+public class ReceiptsApiTests
+{
+    [Fact]
+    public async Task PostReceipt_ReturnsCreatedReceiptWithCalculatedTotals()
+    {
+        await using var factory = new WebApplicationFactory<Program>();
+        using var client = factory.CreateClient();
+
+        var request = new
+        {
+            number = "RCPT-1001",
+            supplier = "Green Foods LLC",
+            warehouse = "Central Warehouse",
+            receivedAt = DateTime.UtcNow,
+            items = new[]
+            {
+                new { catalogItemId = "CAT-001", itemName = "Tomatoes", quantity = 10.5m, unit = "kg", unitPrice = 2.75m },
+                new { catalogItemId = "CAT-002", itemName = "Mozzarella", quantity = 4.0m, unit = "kg", unitPrice = 8.10m }
+            }
+        };
+
+        var response = await client.PostAsJsonAsync("/api/receipts", request);
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        Assert.NotNull(response.Headers.Location);
+
+        var created = await response.Content.ReadFromJsonAsync<Receipt>();
+        Assert.NotNull(created);
+        Assert.False(string.IsNullOrWhiteSpace(created!.Id));
+        Assert.Equal(request.number, created.Number);
+        Assert.Equal(request.supplier, created.Supplier);
+        Assert.Equal(request.items.Length, created.Items.Count);
+
+        var expectedTotal = request.items.Sum(item => item.unitPrice * item.quantity);
+        Assert.Equal(expectedTotal, created.TotalAmount);
+    }
+
+    [Fact]
+    public async Task GetReceiptById_ReturnsStoredReceipt()
+    {
+        await using var factory = new WebApplicationFactory<Program>();
+        using var client = factory.CreateClient();
+
+        var createResponse = await client.PostAsJsonAsync("/api/receipts", new
+        {
+            number = "RCPT-1002",
+            supplier = "Fresh Farms",
+            warehouse = "North Warehouse",
+            receivedAt = DateTime.UtcNow,
+            items = new[]
+            {
+                new { catalogItemId = "CAT-010", itemName = "Basil", quantity = 15.0m, unit = "bunch", unitPrice = 1.20m }
+            }
+        });
+
+        var created = await createResponse.Content.ReadFromJsonAsync<Receipt>();
+        Assert.NotNull(created);
+
+        var response = await client.GetAsync($"/api/receipts/{created!.Id}");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var fetched = await response.Content.ReadFromJsonAsync<Receipt>();
+        Assert.NotNull(fetched);
+        Assert.Equal(created.Id, fetched!.Id);
+        Assert.Equal(created.Number, fetched.Number);
+        Assert.Equal(created.TotalAmount, fetched.TotalAmount);
+    }
+
+    [Fact]
+    public async Task GetReceiptById_ReturnsNotFoundForUnknownReceipt()
+    {
+        await using var factory = new WebApplicationFactory<Program>();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync($"/api/receipts/{Guid.NewGuid()}");
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+}

--- a/feedme.Server.Tests/feedme.Server.Tests.csproj
+++ b/feedme.Server.Tests/feedme.Server.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\feedme.Server\feedme.Server.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/feedme.Server/Controllers/ReceiptsController.cs
+++ b/feedme.Server/Controllers/ReceiptsController.cs
@@ -1,0 +1,38 @@
+using feedme.Server.Models;
+using feedme.Server.Repositories;
+using Microsoft.AspNetCore.Mvc;
+
+namespace feedme.Server.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class ReceiptsController : ControllerBase
+{
+    private readonly IReceiptRepository _repository;
+
+    public ReceiptsController(IReceiptRepository repository)
+    {
+        _repository = repository;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<Receipt>>> Get()
+    {
+        var receipts = await _repository.GetAllAsync();
+        return Ok(receipts);
+    }
+
+    [HttpGet("{id}")]
+    public async Task<ActionResult<Receipt>> GetById(string id)
+    {
+        var receipt = await _repository.GetByIdAsync(id);
+        return receipt is null ? NotFound() : Ok(receipt);
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<Receipt>> Create([FromBody] Receipt receipt)
+    {
+        var created = await _repository.AddAsync(receipt);
+        return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
+    }
+}

--- a/feedme.Server/Models/Receipt.cs
+++ b/feedme.Server/Models/Receipt.cs
@@ -1,0 +1,27 @@
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+
+namespace feedme.Server.Models;
+
+public class Receipt
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+
+    [Required]
+    [MaxLength(64)]
+    public string Number { get; set; } = string.Empty;
+
+    [Required]
+    [MaxLength(128)]
+    public string Supplier { get; set; } = string.Empty;
+
+    [MaxLength(128)]
+    public string Warehouse { get; set; } = string.Empty;
+
+    public DateTime ReceivedAt { get; set; } = DateTime.UtcNow;
+
+    [MinLength(1, ErrorMessage = "A receipt must contain at least one item.")]
+    public List<ReceiptLine> Items { get; set; } = new();
+
+    public decimal TotalAmount => Items.Sum(item => item.TotalCost);
+}

--- a/feedme.Server/Models/ReceiptLine.cs
+++ b/feedme.Server/Models/ReceiptLine.cs
@@ -1,0 +1,26 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace feedme.Server.Models;
+
+public class ReceiptLine
+{
+    [Required]
+    [MaxLength(64)]
+    public string CatalogItemId { get; set; } = string.Empty;
+
+    [Required]
+    [MaxLength(128)]
+    public string ItemName { get; set; } = string.Empty;
+
+    [Range(typeof(decimal), "0.01", "79228162514264337593543950335", ErrorMessage = "Quantity must be greater than zero.")]
+    public decimal Quantity { get; set; }
+
+    [Required]
+    [MaxLength(32)]
+    public string Unit { get; set; } = string.Empty;
+
+    [Range(typeof(decimal), "0.00", "79228162514264337593543950335", ErrorMessage = "Unit price must be non-negative.")]
+    public decimal UnitPrice { get; set; }
+
+    public decimal TotalCost => UnitPrice * Quantity;
+}

--- a/feedme.Server/Program.cs
+++ b/feedme.Server/Program.cs
@@ -13,6 +13,7 @@ public class Program
 
         builder.Services.AddControllers();
         builder.Services.AddSingleton<ICatalogRepository, InMemoryCatalogRepository>();
+        builder.Services.AddSingleton<IReceiptRepository, InMemoryReceiptRepository>();
         // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
         builder.Services.AddOpenApi();
 

--- a/feedme.Server/Repositories/IReceiptRepository.cs
+++ b/feedme.Server/Repositories/IReceiptRepository.cs
@@ -1,0 +1,10 @@
+using feedme.Server.Models;
+
+namespace feedme.Server.Repositories;
+
+public interface IReceiptRepository
+{
+    Task<IEnumerable<Receipt>> GetAllAsync();
+    Task<Receipt?> GetByIdAsync(string id);
+    Task<Receipt> AddAsync(Receipt receipt);
+}

--- a/feedme.Server/Repositories/InMemoryReceiptRepository.cs
+++ b/feedme.Server/Repositories/InMemoryReceiptRepository.cs
@@ -1,0 +1,107 @@
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using feedme.Server.Models;
+
+namespace feedme.Server.Repositories;
+
+public class InMemoryReceiptRepository : IReceiptRepository
+{
+    private readonly ConcurrentDictionary<string, Receipt> _receipts = new();
+
+    public Task<IEnumerable<Receipt>> GetAllAsync()
+    {
+        var receipts = _receipts.Values
+            .OrderBy(receipt => receipt.ReceivedAt)
+            .Select(CloneReceipt)
+            .ToList();
+
+        return Task.FromResult<IEnumerable<Receipt>>(receipts);
+    }
+
+    public Task<Receipt?> GetByIdAsync(string id)
+    {
+        if (!_receipts.TryGetValue(id, out var receipt))
+        {
+            return Task.FromResult<Receipt?>(null);
+        }
+
+        return Task.FromResult<Receipt?>(CloneReceipt(receipt));
+    }
+
+    public Task<Receipt> AddAsync(Receipt receipt)
+    {
+        var normalized = NormalizeReceipt(receipt);
+        _receipts[normalized.Id] = normalized;
+
+        return Task.FromResult(CloneReceipt(normalized));
+    }
+
+    private static Receipt NormalizeReceipt(Receipt receipt)
+    {
+        var id = string.IsNullOrWhiteSpace(receipt.Id) ? Guid.NewGuid().ToString() : receipt.Id;
+        var receivedAt = NormalizeTimestamp(receipt.ReceivedAt);
+
+        var items = (receipt.Items ?? new List<ReceiptLine>())
+            .Select(item => new ReceiptLine
+            {
+                CatalogItemId = Sanitize(item.CatalogItemId),
+                ItemName = Sanitize(item.ItemName),
+                Quantity = item.Quantity,
+                Unit = Sanitize(item.Unit),
+                UnitPrice = item.UnitPrice
+            })
+            .ToList();
+
+        var normalized = new Receipt
+        {
+            Id = id,
+            Number = Sanitize(receipt.Number),
+            Supplier = Sanitize(receipt.Supplier),
+            Warehouse = Sanitize(receipt.Warehouse),
+            ReceivedAt = receivedAt,
+            Items = items
+        };
+
+        return normalized;
+    }
+
+    private static Receipt CloneReceipt(Receipt receipt)
+    {
+        return new Receipt
+        {
+            Id = receipt.Id,
+            Number = receipt.Number,
+            Supplier = receipt.Supplier,
+            Warehouse = receipt.Warehouse,
+            ReceivedAt = receipt.ReceivedAt,
+            Items = receipt.Items
+                .Select(item => new ReceiptLine
+                {
+                    CatalogItemId = item.CatalogItemId,
+                    ItemName = item.ItemName,
+                    Quantity = item.Quantity,
+                    Unit = item.Unit,
+                    UnitPrice = item.UnitPrice
+                })
+                .ToList()
+        };
+    }
+
+    private static DateTime NormalizeTimestamp(DateTime timestamp)
+    {
+        if (timestamp == default)
+        {
+            return DateTime.UtcNow;
+        }
+
+        return timestamp.Kind switch
+        {
+            DateTimeKind.Unspecified => DateTime.SpecifyKind(timestamp, DateTimeKind.Utc),
+            DateTimeKind.Local => timestamp.ToUniversalTime(),
+            _ => timestamp
+        };
+    }
+
+    private static string Sanitize(string value) => value?.Trim() ?? string.Empty;
+}

--- a/feedme.sln
+++ b/feedme.sln
@@ -10,6 +10,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "feedme.AppHost", "feedme.Ap
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "feedme.ServiceDefaults", "feedme.ServiceDefaults\feedme.ServiceDefaults.csproj", "{C59C9769-80ED-8549-813F-2D200765C139}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "feedme.Server.Tests", "feedme.Server.Tests\feedme.Server.Tests.csproj", "{F0A6E850-48DE-416B-A46D-FC62DE8977FF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -32,6 +34,10 @@ Global
 		{C59C9769-80ED-8549-813F-2D200765C139}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C59C9769-80ED-8549-813F-2D200765C139}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C59C9769-80ED-8549-813F-2D200765C139}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F0A6E850-48DE-416B-A46D-FC62DE8977FF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F0A6E850-48DE-416B-A46D-FC62DE8977FF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F0A6E850-48DE-416B-A46D-FC62DE8977FF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F0A6E850-48DE-416B-A46D-FC62DE8977FF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- add receipt and receipt line models with validation and total calculations
- implement an in-memory receipt repository and API controller and register the service
- create an integration test project that verifies creating and fetching receipts

## Testing
- dotnet test feedme.Server.Tests/feedme.Server.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68caeaa406008323a262507e12ac2129