### PR TITLE
Use origin-based API base URL in development

### DIFF
--- a/feedme.client/src/environments/environment.model.ts
+++ b/feedme.client/src/environments/environment.model.ts
@@ -1,0 +1,5 @@
+// Общая типизация для всех конфигураций окружений Angular приложения.
+export type EnvironmentConfig = {
+  production: boolean;
+  apiBaseUrl?: string;
+};

--- a/feedme.client/src/environments/environment.prod.ts
+++ b/feedme.client/src/environments/environment.prod.ts
@@ -1,8 +1,10 @@
 // src/environments/environment.prod.ts
-export const environment = {
+//
+// Продакшен-сборка также использует фиксированный адрес API, который
+// развёрнут на публичном сервере приложения.
+import type { EnvironmentConfig } from './environment.model';
+
+export const environment: EnvironmentConfig = {
   production: true,
-  /**
-   * Продакшен-сборка также работает с основным сервером по фиксированному адресу.
-   */
   apiBaseUrl: 'http://185.251.90.40:8080'
 };

--- a/feedme.client/src/environments/environment.ts
+++ b/feedme.client/src/environments/environment.ts
@@ -1,9 +1,10 @@
 // src/environments/environment.ts
-export const environment = {
-  production: false,
-  /**
-   * Базовый адрес API, который используется клиентом в режиме разработки.
-   * Указываем удалённый сервер, чтобы фронтенд всегда работал с общей базой.
-   */
-  apiBaseUrl: 'http://185.251.90.40:8080'
+//
+// В режиме разработки базовый адрес API берём из origin браузера. Это
+// гарантирует, что прокси или локальный backend будут использоваться без
+// дополнительной конфигурации.
+import type { EnvironmentConfig } from './environment.model';
+
+export const environment: EnvironmentConfig = {
+  production: false
 };


### PR DESCRIPTION
## Summary
- allow the development environment to rely on the browser origin instead of a hard-coded API URL
- share a typed environment contract so both development and production builds stay type-safe

## Testing
- CI=1 npm start -- --proxy-config src/proxy.conf.js --open false
- curl -i -X POST http://localhost:4200/api/receipts -H 'Content-Type: application/json' -d '{"number":"R-001","supplier":"Test Supplier","warehouse":"Main Warehouse","receivedAt":"2024-01-01T00:00:00Z","items":[{"catalogItemId":"item-1","itemName":"Test Item","quantity":1,"unit":"pcs","unitPrice":10}]}'

------
https://chatgpt.com/codex/tasks/task_e_68ce6f0d30e883238db23fd0c3374014