### PR TITLE
Fix catalog and stock filters to cover all searchable data

### DIFF
--- a/feedme.client/src/app/components/StockTableComponent/stock-table.component.html
+++ b/feedme.client/src/app/components/StockTableComponent/stock-table.component.html
@@ -1,6 +1,8 @@
 <div class="table-header">
-  <app-table-controls [(searchQuery)]="searchQuery"
-                      [(rowsPerPage)]="rowsPerPage">
+  <app-table-controls [searchQuery]="searchQuery"
+                      [rowsPerPage]="rowsPerPage"
+                      (searchQueryChange)="onSearchChange($event)"
+                      (rowsPerPageChange)="onRowsChange($event)">
   </app-table-controls>
 </div>
 
@@ -19,7 +21,7 @@
     </thead>
     <tbody>
       <tr *ngFor="let item of paginatedData">
-        <td>{{ item.name }}</td>
+        <td>{{ item.name || item.productName }}</td>
         <td>{{ item.category }}</td>
         <td>{{ item.expiryDate }}</td>
         <td>{{ item.unitPrice }}</td>

--- a/feedme.client/src/app/components/StockTableComponent/stock-table.component.ts
+++ b/feedme.client/src/app/components/StockTableComponent/stock-table.component.ts
@@ -1,6 +1,21 @@
-import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { Component, Input, Output, EventEmitter, OnChanges, SimpleChanges } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { TableControlsComponent } from '../table-controls/table-controls.component';
+
+interface StockTableItem {
+  name?: string;
+  productName?: string;
+  category?: string;
+  expiryDate?: string | Date;
+  unitPrice?: string | number;
+  totalCost?: string | number;
+  stock?: string | number;
+}
+
+interface FilterOptions {
+  justAdded?: boolean;
+  preservePage?: boolean;
+}
 
 @Component({
   selector: 'app-stock-table',
@@ -9,22 +24,51 @@ import { TableControlsComponent } from '../table-controls/table-controls.compone
   templateUrl: './stock-table.component.html',
   styleUrls: ['./stock-table.component.css']
 })
-export class StockTableComponent {
-  @Input() data: any[] = [];
-  @Output() onSettingsClick = new EventEmitter<any>();
+export class StockTableComponent implements OnChanges {
+  @Input() data: StockTableItem[] = [];
+  @Output() onSettingsClick = new EventEmitter<StockTableItem>();
 
-  searchQuery: string = '';
-  rowsPerPage: number = 10;
-  currentPage: number = 1;
+  searchQuery = '';
+  rowsPerPage = 10;
+  currentPage = 1;
+  filteredData: StockTableItem[] = [];
 
-  get filteredData(): any[] {
-    const q = this.searchQuery.toLowerCase();
-    return this.data.filter(item =>
-      item.name.toLowerCase().includes(q)
-    );
+  private readonly searchableFields: (keyof StockTableItem)[] = [
+    'name',
+    'category',
+    'expiryDate',
+    'unitPrice',
+    'totalCost',
+    'stock',
+  ];
+
+  private previousLength = 0;
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['data']) {
+      const { firstChange } = changes['data'];
+      const newLength = this.data.length;
+      const justAdded = !firstChange && newLength > this.previousLength;
+      this.previousLength = newLength;
+
+      this.applyFilters({
+        justAdded,
+        preservePage: true,
+      });
+    }
   }
 
-  get paginatedData(): any[] {
+  onSearchChange(query: string): void {
+    this.searchQuery = query;
+    this.applyFilters();
+  }
+
+  onRowsChange(rows: number): void {
+    this.rowsPerPage = rows;
+    this.applyFilters();
+  }
+
+  get paginatedData(): StockTableItem[] {
     const start = (this.currentPage - 1) * this.rowsPerPage;
     return this.filteredData.slice(start, start + this.rowsPerPage);
   }
@@ -33,15 +77,68 @@ export class StockTableComponent {
     return Math.max(1, Math.ceil(this.filteredData.length / this.rowsPerPage));
   }
 
-  nextPage() {
+  nextPage(): void {
     if (this.currentPage < this.totalPages) {
       this.currentPage++;
     }
   }
 
-  prevPage() {
+  prevPage(): void {
     if (this.currentPage > 1) {
       this.currentPage--;
     }
+  }
+
+  private applyFilters(options: FilterOptions = {}): void {
+    const { justAdded = false, preservePage = false } = options;
+    const normalizedQuery = this.normalize(this.searchQuery);
+
+    const nonEmptyItems = this.data.filter(item => this.hasSearchableValue(item));
+
+    const matches = normalizedQuery
+      ? nonEmptyItems.filter(item => this.matchesQuery(item, normalizedQuery))
+      : nonEmptyItems;
+
+    this.filteredData = matches;
+
+    if (justAdded && !normalizedQuery) {
+      this.currentPage = this.totalPages;
+      return;
+    }
+
+    if (preservePage) {
+      this.currentPage = Math.min(this.currentPage, this.totalPages);
+      return;
+    }
+
+    this.currentPage = 1;
+  }
+
+  private matchesQuery(item: StockTableItem, query: string): boolean {
+    return this.searchableFields.some(field =>
+      this.normalize(this.readField(item, field)).includes(query)
+    );
+  }
+
+  private normalize(value: unknown): string {
+    return value === null || value === undefined
+      ? ''
+      : value instanceof Date
+        ? value.toISOString().toLowerCase()
+        : value.toString().trim().toLowerCase();
+  }
+
+  private readField(item: StockTableItem, field: keyof StockTableItem): unknown {
+    if (field === 'name') {
+      return item.name ?? item.productName ?? '';
+    }
+
+    return item[field];
+  }
+
+  private hasSearchableValue(item: StockTableItem): boolean {
+    return this.searchableFields.some(field =>
+      this.normalize(this.readField(item, field)).length > 0
+    );
   }
 }

--- a/feedme.client/src/app/components/content/content.component.ts
+++ b/feedme.client/src/app/components/content/content.component.ts
@@ -103,11 +103,11 @@ export class ContentComponent implements OnInit {
   /** Получить новые данные из формы */
   onNewProductSubmit(item: any): void {
     if (this.selectedSupply === 'supplies') {
-      this.supplyData.push(item);
+      this.supplyData = [...this.supplyData, item];
       localStorage.setItem(`warehouseSupplies_${this.selectedTab}`, JSON.stringify(this.supplyData));
       this.closeNewProductPopup();
     } else if (this.selectedSupply === 'stock') {
-      this.stockData.push(item);
+      this.stockData = [...this.stockData, item];
       localStorage.setItem(`warehouseStock_${this.selectedTab}`, JSON.stringify(this.stockData));
       this.closeNewProductPopup();
     } else {


### PR DESCRIPTION
## Summary
- expand catalog filtering to examine all catalog columns, keeping rows even when one view lacks data and still preserving pagination state
- adjust stock table filtering and rendering to treat stored `productName` values as valid search targets and display names so rows are not dropped

## Testing
- npm run test -- --watch=false --browsers=ChromeHeadlessNoSandbox *(fails: ChromeHeadless cannot start because libatk-1.0.so.0 is missing in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb2588f68c83239ab5e961bf795868