### PR TITLE
Map receipt form to DTO

### DIFF
--- a/feedme.client/src/app/components/add-receipt-popup/add-receipt-popup.component.spec.ts
+++ b/feedme.client/src/app/components/add-receipt-popup/add-receipt-popup.component.spec.ts
@@ -3,8 +3,9 @@ import { By } from '@angular/platform-browser';
 import { of } from 'rxjs';
 
 import { AddReceiptPopupComponent } from './add-receipt-popup.component';
-import { CatalogService } from '../../services/catalog.service';
+import { CatalogService, CatalogItem } from '../../services/catalog.service';
 import { ReceiptService } from '../../services/receipt.service';
+import { Receipt } from '../../models/receipt';
 
 describe('AddReceiptPopupComponent', () => {
   let component: AddReceiptPopupComponent;
@@ -14,8 +15,11 @@ describe('AddReceiptPopupComponent', () => {
     await TestBed.configureTestingModule({
       imports: [AddReceiptPopupComponent],
       providers: [
-        { provide: CatalogService, useValue: { getAll: () => of([]), getById: () => of() } },
-        { provide: ReceiptService, useValue: { saveReceipt: () => of() } }
+        {
+          provide: CatalogService,
+          useValue: { getAll: () => of<CatalogItem[]>([]), getById: () => of({} as CatalogItem) }
+        },
+        { provide: ReceiptService, useValue: { saveReceipt: () => of({} as Receipt) } }
       ]
     }).compileComponents();
 

--- a/feedme.client/src/app/models/receipt.ts
+++ b/feedme.client/src/app/models/receipt.ts
@@ -1,0 +1,18 @@
+export interface ReceiptLine {
+  catalogItemId: string;
+  itemName: string;
+  quantity: number;
+  unit: string;
+  unitPrice: number;
+  totalCost?: number;
+}
+
+export interface Receipt {
+  id?: string;
+  number: string;
+  supplier: string;
+  warehouse: string;
+  receivedAt: string;
+  items: ReceiptLine[];
+  totalAmount?: number;
+}

--- a/feedme.client/src/app/services/receipt.service.ts
+++ b/feedme.client/src/app/services/receipt.service.ts
@@ -1,6 +1,7 @@
 import { inject, Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { Receipt } from '../models/receipt';
 import { ApiUrlService } from './api-url.service';
 
 @Injectable({ providedIn: 'root' })
@@ -9,7 +10,7 @@ export class ReceiptService {
   private readonly apiUrl = inject(ApiUrlService);
   private readonly baseUrl = this.apiUrl.build('/api/receipts');
 
-  saveReceipt(data: any): Observable<void> {
-    return this.http.post<void>(this.baseUrl, data);
+  saveReceipt(receipt: Receipt): Observable<Receipt> {
+    return this.http.post<Receipt>(this.baseUrl, receipt);
   }
 }


### PR DESCRIPTION
## Summary
- add shared Receipt and ReceiptLine interfaces for client-side typing
- build a typed Receipt DTO in the add receipt popup before saving, ensuring catalog metadata populates the line item
- update ReceiptService to accept and return typed Receipt payloads

## Testing
- npm run lint *(fails: workspace has no configured lint target)*
- npm run test -- --watch=false *(fails: ChromeHeadless missing system library libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68ce6705bfa8832395de03316a844586