### PR TITLE
Support optional EF in-memory provider via reflection

### DIFF
--- a/feedme.Server/feedme.Server.csproj
+++ b/feedme.Server/feedme.Server.csproj
@@ -16,7 +16,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="9.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.0" />


### PR DESCRIPTION
## Summary
- configure the application DbContext to resolve the database provider from configuration at runtime
- add helper methods that locate and invoke the EF Core in-memory provider via reflection so the package is optional for production builds
- drop the direct Microsoft.EntityFrameworkCore.InMemory reference from the server project because tests supply it when required

## Testing
- ~/.dotnet/dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68cc5fed015c832381540644bdbf7a8d