### PR TITLE
feat: enable column sorting in supply table

### DIFF
--- a/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.css
+++ b/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.css
@@ -57,6 +57,35 @@ table.supply-table {
     text-align: left;
   }
 
+.sort-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0;
+  margin: 0;
+  border: none;
+  background: none;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  transition: color 0.2s ease;
+}
+
+.sort-button:hover,
+.sort-button:focus-visible {
+  color: #fa4b00;
+  outline: none;
+}
+
+.sort-button--active {
+  color: #fa4b00;
+}
+
+.sort-icon {
+  font-size: 0.75rem;
+  line-height: 1;
+}
+
   /* 7. строки */
   table.supply-table tbody td {
     padding: 1.25rem 1rem;
@@ -83,34 +112,33 @@ table.supply-table {
   }
 
 /* 10. пагинация */
-.pagination-controls
-{
-   display: flex;
-   align-items: center;
-   justify-content: center;
-   gap: 1rem;
-   margin: 1rem 0;
+.pagination-controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  margin: 1rem 0;
 }
 .pagination-controls button {
-    background-color: #fa4b00;
-    color: #ffffff;
-    border: none;
-    padding: 0.5rem 1rem;
-    font-size: 1rem;
-    border-radius: 0.25rem;
-    transition: background-color 0.4s ease-in;
-
-  }
-.pagination-controls button:hover:not(:disabled) {
-      background-color: #d94300;
-      cursor: pointer;
-  }
-pagination-controls button:disabled
-{
-    opacity: 0.6;
-    cursor: not-allowed;
+  background-color: #fa4b00;
+  color: #ffffff;
+  border: none;
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+  border-radius: 0.25rem;
+  transition: background-color 0.4s ease-in;
 }
-pagination-controls span
-{
-    font-size: 1 rem;
+
+.pagination-controls button:hover:not(:disabled) {
+  background-color: #d94300;
+  cursor: pointer;
+}
+
+.pagination-controls button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.pagination-controls span {
+  font-size: 1rem;
 }

--- a/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.html
+++ b/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.html
@@ -14,13 +14,83 @@
   <table class="supply-table">
     <thead>
       <tr>
-        <th>Название</th>
-        <th>Категория</th>
-        <th>Количество</th>
-        <th>Цена</th>
-        <th>Срок годности</th>
-        <th>Ответственный склад</th>
-        <th>Поставщик</th>
+        <th [attr.aria-sort]="getAriaSort('productName')">
+          <button type="button"
+                  class="sort-button"
+                  (click)="toggleSort('productName')"
+                  [class.sort-button--active]="isSortedBy('productName')">
+            <span>Название</span>
+            <span class="sort-icon" aria-hidden="true" *ngIf="isSortedBy('productName')">
+              {{ sortState?.direction === 'asc' ? '▲' : '▼' }}
+            </span>
+          </button>
+        </th>
+        <th [attr.aria-sort]="getAriaSort('category')">
+          <button type="button"
+                  class="sort-button"
+                  (click)="toggleSort('category')"
+                  [class.sort-button--active]="isSortedBy('category')">
+            <span>Категория</span>
+            <span class="sort-icon" aria-hidden="true" *ngIf="isSortedBy('category')">
+              {{ sortState?.direction === 'asc' ? '▲' : '▼' }}
+            </span>
+          </button>
+        </th>
+        <th [attr.aria-sort]="getAriaSort('stock')">
+          <button type="button"
+                  class="sort-button"
+                  (click)="toggleSort('stock')"
+                  [class.sort-button--active]="isSortedBy('stock')">
+            <span>Количество</span>
+            <span class="sort-icon" aria-hidden="true" *ngIf="isSortedBy('stock')">
+              {{ sortState?.direction === 'asc' ? '▲' : '▼' }}
+            </span>
+          </button>
+        </th>
+        <th [attr.aria-sort]="getAriaSort('unitPrice')">
+          <button type="button"
+                  class="sort-button"
+                  (click)="toggleSort('unitPrice')"
+                  [class.sort-button--active]="isSortedBy('unitPrice')">
+            <span>Цена</span>
+            <span class="sort-icon" aria-hidden="true" *ngIf="isSortedBy('unitPrice')">
+              {{ sortState?.direction === 'asc' ? '▲' : '▼' }}
+            </span>
+          </button>
+        </th>
+        <th [attr.aria-sort]="getAriaSort('expiryDate')">
+          <button type="button"
+                  class="sort-button"
+                  (click)="toggleSort('expiryDate')"
+                  [class.sort-button--active]="isSortedBy('expiryDate')">
+            <span>Срок годности</span>
+            <span class="sort-icon" aria-hidden="true" *ngIf="isSortedBy('expiryDate')">
+              {{ sortState?.direction === 'asc' ? '▲' : '▼' }}
+            </span>
+          </button>
+        </th>
+        <th [attr.aria-sort]="getAriaSort('responsible')">
+          <button type="button"
+                  class="sort-button"
+                  (click)="toggleSort('responsible')"
+                  [class.sort-button--active]="isSortedBy('responsible')">
+            <span>Ответственный склад</span>
+            <span class="sort-icon" aria-hidden="true" *ngIf="isSortedBy('responsible')">
+              {{ sortState?.direction === 'asc' ? '▲' : '▼' }}
+            </span>
+          </button>
+        </th>
+        <th [attr.aria-sort]="getAriaSort('supplier')">
+          <button type="button"
+                  class="sort-button"
+                  (click)="toggleSort('supplier')"
+                  [class.sort-button--active]="isSortedBy('supplier')">
+            <span>Поставщик</span>
+            <span class="sort-icon" aria-hidden="true" *ngIf="isSortedBy('supplier')">
+              {{ sortState?.direction === 'asc' ? '▲' : '▼' }}
+            </span>
+          </button>
+        </th>
         <th>Действие</th>
       </tr>
     </thead>

--- a/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.ts
+++ b/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.ts
@@ -3,6 +3,20 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { TableControlsComponent } from '../table-controls/table-controls.component';
 
+type SortDirection = 'asc' | 'desc';
+type SortType = 'string' | 'number' | 'date';
+type SortableColumn = 'productName' | 'category' | 'stock' | 'unitPrice' | 'expiryDate' | 'responsible' | 'supplier';
+
+interface SortState {
+  column: SortableColumn;
+  direction: SortDirection;
+}
+
+interface FilterOptions {
+  justAdded?: boolean;
+  preservePage?: boolean;
+}
+
 @Component({
   selector: 'app-supply-table',
   standalone: true,
@@ -24,6 +38,18 @@ export class SupplyTableComponent implements OnChanges {
   currentPage = 1;
   filteredData: any[] = [];
 
+  sortState: SortState | null = null;
+
+  private readonly sortConfig: Record<SortableColumn, SortType> = {
+    productName: 'string',
+    category: 'string',
+    stock: 'number',
+    unitPrice: 'number',
+    expiryDate: 'date',
+    responsible: 'string',
+    supplier: 'string',
+  };
+
   /** Храним прошлую длину, чтобы понять, добавили ли новый элемент */
   private prevLength = 0;
 
@@ -32,12 +58,16 @@ export class SupplyTableComponent implements OnChanges {
       const newLength = this.data.length;
       const added = newLength > this.prevLength;
       this.prevLength = newLength;
-      this.applyFilters(added);
+      this.applyFilters({
+        justAdded: added,
+        preservePage: added && !this.searchQuery,
+      });
     }
   }
 
   /** Фильтрует, убирает пустые записи и переключает страницу */
-  private applyFilters(justAdded: boolean): void {
+  private applyFilters(options: FilterOptions = {}): void {
+    const { justAdded = false, preservePage = false } = options;
     // 1) убираем полностью пустые
     const nonEmpty = this.data.filter(item =>
       !!(item.productName?.toString().trim()) ||
@@ -47,15 +77,22 @@ export class SupplyTableComponent implements OnChanges {
 
     // 2) поиск
     const q = this.searchQuery.toLowerCase();
-    this.filteredData = nonEmpty.filter(item =>
+    const matches = nonEmpty.filter(item =>
       (item.productName || '').toLowerCase().includes(q) ||
       (item.category || '').toLowerCase().includes(q) ||
       (item.supplier || '').toLowerCase().includes(q)
     );
 
+    this.filteredData = this.sortData(matches);
+
     // 3) если добавили новую запись и поиск не используется — ставим последнюю страницу
     if (justAdded && !q) {
       this.currentPage = this.totalPages;
+      return;
+    }
+
+    if (preservePage) {
+      this.currentPage = Math.min(this.currentPage, this.totalPages);
     } else {
       this.currentPage = 1;
     }
@@ -63,12 +100,33 @@ export class SupplyTableComponent implements OnChanges {
 
   onSearchChange(query: string): void {
     this.searchQuery = query;
-    this.applyFilters(false);
+    this.applyFilters();
   }
 
   onRowsChange(rows: number): void {
     this.rowsPerPage = rows;
-    this.applyFilters(false);
+    this.applyFilters();
+  }
+
+  toggleSort(column: SortableColumn): void {
+    const isSameColumn = this.sortState?.column === column;
+    const nextDirection: SortDirection = isSameColumn && this.sortState?.direction === 'asc' ? 'desc' : 'asc';
+    this.sortState = {
+      column,
+      direction: nextDirection,
+    };
+    this.applyFilters({ preservePage: true });
+  }
+
+  isSortedBy(column: SortableColumn): boolean {
+    return this.sortState?.column === column;
+  }
+
+  getAriaSort(column: SortableColumn): 'ascending' | 'descending' | 'none' {
+    if (!this.sortState || this.sortState.column !== column) {
+      return 'none';
+    }
+    return this.sortState.direction === 'asc' ? 'ascending' : 'descending';
   }
 
   get totalPages(): number {
@@ -90,5 +148,93 @@ export class SupplyTableComponent implements OnChanges {
 
   addSupply(): void {
     this.onAddSupply.emit();
+  }
+
+  private sortData(data: any[]): any[] {
+    if (!this.sortState) {
+      return [...data];
+    }
+
+    const { column, direction } = this.sortState;
+    const type = this.sortConfig[column];
+
+    return [...data].sort((a, b) => {
+      const aValue = this.getComparableValue(a, column, type);
+      const bValue = this.getComparableValue(b, column, type);
+      return this.compareValues(aValue, bValue, type, direction);
+    });
+  }
+
+  private getComparableValue(item: any, column: SortableColumn, type: SortType): string | number {
+    switch (column) {
+      case 'productName':
+        return (item.productName || item.name || '').toString();
+      case 'category':
+        return (item.category || '').toString();
+      case 'responsible':
+        return (item.responsible || '').toString();
+      case 'supplier':
+        return (item.supplier || '').toString();
+      case 'stock':
+        return this.toNumber(item.stock);
+      case 'unitPrice':
+        return this.toNumber(item.unitPrice);
+      case 'expiryDate':
+        return this.toDateValue(item.expiryDate);
+      default:
+        return type === 'number' ? 0 : '';
+    }
+  }
+
+  private compareValues(
+    a: string | number,
+    b: string | number,
+    type: SortType,
+    direction: SortDirection,
+  ): number {
+    if (type === 'string') {
+      const aStr = (a as string).toString();
+      const bStr = (b as string).toString();
+      const base = aStr.localeCompare(bStr, 'ru', { sensitivity: 'base' });
+      return direction === 'asc' ? base : -base;
+    }
+
+    const aNum = a as number;
+    const bNum = b as number;
+
+    const aIsNaN = Number.isNaN(aNum);
+    const bIsNaN = Number.isNaN(bNum);
+
+    if (aIsNaN && bIsNaN) {
+      return 0;
+    }
+
+    if (aIsNaN) {
+      return 1;
+    }
+
+    if (bIsNaN) {
+      return -1;
+    }
+
+    return direction === 'asc' ? aNum - bNum : bNum - aNum;
+  }
+
+  private toNumber(value: unknown): number {
+    const num = Number(value);
+    return Number.isFinite(num) ? num : Number.NaN;
+  }
+
+  private toDateValue(value: unknown): number {
+    if (value instanceof Date) {
+      return value.getTime();
+    }
+
+    if (typeof value === 'string') {
+      const timestamp = Date.parse(value);
+      return Number.isNaN(timestamp) ? Number.NaN : timestamp;
+    }
+
+    return Number.NaN;
   }
 }


### PR DESCRIPTION
## Summary
- add accessible sort controls to each supply table header so columns can be reordered by clicking
- track and apply sort state in the supply table component while preserving pagination behaviour
- align table control styles, including new sort button visuals and corrected pagination selectors

## Testing
- npm run lint *(fails: Angular project has no configured `lint` target and prompts to add ESLint)*
- npm run test *(fails: ChromeHeadless cannot start because libatk-1.0.so.0 is missing in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb1a42e734832388455a3499db1ef4