### PR TITLE
Ensure EF Core InMemory provider is deployed

### DIFF
--- a/feedme.Server/feedme.Server.csproj
+++ b/feedme.Server/feedme.Server.csproj
@@ -16,9 +16,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="9.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.0" />


### PR DESCRIPTION
## Summary
- ensure the Microsoft.EntityFrameworkCore.InMemory package is included in the server runtime output by removing its PrivateAssets restriction

## Testing
- `dotnet test` *(fails: dotnet not available in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc5b9dd31483238de3e615743a2b05