### PR TITLE
Add interactive column sorting for catalog and stock tables

### DIFF
--- a/feedme.client/src/app/components/CatalogTableComponent/catalog-table.component.css
+++ b/feedme.client/src/app/components/CatalogTableComponent/catalog-table.component.css
@@ -63,6 +63,35 @@ table.catalog-table {
     text-align: left;
   }
 
+  table.catalog-table thead th.sorted {
+    color: #fa4b00;
+  }
+
+  table.catalog-table thead th .sort-button {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    width: 100%;
+    padding: 0;
+    margin: 0;
+    background: none;
+    border: none;
+    cursor: pointer;
+    font: inherit;
+    color: inherit;
+    text-align: left;
+  }
+
+  table.catalog-table thead th .sort-button:focus-visible {
+    outline: 2px solid #fa4b00;
+    outline-offset: 2px;
+    border-radius: 0.25rem;
+  }
+
+  table.catalog-table thead th .sort-indicator {
+    font-size: 0.75rem;
+  }
+
   /* Ячейки */
   table.catalog-table tbody td {
     padding: 1.25rem 1rem;

--- a/feedme.client/src/app/components/CatalogTableComponent/catalog-table.component.html
+++ b/feedme.client/src/app/components/CatalogTableComponent/catalog-table.component.html
@@ -15,7 +15,18 @@
   <table class="catalog-table">
     <thead>
       <tr>
-        <th *ngFor="let col of columns">{{ col.label }}</th>
+        <th *ngFor="let col of columns"
+            [attr.aria-sort]="getAriaSort(col)"
+            [class.sorted]="sortKey === col.key">
+          <button type="button"
+                  class="sort-button"
+                  (click)="onSortColumn(col)">
+            <span>{{ col.label }}</span>
+            <span class="sort-indicator" *ngIf="sortKey === col.key">
+              {{ sortDirection === 'asc' ? '▲' : '▼' }}
+            </span>
+          </button>
+        </th>
 
         <th class="actions-header"></th>
 

--- a/feedme.client/src/app/components/StockTableComponent/stock-table.component.css
+++ b/feedme.client/src/app/components/StockTableComponent/stock-table.component.css
@@ -28,6 +28,35 @@ table.stock-table thead th {
   text-align: left;
 }
 
+table.stock-table thead th.sorted {
+  color: #fa4b00;
+}
+
+table.stock-table thead th .sort-button {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  width: 100%;
+  padding: 0;
+  margin: 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+  text-align: left;
+}
+
+table.stock-table thead th .sort-button:focus-visible {
+  outline: 2px solid #fa4b00;
+  outline-offset: 2px;
+  border-radius: 0.25rem;
+}
+
+table.stock-table thead th .sort-indicator {
+  font-size: 0.75rem;
+}
+
 table.stock-table tbody td {
   padding: 1.25rem 1rem;
   font-size: 1.125rem;

--- a/feedme.client/src/app/components/StockTableComponent/stock-table.component.html
+++ b/feedme.client/src/app/components/StockTableComponent/stock-table.component.html
@@ -10,23 +10,24 @@
   <table class="stock-table">
     <thead>
       <tr>
-        <th>Название</th>
-        <th>Категория</th>
-        <th>Срок годности</th>
-        <th>Цена за единицу</th>
-        <th>Стоимость</th>
-        <th>Остаток</th>
+        <th *ngFor="let column of columns"
+            [attr.aria-sort]="getAriaSort(column.field)"
+            [class.sorted]="sortKey === column.field">
+          <button type="button"
+                  class="sort-button"
+                  (click)="changeSort(column.field)">
+            <span>{{ column.label }}</span>
+            <span class="sort-indicator" *ngIf="sortKey === column.field">
+              {{ sortDirection === 'asc' ? '▲' : '▼' }}
+            </span>
+          </button>
+        </th>
         <th>Действие</th>
       </tr>
     </thead>
     <tbody>
       <tr *ngFor="let item of paginatedData">
-        <td>{{ item.name || item.productName }}</td>
-        <td>{{ item.category }}</td>
-        <td>{{ item.expiryDate }}</td>
-        <td>{{ item.unitPrice }}</td>
-        <td>{{ item.totalCost }}</td>
-        <td>{{ item.stock }}</td>
+        <td *ngFor="let column of columns">{{ formatValue(item, column) }}</td>
         <td class="actions-cell">
           <button (click)="onSettingsClick.emit(item)">⚙️</button>
         </td>

--- a/feedme.client/src/app/utils/sort.util.ts
+++ b/feedme.client/src/app/utils/sort.util.ts
@@ -1,0 +1,108 @@
+export type SortDirection = 'asc' | 'desc';
+
+type ComparableKind = 'number' | 'string';
+
+interface ComparableValue {
+  kind: ComparableKind;
+  numeric: number;
+  text: string;
+  isEmpty: boolean;
+}
+
+const collator = new Intl.Collator('ru', { numeric: true, sensitivity: 'base' });
+
+export function toggleDirection(direction: SortDirection): SortDirection {
+  return direction === 'asc' ? 'desc' : 'asc';
+}
+
+export function sortBySelector<T>(items: T[], selector: (item: T) => unknown, direction: SortDirection): T[] {
+  const factor = direction === 'asc' ? 1 : -1;
+
+  return [...items].sort((left, right) => {
+    const comparison = compareValues(selector(left), selector(right));
+    return comparison * factor;
+  });
+}
+
+function compareValues(left: unknown, right: unknown): number {
+  const comparableLeft = toComparable(left);
+  const comparableRight = toComparable(right);
+
+  if (comparableLeft.isEmpty && comparableRight.isEmpty) {
+    return 0;
+  }
+
+  if (comparableLeft.isEmpty) {
+    return 1;
+  }
+
+  if (comparableRight.isEmpty) {
+    return -1;
+  }
+
+  if (comparableLeft.kind === 'number' && comparableRight.kind === 'number') {
+    if (comparableLeft.numeric === comparableRight.numeric) {
+      return 0;
+    }
+
+    return comparableLeft.numeric < comparableRight.numeric ? -1 : 1;
+  }
+
+  return collator.compare(comparableLeft.text, comparableRight.text);
+}
+
+function toComparable(value: unknown): ComparableValue {
+  if (value === null || value === undefined) {
+    return { kind: 'string', numeric: 0, text: '', isEmpty: true };
+  }
+
+  if (value instanceof Date) {
+    return {
+      kind: 'number',
+      numeric: value.getTime(),
+      text: value.toISOString(),
+      isEmpty: false,
+    };
+  }
+
+  if (typeof value === 'number') {
+    return { kind: 'number', numeric: value, text: value.toString(), isEmpty: false };
+  }
+
+  if (typeof value === 'boolean') {
+    const numeric = value ? 1 : 0;
+    return { kind: 'number', numeric, text: numeric.toString(), isEmpty: false };
+  }
+
+  const stringValue = value.toString().trim();
+
+  if (stringValue.length === 0) {
+    return { kind: 'string', numeric: 0, text: '', isEmpty: true };
+  }
+
+  const numericCandidate = tryParseNumber(stringValue);
+
+  if (numericCandidate !== null) {
+    return { kind: 'number', numeric: numericCandidate, text: stringValue, isEmpty: false };
+  }
+
+  const timestamp = Date.parse(stringValue);
+
+  if (!Number.isNaN(timestamp)) {
+    return { kind: 'number', numeric: timestamp, text: stringValue, isEmpty: false };
+  }
+
+  return { kind: 'string', numeric: 0, text: stringValue.toLowerCase(), isEmpty: false };
+}
+
+function tryParseNumber(value: string): number | null {
+  const compact = value.replace(/\s+/g, '');
+  const normalized = compact.replace(',', '.');
+
+  if (!/^[-+]?\d*(?:\.\d+)?$/.test(normalized)) {
+    return null;
+  }
+
+  const parsed = Number(normalized);
+  return Number.isNaN(parsed) ? null : parsed;
+}


### PR DESCRIPTION
## Summary
- add a reusable sorting utility that handles text, numbers, booleans, and date-like values
- enable sortable column headers with visual indicators in the catalog table view
- refactor the stock table to render from a column schema and support the same sorting behaviour

## Testing
- npm run lint *(fails: Angular workspace has no lint target configured)*
- npm run test *(fails: ChromeHeadless is missing libatk-1.0.so.0 in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb32f0b5848323ab6f5b33e04accbd