### PR TITLE
Allow fallback database connection string configuration

### DIFF
--- a/feedme.Server/Program.cs
+++ b/feedme.Server/Program.cs
@@ -29,12 +29,7 @@ public class Program
                 return;
             }
 
-            var connectionString = configuration.GetConnectionString(AppDbContext.ConnectionStringName);
-
-            if (string.IsNullOrWhiteSpace(connectionString))
-            {
-                throw new InvalidOperationException($"Connection string '{AppDbContext.ConnectionStringName}' is not configured.");
-            }
+            var connectionString = ResolveConnectionString(configuration);
 
             options.UseNpgsql(connectionString);
         });
@@ -77,6 +72,27 @@ public class Program
         await app.ApplyMigrationsAsync();
 
         await app.RunAsync();
+    }
+
+    private static string ResolveConnectionString(IConfiguration configuration)
+    {
+        var connectionString = configuration.GetConnectionString(AppDbContext.ConnectionStringName);
+
+        if (!string.IsNullOrWhiteSpace(connectionString))
+        {
+            return connectionString;
+        }
+
+        const string fallbackConnectionName = "Default";
+        var fallbackConnectionString = configuration.GetConnectionString(fallbackConnectionName);
+
+        if (!string.IsNullOrWhiteSpace(fallbackConnectionString))
+        {
+            return fallbackConnectionString;
+        }
+
+        throw new InvalidOperationException(
+            $"Connection string '{AppDbContext.ConnectionStringName}' is not configured. Provide the '{AppDbContext.ConnectionStringName}' connection string or configure the '{fallbackConnectionName}' fallback connection string via configuration or environment variables.");
     }
 
     private static void ConfigureInMemoryDatabase(DbContextOptionsBuilder options, IConfiguration configuration)


### PR DESCRIPTION
## Summary
- add a connection string resolver that falls back to the Default connection string when WarehouseDb is not configured
- reuse the resolver when configuring the PostgreSQL DbContext to improve container configuration flexibility

## Testing
- dotnet test *(fails: command not found in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc789ab2448323bfcf41e4d7c885af