### PR TITLE
Implement typed receipt submission flow

### DIFF
--- a/feedme.client/src/app/components/add-receipt-popup/add-receipt-popup.component.html
+++ b/feedme.client/src/app/components/add-receipt-popup/add-receipt-popup.component.html
@@ -10,7 +10,7 @@
       </select>
 
       <label>Поставщик</label>
-      <input formControlName="supplierId" disabled />
+      <input formControlName="supplier" disabled />
 
       <label>Код ТН ВЭД</label>
       <input formControlName="tnvedCode" disabled />
@@ -21,11 +21,14 @@
       <label>Цена закупки за единицу</label>
       <input formControlName="unitPrice" disabled />
 
+      <label>Склад</label>
+      <input type="text" formControlName="warehouse" />
+
       <label>Дата приёмки</label>
-      <input type="date" formControlName="receiptDate" />
+      <input type="date" formControlName="receivedAt" />
 
       <label>Номер документа</label>
-      <input type="text" formControlName="documentNumber" />
+      <input type="text" formControlName="number" />
 
       <label>Количество</label>
       <input type="number" formControlName="quantity" />

--- a/feedme.client/src/app/components/add-receipt-popup/add-receipt-popup.component.spec.ts
+++ b/feedme.client/src/app/components/add-receipt-popup/add-receipt-popup.component.spec.ts
@@ -3,19 +3,74 @@ import { By } from '@angular/platform-browser';
 import { of } from 'rxjs';
 
 import { AddReceiptPopupComponent } from './add-receipt-popup.component';
-import { CatalogService } from '../../services/catalog.service';
-import { ReceiptService } from '../../services/receipt.service';
+import { CatalogService, CatalogItem } from '../../services/catalog.service';
+import { Receipt, ReceiptService } from '../../services/receipt.service';
 
 describe('AddReceiptPopupComponent', () => {
   let component: AddReceiptPopupComponent;
   let fixture: ComponentFixture<AddReceiptPopupComponent>;
+  let catalogService: jasmine.SpyObj<CatalogService>;
+  let receiptService: jasmine.SpyObj<ReceiptService>;
+
+  const catalogItem: CatalogItem = {
+    id: 'product-1',
+    name: 'Помидоры',
+    type: 'Ingredient',
+    code: 'PRD-001',
+    category: 'Овощи',
+    unit: 'кг',
+    weight: 1,
+    writeoffMethod: 'FIFO',
+    allergens: 'нет',
+    packagingRequired: false,
+    spoilsAfterOpening: true,
+    supplier: 'ООО Поставщик',
+    deliveryTime: 2,
+    costEstimate: 120,
+    taxRate: '20%',
+    unitPrice: 150,
+    salePrice: 200,
+    tnved: '0702000000',
+    isMarked: false,
+    isAlcohol: false,
+    alcoholCode: '',
+    alcoholStrength: 0,
+    alcoholVolume: 0
+  };
 
   beforeEach(async () => {
+    catalogService = jasmine.createSpyObj<CatalogService>('CatalogService', ['getAll', 'getById']);
+    receiptService = jasmine.createSpyObj<ReceiptService>('ReceiptService', ['saveReceipt']);
+
+    catalogService.getAll.and.returnValue(of([catalogItem]));
+    catalogService.getById.and.returnValue(of(catalogItem));
+
+    const createdReceipt: Receipt = {
+      id: 'receipt-1',
+      number: 'RCPT-001',
+      supplier: catalogItem.supplier,
+      warehouse: 'Главный склад',
+      receivedAt: '2024-04-15T00:00:00.000Z',
+      items: [
+        {
+          catalogItemId: catalogItem.id,
+          itemName: catalogItem.name,
+          quantity: 5,
+          unit: 'кг',
+          unitPrice: catalogItem.unitPrice,
+          totalCost: catalogItem.unitPrice * 5
+        }
+      ],
+      totalAmount: catalogItem.unitPrice * 5
+    };
+
+    receiptService.saveReceipt.and.returnValue(of(createdReceipt));
+
     await TestBed.configureTestingModule({
       imports: [AddReceiptPopupComponent],
       providers: [
-        { provide: CatalogService, useValue: { getAll: () => of([]), getById: () => of() } },
-        { provide: ReceiptService, useValue: { saveReceipt: () => of() } }
+        { provide: CatalogService, useValue: catalogService },
+        { provide: ReceiptService, useValue: receiptService }
       ]
     }).compileComponents();
 
@@ -32,6 +87,37 @@ describe('AddReceiptPopupComponent', () => {
     spyOn(component.close, 'emit');
     const btn = fixture.debugElement.query(By.css('.cancel-btn'));
     btn.nativeElement.click();
+    expect(component.close.emit).toHaveBeenCalled();
+  });
+
+  it('should construct receipt payload and close popup on submit', () => {
+    spyOn(component.close, 'emit');
+
+    component.form.controls.productId.setValue(catalogItem.id);
+    component.form.controls.number.setValue(' RCPT-001 ');
+    component.form.controls.warehouse.setValue('  Главный склад  ');
+    component.form.controls.receivedAt.setValue('2024-04-15');
+    component.form.controls.quantity.setValue(5);
+    component.form.controls.unit.setValue('кг');
+
+    component.onSubmit();
+
+    expect(receiptService.saveReceipt).toHaveBeenCalledWith({
+      number: 'RCPT-001',
+      supplier: catalogItem.supplier,
+      warehouse: 'Главный склад',
+      receivedAt: '2024-04-15T00:00:00.000Z',
+      items: [
+        {
+          catalogItemId: catalogItem.id,
+          itemName: catalogItem.name,
+          quantity: 5,
+          unit: 'кг',
+          unitPrice: catalogItem.unitPrice
+        }
+      ]
+    });
+
     expect(component.close.emit).toHaveBeenCalled();
   });
 });

--- a/feedme.client/src/app/components/add-receipt-popup/add-receipt-popup.component.ts
+++ b/feedme.client/src/app/components/add-receipt-popup/add-receipt-popup.component.ts
@@ -1,9 +1,27 @@
-import { Component, EventEmitter, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { FormBuilder, FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { combineLatest, startWith } from 'rxjs';
 
 import { CatalogService, CatalogItem } from '../../services/catalog.service';
-import { ReceiptService } from '../../services/receipt.service';
+import { CreateReceipt, ReceiptService } from '../../services/receipt.service';
+
+type AddReceiptFormControls = {
+  productId: FormControl<string>;
+  supplier: FormControl<string>;
+  tnvedCode: FormControl<string>;
+  writeoffMethod: FormControl<string>;
+  unitPrice: FormControl<number>;
+  receivedAt: FormControl<string>;
+  number: FormControl<string>;
+  warehouse: FormControl<string>;
+  quantity: FormControl<number>;
+  unit: FormControl<string>;
+  totalCost: FormControl<number>;
+  expiryDate: FormControl<string | null>;
+  batchCode: FormControl<string>;
+};
 
 @Component({
   selector: 'app-add-receipt-popup',
@@ -15,25 +33,39 @@ import { ReceiptService } from '../../services/receipt.service';
 export class AddReceiptPopupComponent implements OnInit {
   @Output() close = new EventEmitter<void>();
 
-  form = this.fb.group({
-    productId: ['', Validators.required],
-    supplierId: [{ value: '', disabled: true }],
-    tnvedCode: [{ value: '', disabled: true }],
-    writeoffMethod: [{ value: '', disabled: true }],
-    unitPrice: [{ value: 0, disabled: true }],
+  @Input()
+  set initialWarehouse(value: string | null) {
+    const normalized = (value ?? '').trim();
+    if (normalized) {
+      this.form.controls.warehouse.setValue(normalized);
+    }
+  }
 
-    receiptDate: [new Date(), Validators.required],
-    documentNumber: [''],
-    quantity: [0, Validators.required],
-    unit: ['шт', Validators.required],
-    totalCost: [{ value: 0, disabled: true }],
-
-    expiryDate: [null],
-    batchCode: ['']
+  readonly form = this.fb.group<AddReceiptFormControls>({
+    productId: this.fb.control('', { validators: [Validators.required], nonNullable: true }),
+    supplier: new FormControl({ value: '', disabled: true }, { nonNullable: true }),
+    tnvedCode: new FormControl({ value: '', disabled: true }, { nonNullable: true }),
+    writeoffMethod: new FormControl({ value: '', disabled: true }, { nonNullable: true }),
+    unitPrice: new FormControl({ value: 0, disabled: true }, { nonNullable: true }),
+    receivedAt: this.fb.control(this.formatDate(new Date()), {
+      validators: [Validators.required],
+      nonNullable: true
+    }),
+    number: this.fb.control('', { validators: [Validators.required], nonNullable: true }),
+    warehouse: this.fb.control('Главный склад', { validators: [Validators.required], nonNullable: true }),
+    quantity: this.fb.control(1, {
+      validators: [Validators.required, Validators.min(0.01)],
+      nonNullable: true
+    }),
+    unit: this.fb.control('шт', { validators: [Validators.required], nonNullable: true }),
+    totalCost: new FormControl({ value: 0, disabled: true }, { nonNullable: true }),
+    expiryDate: new FormControl<string | null>(null),
+    batchCode: this.fb.control('', { nonNullable: true })
   });
 
   catalog: CatalogItem[] = [];
   units: string[] = [];
+  private selectedProduct: CatalogItem | null = null;
 
   constructor(
     private fb: FormBuilder,
@@ -42,37 +74,130 @@ export class AddReceiptPopupComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.catalogService.getAll().subscribe(items => (this.catalog = items));
+    this.catalogService
+      .getAll()
+      .pipe(takeUntilDestroyed())
+      .subscribe(items => (this.catalog = items));
+
     this.units = ['шт', 'кг', 'л', 'упаковка'];
 
-    this.form.get('productId')!.valueChanges.subscribe(id => this.onProductChange(id));
+    this.form.controls.productId.valueChanges
+      .pipe(takeUntilDestroyed())
+      .subscribe(id => this.onProductChange(id));
 
-    this.form.valueChanges.subscribe(v => {
-      const sum = (v.quantity || 0) * (v.unitPrice || 0);
-      this.form.get('totalCost')!.setValue(sum, { emitEvent: false });
-    });
+    combineLatest([
+      this.form.controls.quantity.valueChanges.pipe(startWith(this.form.controls.quantity.value)),
+      this.form.controls.unitPrice.valueChanges.pipe(startWith(this.form.controls.unitPrice.getRawValue()))
+    ])
+      .pipe(takeUntilDestroyed())
+      .subscribe(([quantity, unitPrice]) => this.updateTotalCost(Number(quantity), Number(unitPrice)));
   }
 
   onProductChange(id: string | null): void {
-    if (!id) return;
-    this.catalogService.getById(id).subscribe(item => {
-      this.form.patchValue({
-        supplierId: item.supplier,
-        tnvedCode: item.tnved,
-        writeoffMethod: item.writeoffMethod,
-        unitPrice: item.unitPrice
+    if (!id) {
+      this.selectedProduct = null;
+      this.form.controls.supplier.setValue('', { emitEvent: false });
+      this.form.controls.tnvedCode.setValue('', { emitEvent: false });
+      this.form.controls.writeoffMethod.setValue('', { emitEvent: false });
+      this.form.controls.unitPrice.setValue(0);
+      this.form.controls.unit.setValue('шт');
+      return;
+    }
+
+    this.catalogService
+      .getById(id)
+      .pipe(takeUntilDestroyed())
+      .subscribe(item => {
+        this.selectedProduct = item;
+        this.form.controls.supplier.setValue(item.supplier, { emitEvent: false });
+        this.form.controls.tnvedCode.setValue(item.tnved, { emitEvent: false });
+        this.form.controls.writeoffMethod.setValue(item.writeoffMethod, { emitEvent: false });
+        this.form.controls.unitPrice.setValue(item.unitPrice);
+        this.form.controls.unit.setValue(item.unit || this.form.controls.unit.value);
       });
-    });
   }
 
   onSubmit(): void {
-    if (this.form.valid) {
-      const data = { ...this.form.getRawValue() };
-      this.receiptService.saveReceipt(data).subscribe(() => this.onClose());
+    this.form.markAllAsTouched();
+
+    if (this.form.invalid) {
+      return;
     }
+
+    const rawValue = this.form.getRawValue();
+    const product = this.selectedProduct ?? this.catalog.find(item => item.id === rawValue.productId);
+
+    if (!product) {
+      return;
+    }
+
+    const number = rawValue.number.trim();
+    const warehouse = rawValue.warehouse.trim();
+    const quantity = Number(rawValue.quantity);
+    const unit = (rawValue.unit || product.unit || '').trim();
+
+    if (!number) {
+      this.form.controls.number.setErrors({ required: true });
+      return;
+    }
+
+    if (!warehouse) {
+      this.form.controls.warehouse.setErrors({ required: true });
+      return;
+    }
+
+    if (!Number.isFinite(quantity) || quantity <= 0) {
+      this.form.controls.quantity.setErrors({ min: true });
+      return;
+    }
+
+    if (!unit) {
+      this.form.controls.unit.setErrors({ required: true });
+      return;
+    }
+
+    const payload: CreateReceipt = {
+      number,
+      supplier: rawValue.supplier?.trim() || product.supplier,
+      warehouse,
+      receivedAt: this.toIsoDate(rawValue.receivedAt),
+      items: [
+        {
+          catalogItemId: product.id,
+          itemName: product.name,
+          quantity,
+          unit,
+          unitPrice: product.unitPrice
+        }
+      ]
+    };
+
+    this.receiptService.saveReceipt(payload).subscribe(() => this.onClose());
   }
 
   onClose(): void {
     this.close.emit();
+  }
+
+  private updateTotalCost(quantity: number, unitPrice: number): void {
+    const total = Number.isFinite(quantity) && Number.isFinite(unitPrice) ? quantity * unitPrice : 0;
+    this.form.controls.totalCost.setValue(total, { emitEvent: false });
+  }
+
+  private formatDate(date: Date): string {
+    const year = date.getFullYear();
+    const month = `${date.getMonth() + 1}`.padStart(2, '0');
+    const day = `${date.getDate()}`.padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  }
+
+  private toIsoDate(date: string): string {
+    const [year, month, day] = date.split('-').map(Number);
+
+    if (!year || !month || !day) {
+      return new Date().toISOString();
+    }
+
+    return new Date(Date.UTC(year, month - 1, day)).toISOString();
   }
 }

--- a/feedme.client/src/app/services/receipt.service.spec.ts
+++ b/feedme.client/src/app/services/receipt.service.spec.ts
@@ -1,0 +1,71 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+
+import { ReceiptService, CreateReceipt, Receipt } from './receipt.service';
+import { API_BASE_URL } from '../tokens/api-base-url.token';
+
+describe('ReceiptService', () => {
+  let service: ReceiptService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        ReceiptService,
+        { provide: API_BASE_URL, useValue: 'https://api.test' }
+      ]
+    });
+
+    service = TestBed.inject(ReceiptService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should send typed payload and return created receipt', () => {
+    const payload: CreateReceipt = {
+      number: 'RCPT-100',
+      supplier: 'ООО Поставщик',
+      warehouse: 'Главный склад',
+      receivedAt: '2024-04-15T00:00:00.000Z',
+      items: [
+        {
+          catalogItemId: 'product-1',
+          itemName: 'Помидоры',
+          quantity: 5,
+          unit: 'кг',
+          unitPrice: 150
+        }
+      ]
+    };
+
+    const response: Receipt = {
+      id: 'receipt-1',
+      number: payload.number,
+      supplier: payload.supplier,
+      warehouse: payload.warehouse,
+      receivedAt: payload.receivedAt,
+      items: [
+        {
+          ...payload.items[0],
+          totalCost: payload.items[0].quantity * payload.items[0].unitPrice
+        }
+      ],
+      totalAmount: payload.items[0].quantity * payload.items[0].unitPrice
+    };
+
+    let actual: Receipt | undefined;
+    service.saveReceipt(payload).subscribe(result => (actual = result));
+
+    const req = httpMock.expectOne('https://api.test/api/receipts');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual(payload);
+
+    req.flush(response);
+
+    expect(actual).toEqual(response);
+  });
+});

--- a/feedme.client/src/app/services/receipt.service.ts
+++ b/feedme.client/src/app/services/receipt.service.ts
@@ -3,13 +3,42 @@ import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { ApiUrlService } from './api-url.service';
 
+export interface ReceiptLine {
+  catalogItemId: string;
+  itemName: string;
+  quantity: number;
+  unit: string;
+  unitPrice: number;
+  totalCost: number;
+}
+
+export interface Receipt {
+  id: string;
+  number: string;
+  supplier: string;
+  warehouse: string;
+  receivedAt: string;
+  items: ReceiptLine[];
+  totalAmount: number;
+}
+
+export type CreateReceiptLine = Omit<ReceiptLine, 'totalCost'>;
+
+export interface CreateReceipt {
+  number: string;
+  supplier: string;
+  warehouse: string;
+  receivedAt: string;
+  items: CreateReceiptLine[];
+}
+
 @Injectable({ providedIn: 'root' })
 export class ReceiptService {
   private readonly http = inject(HttpClient);
   private readonly apiUrl = inject(ApiUrlService);
   private readonly baseUrl = this.apiUrl.build('/api/receipts');
 
-  saveReceipt(data: any): Observable<void> {
-    return this.http.post<void>(this.baseUrl, data);
+  saveReceipt(data: CreateReceipt): Observable<Receipt> {
+    return this.http.post<Receipt>(this.baseUrl, data);
   }
 }


### PR DESCRIPTION
## Summary
- type the receipt service DTOs and return values to match the backend contract
- refactor the add receipt popup to build a backend-compliant payload and expose required fields
- extend unit tests for the popup and cover the receipt service request handling

## Testing
- `npm test` *(fails: ChromeHeadless missing libatk-1.0.so.0 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce65a5b9b08323a02a429f071a7c14