### PR TITLE
Ensure popup opens and closes correctly

### DIFF
--- a/feedme.client/src/app/components/content/content.component.html
+++ b/feedme.client/src/app/components/content/content.component.html
@@ -18,5 +18,9 @@
                        (onSettingsClick)="handleSettingsClick($event)">
   </app-warehouse-table>
 
-  <app-popup (onAddItem)="handleAddItem($event)"></app-popup>
+  <ng-container *ngIf="showPopup">
+    <app-popup (onAddItem)="onAddItem($event)"
+               (onClose)="closePopup()">
+    </app-popup>
+  </ng-container>
 </div>

--- a/feedme.client/src/app/components/content/content.component.ts
+++ b/feedme.client/src/app/components/content/content.component.ts
@@ -47,21 +47,16 @@ export class ContentComponent implements OnInit {
     this.tableData = data ? JSON.parse(data) : [];
   }
 
-  handleAddItem(newItem: any) {
-    this.tableData.push(newItem);
-    localStorage.setItem(
-      `warehouseData_${this.selectedTab}`,
-      JSON.stringify(this.tableData)
-    );
-    // Закрываем попап после добавления
-    this.showPopup = false;
-  }
   handleSettingsClick(item: any) {
     this.selectedItem = item;
   }
 
   openPopup() {
     this.showPopup = true;
+  }
+
+  closePopup() {
+    this.showPopup = false;
   }
 
   goToCatalog() {
@@ -73,7 +68,12 @@ export class ContentComponent implements OnInit {
   }
 
   onAddItem(item: any) {
-    this.handleAddItem(item);
-    this.showPopup = false;
+    const updatedData = [...this.tableData, item];
+    this.tableData = updatedData;
+    localStorage.setItem(
+      `warehouseData_${this.selectedTab}`,
+      JSON.stringify(updatedData)
+    );
+    this.closePopup();
   }
 }


### PR DESCRIPTION
## Summary
- render the popup component only when the content view requests it and wire up the close output
- persist newly added items through the existing handler and close the popup after adding or canceling

## Testing
- npm install *(fails: unable to resolve TypeScript 5.8.4 dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68cf204fcb3c8323be1e47acc19ecc3f