### PR TITLE
Fix Postgres image configuration

### DIFF
--- a/feedme.AppHost/Program.cs
+++ b/feedme.AppHost/Program.cs
@@ -3,7 +3,7 @@ using Aspire.Hosting;
 var builder = DistributedApplication.CreateBuilder(args);
 
 var postgres = builder.AddPostgres("postgres")
-    .WithImage("postgres:16-alpine")
+    .WithImageTag("16-alpine")
     .WithDataVolume();
 
 var warehouseDb = postgres.AddDatabase("WarehouseDb");


### PR DESCRIPTION
## Summary
- set the Postgres container image tag to 16-alpine using the Aspire helper

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cf16f8fee083239b4cc60c43c60f70