### PR TITLE
Add consistent filtering to stock and catalog tables

### DIFF
--- a/feedme.client/src/app/components/CatalogTableComponent/catalog-table.component.ts
+++ b/feedme.client/src/app/components/CatalogTableComponent/catalog-table.component.ts
@@ -4,6 +4,19 @@ import { FormsModule } from '@angular/forms';
 import { ConfirmDeletePopupComponent } from '../confirm-delete-popup/confirm-delete-popup.component';
 import { TableControlsComponent } from '../table-controls/table-controls.component';
 import { CatalogViewSwitcherComponent } from '../catalog-view-switcher/catalog-view-switcher.component';
+import { CatalogItem } from '../../services/catalog.service';
+
+type CatalogView = 'info' | 'logistics';
+
+interface CatalogColumn {
+  label: string;
+  key: keyof CatalogItem;
+}
+
+interface FilterOptions {
+  justAdded?: boolean;
+  preservePage?: boolean;
+}
 @Component({
   selector: 'app-catalog-table',
   standalone: true,
@@ -19,28 +32,29 @@ import { CatalogViewSwitcherComponent } from '../catalog-view-switcher/catalog-v
 })
 export class CatalogTableComponent implements OnChanges {
   /** Входные данные для каталога */
-  @Input() data: any[] = [];
+  @Input() data: CatalogItem[] = [];
 
   /** Режим отображения таблицы */
-  viewMode: 'info' | 'logistics' = 'info';
+  viewMode: CatalogView = 'info';
 
 
   @Output() onAddSupply = new EventEmitter<void>();
-  @Output() edit = new EventEmitter<any>();
-  @Output() deleteRow = new EventEmitter<any>();
+  @Output() edit = new EventEmitter<CatalogItem>();
+  @Output() deleteRow = new EventEmitter<CatalogItem>();
 
   /** Управление фильтрацией и пагинацией */
-  searchQuery: string = '';
-  rowsPerPage: number = 10;
-  currentPage: number = 1;
+  searchQuery = '';
+  rowsPerPage = 10;
+  currentPage = 1;
+  filteredData: CatalogItem[] = [];
 
   /** Строка, выбранная для удаления */
-  deleteCandidate: any | null = null;
+  deleteCandidate: CatalogItem | null = null;
   showConfirm = false;
 
 
   /** Колонки для режима "Основная информация" */
-  readonly infoColumns = [
+  private readonly infoColumns: CatalogColumn[] = [
     { label: 'Название товара', key: 'name' },
     { label: 'Тип номенклатуры', key: 'type' },
     { label: 'Номенклатурный код', key: 'code' },
@@ -54,7 +68,7 @@ export class CatalogTableComponent implements OnChanges {
   ];
 
   /** Колонки для режима "Закупка и логистика" */
-  readonly logisticsColumns = [
+  private readonly logisticsColumns: CatalogColumn[] = [
     { label: 'Поставщик (основной)', key: 'supplier' },
     { label: 'Срок поставки (дней)', key: 'deliveryTime' },
     { label: 'Оценочная себестоимость', key: 'costEstimate' },
@@ -65,9 +79,16 @@ export class CatalogTableComponent implements OnChanges {
     { label: 'Алкогольная продукция', key: 'isAlcohol' },
   ];
 
+  private readonly columnsByView: Record<CatalogView, CatalogColumn[]> = {
+    info: this.infoColumns,
+    logistics: this.logisticsColumns,
+  };
+
+  private previousLength = 0;
+
   /** Текущие колонки по выбранному режиму */
-  get columns() {
-    return this.viewMode === 'info' ? this.infoColumns : this.logisticsColumns;
+  get columns(): CatalogColumn[] {
+    return this.columnsByView[this.viewMode];
   }
 
   /** Приведение значения для отображения */
@@ -78,31 +99,30 @@ export class CatalogTableComponent implements OnChanges {
     return value ?? '';
   }
 
-  ngOnChanges(_: SimpleChanges): void {
-    this.currentPage = 1;
-  }
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['data']) {
+      const { firstChange } = changes['data'];
+      const newLength = this.data.length;
+      const justAdded = !firstChange && newLength > this.previousLength;
+      this.previousLength = newLength;
 
-  /** Фильтрованные данные по поисковому запросу */
-  get filteredData(): any[] {
-    const q = this.searchQuery.toLowerCase();
-    if (!q) return this.data;
-    return this.data.filter(item =>
-      Object.values(item).some(val =>
-        val && val.toString().toLowerCase().includes(q)
-      )
-    );
+      this.applyFilters({
+        justAdded,
+        preservePage: true,
+      });
+    }
   }
 
   /** Обновление поискового запроса */
   onSearchChange(query: string): void {
     this.searchQuery = query;
-    this.currentPage = 1;
+    this.applyFilters();
   }
 
   /** Обновление количества строк на странице */
   onRowsChange(rows: number): void {
     this.rowsPerPage = rows;
-    this.currentPage = 1;
+    this.applyFilters();
   }
 
   /** Общее число страниц */
@@ -111,16 +131,18 @@ export class CatalogTableComponent implements OnChanges {
   }
 
   /** Данные для текущей страницы */
-  get paginatedData(): any[] {
+  get paginatedData(): CatalogItem[] {
     const start = (this.currentPage - 1) * this.rowsPerPage;
     return this.filteredData.slice(start, start + this.rowsPerPage);
   }
 
-  addSupply(): void { this.onAddSupply.emit() }
+  addSupply(): void {
+    this.onAddSupply.emit();
+  }
 
 
   /** Выбор строки для удаления */
-  requestDelete(item: any): void {
+  requestDelete(item: CatalogItem): void {
     this.deleteCandidate = item;
     this.showConfirm = true;
   }
@@ -142,8 +164,9 @@ export class CatalogTableComponent implements OnChanges {
   }
 
 
-  onViewChange(view: 'info' | 'logistics'): void {
+  onViewChange(view: CatalogView): void {
     this.viewMode = view;
+    this.applyFilters({ preservePage: true });
   }
   /** Навигация по страницам */
   prevPage(): void {
@@ -151,5 +174,53 @@ export class CatalogTableComponent implements OnChanges {
   }
   nextPage(): void {
     if (this.currentPage < this.totalPages) this.currentPage++;
+  }
+
+  private applyFilters(options: FilterOptions = {}): void {
+    const { justAdded = false, preservePage = false } = options;
+    const normalizedQuery = this.normalize(this.searchQuery);
+    const activeColumns = this.columns;
+
+    const nonEmptyItems = this.data.filter(item =>
+      activeColumns.some(column => this.normalize(item[column.key]).length > 0)
+    );
+
+    const matches = normalizedQuery
+      ? nonEmptyItems.filter(item =>
+          activeColumns.some(column =>
+            this.normalize(item[column.key]).includes(normalizedQuery)
+          )
+        )
+      : nonEmptyItems;
+
+    this.filteredData = matches;
+
+    if (justAdded && !normalizedQuery) {
+      this.currentPage = this.totalPages;
+      return;
+    }
+
+    if (preservePage) {
+      this.currentPage = Math.min(this.currentPage, this.totalPages);
+      return;
+    }
+
+    this.currentPage = 1;
+  }
+
+  private normalize(value: unknown): string {
+    if (value === null || value === undefined) {
+      return '';
+    }
+
+    if (typeof value === 'boolean') {
+      return value ? 'да' : 'нет';
+    }
+
+    if (value instanceof Date) {
+      return value.toISOString().toLowerCase();
+    }
+
+    return value.toString().trim().toLowerCase();
   }
 }

--- a/feedme.client/src/app/components/StockTableComponent/stock-table.component.html
+++ b/feedme.client/src/app/components/StockTableComponent/stock-table.component.html
@@ -1,6 +1,8 @@
 <div class="table-header">
-  <app-table-controls [(searchQuery)]="searchQuery"
-                      [(rowsPerPage)]="rowsPerPage">
+  <app-table-controls [searchQuery]="searchQuery"
+                      [rowsPerPage]="rowsPerPage"
+                      (searchQueryChange)="onSearchChange($event)"
+                      (rowsPerPageChange)="onRowsChange($event)">
   </app-table-controls>
 </div>
 

--- a/feedme.client/src/app/components/StockTableComponent/stock-table.component.ts
+++ b/feedme.client/src/app/components/StockTableComponent/stock-table.component.ts
@@ -1,6 +1,20 @@
-import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { Component, Input, Output, EventEmitter, OnChanges, SimpleChanges } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { TableControlsComponent } from '../table-controls/table-controls.component';
+
+interface StockTableItem {
+  name?: string;
+  category?: string;
+  expiryDate?: string | Date;
+  unitPrice?: string | number;
+  totalCost?: string | number;
+  stock?: string | number;
+}
+
+interface FilterOptions {
+  justAdded?: boolean;
+  preservePage?: boolean;
+}
 
 @Component({
   selector: 'app-stock-table',
@@ -9,22 +23,51 @@ import { TableControlsComponent } from '../table-controls/table-controls.compone
   templateUrl: './stock-table.component.html',
   styleUrls: ['./stock-table.component.css']
 })
-export class StockTableComponent {
-  @Input() data: any[] = [];
-  @Output() onSettingsClick = new EventEmitter<any>();
+export class StockTableComponent implements OnChanges {
+  @Input() data: StockTableItem[] = [];
+  @Output() onSettingsClick = new EventEmitter<StockTableItem>();
 
-  searchQuery: string = '';
-  rowsPerPage: number = 10;
-  currentPage: number = 1;
+  searchQuery = '';
+  rowsPerPage = 10;
+  currentPage = 1;
+  filteredData: StockTableItem[] = [];
 
-  get filteredData(): any[] {
-    const q = this.searchQuery.toLowerCase();
-    return this.data.filter(item =>
-      item.name.toLowerCase().includes(q)
-    );
+  private readonly searchableFields: (keyof StockTableItem)[] = [
+    'name',
+    'category',
+    'expiryDate',
+    'unitPrice',
+    'totalCost',
+    'stock',
+  ];
+
+  private previousLength = 0;
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['data']) {
+      const { firstChange } = changes['data'];
+      const newLength = this.data.length;
+      const justAdded = !firstChange && newLength > this.previousLength;
+      this.previousLength = newLength;
+
+      this.applyFilters({
+        justAdded,
+        preservePage: true,
+      });
+    }
   }
 
-  get paginatedData(): any[] {
+  onSearchChange(query: string): void {
+    this.searchQuery = query;
+    this.applyFilters();
+  }
+
+  onRowsChange(rows: number): void {
+    this.rowsPerPage = rows;
+    this.applyFilters();
+  }
+
+  get paginatedData(): StockTableItem[] {
     const start = (this.currentPage - 1) * this.rowsPerPage;
     return this.filteredData.slice(start, start + this.rowsPerPage);
   }
@@ -33,15 +76,56 @@ export class StockTableComponent {
     return Math.max(1, Math.ceil(this.filteredData.length / this.rowsPerPage));
   }
 
-  nextPage() {
+  nextPage(): void {
     if (this.currentPage < this.totalPages) {
       this.currentPage++;
     }
   }
 
-  prevPage() {
+  prevPage(): void {
     if (this.currentPage > 1) {
       this.currentPage--;
     }
+  }
+
+  private applyFilters(options: FilterOptions = {}): void {
+    const { justAdded = false, preservePage = false } = options;
+    const normalizedQuery = this.normalize(this.searchQuery);
+
+    const nonEmptyItems = this.data.filter(item =>
+      this.searchableFields.some(field => this.normalize(item[field]).length > 0)
+    );
+
+    const matches = normalizedQuery
+      ? nonEmptyItems.filter(item => this.matchesQuery(item, normalizedQuery))
+      : nonEmptyItems;
+
+    this.filteredData = matches;
+
+    if (justAdded && !normalizedQuery) {
+      this.currentPage = this.totalPages;
+      return;
+    }
+
+    if (preservePage) {
+      this.currentPage = Math.min(this.currentPage, this.totalPages);
+      return;
+    }
+
+    this.currentPage = 1;
+  }
+
+  private matchesQuery(item: StockTableItem, query: string): boolean {
+    return this.searchableFields.some(field =>
+      this.normalize(item[field]).includes(query)
+    );
+  }
+
+  private normalize(value: unknown): string {
+    return value === null || value === undefined
+      ? ''
+      : value instanceof Date
+        ? value.toISOString().toLowerCase()
+        : value.toString().trim().toLowerCase();
   }
 }

--- a/feedme.client/src/app/components/content/content.component.ts
+++ b/feedme.client/src/app/components/content/content.component.ts
@@ -103,11 +103,11 @@ export class ContentComponent implements OnInit {
   /** Получить новые данные из формы */
   onNewProductSubmit(item: any): void {
     if (this.selectedSupply === 'supplies') {
-      this.supplyData.push(item);
+      this.supplyData = [...this.supplyData, item];
       localStorage.setItem(`warehouseSupplies_${this.selectedTab}`, JSON.stringify(this.supplyData));
       this.closeNewProductPopup();
     } else if (this.selectedSupply === 'stock') {
-      this.stockData.push(item);
+      this.stockData = [...this.stockData, item];
       localStorage.setItem(`warehouseStock_${this.selectedTab}`, JSON.stringify(this.stockData));
       this.closeNewProductPopup();
     } else {


### PR DESCRIPTION
## Summary
- add reusable filtering and pagination pipeline to the stock table
- extend the catalog table with typed filtering over active columns
- reassign stock and supply datasets after creation so filters react to new items

## Testing
- npm run lint *(fails: Angular project has no configured "lint" target yet)*
- npm run test *(fails: ChromeHeadless cannot start because libatk-1.0.so.0 is missing in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb2588f68c83239ab5e961bf795868