### PR TITLE
Add catalog deletion flow across server and client

### DIFF
--- a/feedme.Server.Tests/CatalogApiTests.cs
+++ b/feedme.Server.Tests/CatalogApiTests.cs
@@ -1,0 +1,74 @@
+using System.Net;
+using System.Net.Http.Json;
+using feedme.Server.Models;
+using Xunit;
+
+namespace feedme.Server.Tests;
+
+public class CatalogApiTests
+{
+    [Fact]
+    public async Task DeleteCatalogItem_RemovesItemAndReturnsNoContent()
+    {
+        await using var factory = new FeedmeApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var createRequest = new
+        {
+            name = "Fresh Basil",
+            type = "Ingredient",
+            code = "BAS-001",
+            category = "Herbs",
+            unit = "bunch",
+            weight = 0.15,
+            writeoffMethod = "FIFO",
+            allergens = string.Empty,
+            packagingRequired = false,
+            spoilsAfterOpening = true,
+            supplier = "Green Valley",
+            deliveryTime = 2,
+            costEstimate = 1.10,
+            taxRate = "10%",
+            unitPrice = 1.50,
+            salePrice = 2.20,
+            tnved = "0902",
+            isMarked = false,
+            isAlcohol = false,
+            alcoholCode = string.Empty,
+            alcoholStrength = 0.0,
+            alcoholVolume = 0.0
+        };
+
+        var createResponse = await client.PostAsJsonAsync("/api/catalog", createRequest);
+        Assert.Equal(HttpStatusCode.Created, createResponse.StatusCode);
+
+        var createdItem = await createResponse.Content.ReadFromJsonAsync<CatalogItem>();
+        Assert.NotNull(createdItem);
+
+        var deleteResponse = await client.DeleteAsync($"/api/catalog/{createdItem!.Id}");
+        Assert.Equal(HttpStatusCode.NoContent, deleteResponse.StatusCode);
+
+        var getResponse = await client.GetAsync($"/api/catalog/{createdItem.Id}");
+        Assert.Equal(HttpStatusCode.NotFound, getResponse.StatusCode);
+    }
+
+    [Fact]
+    public async Task DeleteCatalogItem_ReturnsNotFoundForUnknownIdentifier()
+    {
+        await using var factory = new FeedmeApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.DeleteAsync($"/api/catalog/{Guid.NewGuid()}");
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task DeleteCatalogItem_ReturnsNotFoundForInvalidIdentifier()
+    {
+        await using var factory = new FeedmeApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.DeleteAsync("/api/catalog/   ");
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+}

--- a/feedme.Server/Controllers/CatalogController.cs
+++ b/feedme.Server/Controllers/CatalogController.cs
@@ -32,4 +32,16 @@ public class CatalogController : ControllerBase
         var created = await _repository.AddAsync(item);
         return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
     }
+
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> Delete(string id)
+    {
+        if (string.IsNullOrWhiteSpace(id))
+        {
+            return NotFound();
+        }
+
+        var deleted = await _repository.DeleteAsync(id);
+        return deleted ? NoContent() : NotFound();
+    }
 }

--- a/feedme.Server/Repositories/ICatalogRepository.cs
+++ b/feedme.Server/Repositories/ICatalogRepository.cs
@@ -7,4 +7,5 @@ public interface ICatalogRepository
     Task<IEnumerable<CatalogItem>> GetAllAsync();
     Task<CatalogItem?> GetByIdAsync(string id);
     Task<CatalogItem> AddAsync(CatalogItem item);
+    Task<bool> DeleteAsync(string id);
 }

--- a/feedme.Server/Repositories/PostgresCatalogRepository.cs
+++ b/feedme.Server/Repositories/PostgresCatalogRepository.cs
@@ -38,6 +38,28 @@ public class PostgresCatalogRepository(AppDbContext context) : ICatalogRepositor
         return (await GetByIdAsync(normalized.Id))!;
     }
 
+    public async Task<bool> DeleteAsync(string id)
+    {
+        if (string.IsNullOrWhiteSpace(id))
+        {
+            return false;
+        }
+
+        var normalizedId = id.Trim();
+        var existingItem = await _context.CatalogItems
+            .SingleOrDefaultAsync(item => item.Id == normalizedId);
+
+        if (existingItem is null)
+        {
+            return false;
+        }
+
+        _context.CatalogItems.Remove(existingItem);
+        await _context.SaveChangesAsync();
+
+        return true;
+    }
+
     private static CatalogItem Normalize(CatalogItem item)
     {
         if (item is null)

--- a/feedme.client/src/app/components/add-receipt-popup/add-receipt-popup.component.spec.ts
+++ b/feedme.client/src/app/components/add-receipt-popup/add-receipt-popup.component.spec.ts
@@ -11,6 +11,7 @@ describe('AddReceiptPopupComponent', () => {
   let fixture: ComponentFixture<AddReceiptPopupComponent>;
   let catalogService: jasmine.SpyObj<CatalogService>;
   let receiptService: jasmine.SpyObj<ReceiptService>;
+  const runInContext = <T>(fn: () => T): T => TestBed.runInInjectionContext(fn);
 
   const catalogItem: CatalogItem = {
     id: 'product-1',
@@ -76,7 +77,7 @@ describe('AddReceiptPopupComponent', () => {
 
     fixture = TestBed.createComponent(AddReceiptPopupComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    runInContext(() => fixture.detectChanges());
   });
 
   it('should create', () => {
@@ -84,40 +85,44 @@ describe('AddReceiptPopupComponent', () => {
   });
 
   it('should emit close on onClose', () => {
-    spyOn(component.close, 'emit');
-    const btn = fixture.debugElement.query(By.css('.cancel-btn'));
-    btn.nativeElement.click();
-    expect(component.close.emit).toHaveBeenCalled();
+    runInContext(() => {
+      spyOn(component.close, 'emit');
+      const btn = fixture.debugElement.query(By.css('.cancel-btn'));
+      btn.nativeElement.click();
+      expect(component.close.emit).toHaveBeenCalled();
+    });
   });
 
   it('should construct receipt payload and close popup on submit', () => {
-    spyOn(component.close, 'emit');
+    runInContext(() => {
+      spyOn(component.close, 'emit');
 
-    component.form.controls.productId.setValue(catalogItem.id);
-    component.form.controls.number.setValue(' RCPT-001 ');
-    component.form.controls.warehouse.setValue('  Главный склад  ');
-    component.form.controls.receivedAt.setValue('2024-04-15');
-    component.form.controls.quantity.setValue(5);
-    component.form.controls.unit.setValue('кг');
+      component.form.controls.productId.setValue(catalogItem.id);
+      component.form.controls.number.setValue(' RCPT-001 ');
+      component.form.controls.warehouse.setValue('  Главный склад  ');
+      component.form.controls.receivedAt.setValue('2024-04-15');
+      component.form.controls.quantity.setValue(5);
+      component.form.controls.unit.setValue('кг');
 
-    component.onSubmit();
+      component.onSubmit();
 
-    expect(receiptService.saveReceipt).toHaveBeenCalledWith({
-      number: 'RCPT-001',
-      supplier: catalogItem.supplier,
-      warehouse: 'Главный склад',
-      receivedAt: '2024-04-15T00:00:00.000Z',
-      items: [
-        {
-          catalogItemId: catalogItem.id,
-          itemName: catalogItem.name,
-          quantity: 5,
-          unit: 'кг',
-          unitPrice: catalogItem.unitPrice
-        }
-      ]
+      expect(receiptService.saveReceipt).toHaveBeenCalledWith({
+        number: 'RCPT-001',
+        supplier: catalogItem.supplier,
+        warehouse: 'Главный склад',
+        receivedAt: '2024-04-15T00:00:00.000Z',
+        items: [
+          {
+            catalogItemId: catalogItem.id,
+            itemName: catalogItem.name,
+            quantity: 5,
+            unit: 'кг',
+            unitPrice: catalogItem.unitPrice
+          }
+        ]
+      });
+
+      expect(component.close.emit).toHaveBeenCalled();
     });
-
-    expect(component.close.emit).toHaveBeenCalled();
   });
 });

--- a/feedme.client/src/app/components/content/content.component.spec.ts
+++ b/feedme.client/src/app/components/content/content.component.spec.ts
@@ -1,0 +1,98 @@
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+
+import { ContentComponent } from './content.component';
+import { CatalogItem, CatalogService } from '../../services/catalog.service';
+
+describe('ContentComponent', () => {
+  let fixture: ComponentFixture<ContentComponent>;
+  let component: ContentComponent;
+  let catalogService: jasmine.SpyObj<CatalogService>;
+  const createItem = (overrides: Partial<CatalogItem>): CatalogItem => ({
+    id: 'DEFAULT',
+    name: 'Default',
+    type: 'Type',
+    code: '000',
+    category: 'Category',
+    unit: 'kg',
+    weight: 1,
+    writeoffMethod: 'FIFO',
+    allergens: '',
+    packagingRequired: false,
+    spoilsAfterOpening: false,
+    supplier: 'Supplier',
+    deliveryTime: 1,
+    costEstimate: 10,
+    taxRate: '10%',
+    unitPrice: 12,
+    salePrice: 15,
+    tnved: '123',
+    isMarked: false,
+    isAlcohol: false,
+    alcoholCode: '',
+    alcoholStrength: 0,
+    alcoholVolume: 0,
+    ...overrides
+  });
+
+  beforeEach(async () => {
+    catalogService = jasmine.createSpyObj<CatalogService>('CatalogService', ['getAll', 'create', 'delete']);
+    catalogService.getAll.and.returnValue(of([]));
+
+    await TestBed.configureTestingModule({
+      imports: [ContentComponent],
+      providers: [{ provide: CatalogService, useValue: catalogService }],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ContentComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('removes the catalog item optimistically and refreshes data on success', () => {
+    const existingItems: CatalogItem[] = [
+      createItem({ id: 'ITEM-1', name: 'Item 1', code: '001' }),
+      createItem({ id: 'ITEM-2', name: 'Item 2', code: '002' })
+    ];
+
+    component.catalogData = [...existingItems];
+    catalogService.delete.and.returnValue(of(void 0));
+    catalogService.getAll.and.returnValue(of([existingItems[1]]));
+
+    component.onCatalogRemove(existingItems[0]);
+
+    expect(catalogService.delete).toHaveBeenCalledTimes(1);
+    expect(catalogService.delete).toHaveBeenCalledWith('ITEM-1');
+    expect(catalogService.getAll).toHaveBeenCalled();
+    expect(component.catalogData).toEqual([existingItems[1]]);
+    expect(component.errorMessage).toBeNull();
+  });
+
+  it('restores the previous catalog and shows an error when deletion fails', () => {
+    const existingItems: CatalogItem[] = [createItem({ id: 'ITEM-1', name: 'Item 1', code: '001' })];
+
+    component.catalogData = [...existingItems];
+    catalogService.delete.and.returnValue(throwError(() => new Error('Network error')));
+
+    component.onCatalogRemove(existingItems[0]);
+
+    expect(catalogService.delete).toHaveBeenCalledTimes(1);
+    expect(catalogService.delete).toHaveBeenCalledWith('ITEM-1');
+    expect(catalogService.getAll).not.toHaveBeenCalled();
+    expect(component.catalogData).toEqual(existingItems);
+    expect(component.errorMessage).toBe('Не удалось удалить товар. Попробуйте ещё раз.');
+  });
+
+  it('rejects deletion requests without a valid identifier', () => {
+    const invalidItem = createItem({ id: '   ' });
+
+    component.catalogData = [createItem({ id: 'VALID', name: 'Valid', code: '001' })];
+
+    component.onCatalogRemove(invalidItem);
+
+    expect(catalogService.delete).not.toHaveBeenCalled();
+    expect(component.catalogData.length).toBe(1);
+    expect(component.errorMessage).toBe('Не удалось удалить товар: отсутствует идентификатор.');
+  });
+});

--- a/feedme.client/src/app/services/catalog.service.spec.ts
+++ b/feedme.client/src/app/services/catalog.service.spec.ts
@@ -1,0 +1,49 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { CatalogService } from './catalog.service';
+import { ApiUrlService } from './api-url.service';
+
+describe('CatalogService', () => {
+  let service: CatalogService;
+  let http: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        CatalogService,
+        {
+          provide: ApiUrlService,
+          useValue: {
+            build: (path: string) => `https://api.test${path}`
+          }
+        }
+      ]
+    });
+
+    service = TestBed.inject(CatalogService);
+    http = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    http.verify();
+  });
+
+  it('issues a DELETE request with the normalized identifier', () => {
+    service.delete('  CAT-42  ').subscribe({
+      next: response => expect(response).toBeNull(),
+      error: fail
+    });
+
+    const request = http.expectOne('https://api.test/api/catalog/CAT-42');
+    expect(request.request.method).toBe('DELETE');
+    request.flush(null, { status: 204, statusText: 'No Content' });
+  });
+
+  it('emits an error when identifier is missing', () => {
+    service.delete('   ').subscribe({
+      next: () => fail('Expected the call to fail for empty identifier'),
+      error: error => expect(error.message).toContain('identifier')
+    });
+  });
+});

--- a/feedme.client/src/app/services/catalog.service.ts
+++ b/feedme.client/src/app/services/catalog.service.ts
@@ -1,6 +1,6 @@
 import { inject, Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { Observable, throwError } from 'rxjs';
 import { ApiUrlService } from './api-url.service';
 
 export interface CatalogItem {
@@ -45,5 +45,16 @@ export class CatalogService {
 
   create(item: Omit<CatalogItem, 'id'>): Observable<CatalogItem> {
     return this.http.post<CatalogItem>(this.baseUrl, item);
+  }
+
+  delete(id: string): Observable<void> {
+    const normalizedId = id?.trim();
+
+    if (!normalizedId) {
+      return throwError(() => new Error('Catalog item identifier is required.'));
+    }
+
+    const targetUrl = `${this.baseUrl}/${encodeURIComponent(normalizedId)}`;
+    return this.http.delete<void>(targetUrl);
   }
 }


### PR DESCRIPTION
## Summary
- add a delete contract to `ICatalogRepository`, implement it in the Postgres repository, and expose the new `DELETE /api/catalog/{id}` endpoint
- extend the Angular catalog service and content component to call the delete endpoint with optimistic updates and validation
- cover the delete flow with server integration tests, Angular unit tests for the service and component, and update popup tests to run inside an injection context

## Testing
- npm test
- dotnet test *(fails: dotnet CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce8fd40330832399c0f3a0f85eda6f