### PR TITLE
Add flexible Postgres connection string resolution

### DIFF
--- a/feedme.Server.Tests/Configuration/PostgresConnectionStringFactoryTests.cs
+++ b/feedme.Server.Tests/Configuration/PostgresConnectionStringFactoryTests.cs
@@ -1,0 +1,114 @@
+using feedme.Server.Configuration;
+using Microsoft.Extensions.Configuration;
+using Npgsql;
+using Xunit;
+
+namespace feedme.Server.Tests.Configuration;
+
+public class PostgresConnectionStringFactoryTests
+{
+    private const string ConnectionStringName = "WarehouseDb";
+
+    [Fact]
+    public void Create_ReturnsPrimaryConnectionString_WhenNoOverridesProvided()
+    {
+        var expectedConnectionString = "Host=localhost;Port=5432;Database=feedme_dev;Username=postgres;Password=postgres";
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            [$"ConnectionStrings:{ConnectionStringName}"] = expectedConnectionString
+        });
+
+        var connectionString = PostgresConnectionStringFactory.Create(configuration, ConnectionStringName);
+
+        Assert.Equal(expectedConnectionString, connectionString);
+    }
+
+    [Fact]
+    public void Create_ReturnsFallbackConnectionString_WhenPrimaryIsMissing()
+    {
+        var expectedConnectionString = "Host=localhost;Port=5432;Database=feedme;Username=postgres;Password=postgres";
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["ConnectionStrings:Default"] = expectedConnectionString
+        });
+
+        var connectionString = PostgresConnectionStringFactory.Create(configuration, ConnectionStringName);
+
+        Assert.Equal(expectedConnectionString, connectionString);
+    }
+
+    [Fact]
+    public void Create_AppliesDatabaseSectionOverrides()
+    {
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            [$"ConnectionStrings:{ConnectionStringName}"] = "Host=localhost;Port=5432;Database=feedme_dev;Username=postgres;Password=postgres",
+            ["Database:Host"] = "db.internal",
+            ["Database:Port"] = "15432",
+            ["Database:Name"] = "custom",
+            ["Database:Username"] = "feedme",
+            ["Database:Password"] = "secret",
+            ["Database:SslMode"] = "Require"
+        });
+
+        var connectionString = PostgresConnectionStringFactory.Create(configuration, ConnectionStringName);
+        var builder = new NpgsqlConnectionStringBuilder(connectionString);
+
+        Assert.Equal("db.internal", builder.Host);
+        Assert.Equal(15432, builder.Port);
+        Assert.Equal("custom", builder.Database);
+        Assert.Equal("feedme", builder.Username);
+        Assert.Equal("secret", builder.Password);
+        Assert.Equal(SslMode.Require, builder.SslMode);
+    }
+
+    [Fact]
+    public void Create_AppliesPostgresEnvironmentOverrides()
+    {
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            [$"ConnectionStrings:{ConnectionStringName}"] = "Host=localhost;Port=5432;Database=feedme_dev;Username=postgres;Password=postgres",
+            ["POSTGRES_HOST"] = "env-host",
+            ["POSTGRES_PORT"] = "6432",
+            ["POSTGRES_DB"] = "env-db",
+            ["POSTGRES_USER"] = "env-user",
+            ["POSTGRES_PASSWORD"] = "env-password"
+        });
+
+        var connectionString = PostgresConnectionStringFactory.Create(configuration, ConnectionStringName);
+        var builder = new NpgsqlConnectionStringBuilder(connectionString);
+
+        Assert.Equal("env-host", builder.Host);
+        Assert.Equal(6432, builder.Port);
+        Assert.Equal("env-db", builder.Database);
+        Assert.Equal("env-user", builder.Username);
+        Assert.Equal("env-password", builder.Password);
+    }
+
+    [Fact]
+    public void Create_ThrowsInvalidOperationException_ForInvalidPort()
+    {
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            [$"ConnectionStrings:{ConnectionStringName}"] = "Host=localhost;Port=5432;Database=feedme_dev;Username=postgres;Password=postgres",
+            ["Database:Port"] = "invalid"
+        });
+
+        Assert.Throws<InvalidOperationException>(() => PostgresConnectionStringFactory.Create(configuration, ConnectionStringName));
+    }
+
+    [Fact]
+    public void Create_ThrowsInvalidOperationException_WhenConnectionStringMissing()
+    {
+        var configuration = BuildConfiguration(Array.Empty<KeyValuePair<string, string?>>());
+
+        Assert.Throws<InvalidOperationException>(() => PostgresConnectionStringFactory.Create(configuration, ConnectionStringName));
+    }
+
+    private static IConfiguration BuildConfiguration(IEnumerable<KeyValuePair<string, string?>> values)
+    {
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+    }
+}

--- a/feedme.Server/Configuration/PostgresConnectionStringFactory.cs
+++ b/feedme.Server/Configuration/PostgresConnectionStringFactory.cs
@@ -1,0 +1,130 @@
+using System.Globalization;
+using Microsoft.Extensions.Configuration;
+using Npgsql;
+
+namespace feedme.Server.Configuration;
+
+public static class PostgresConnectionStringFactory
+{
+    private const string FallbackConnectionStringName = "Default";
+
+    public static string Create(IConfiguration configuration, string connectionStringName)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentException.ThrowIfNullOrWhiteSpace(connectionStringName);
+
+        var baseConnectionString = ResolveBaseConnectionString(configuration, connectionStringName);
+        var builder = new NpgsqlConnectionStringBuilder(baseConnectionString);
+
+        ApplyOverrides(builder, configuration);
+
+        return builder.ConnectionString;
+    }
+
+    private static string ResolveBaseConnectionString(IConfiguration configuration, string connectionStringName)
+    {
+        var primaryConnectionString = configuration.GetConnectionString(connectionStringName);
+
+        if (!string.IsNullOrWhiteSpace(primaryConnectionString))
+        {
+            return primaryConnectionString;
+        }
+
+        var fallbackConnectionString = configuration.GetConnectionString(FallbackConnectionStringName);
+
+        if (!string.IsNullOrWhiteSpace(fallbackConnectionString))
+        {
+            return fallbackConnectionString;
+        }
+
+        throw new InvalidOperationException(
+            $"Connection string '{connectionStringName}' is not configured. Provide the '{connectionStringName}' connection string or configure the '{FallbackConnectionStringName}' fallback connection string via configuration or environment variables.");
+    }
+
+    private static void ApplyOverrides(NpgsqlConnectionStringBuilder builder, IConfiguration configuration)
+    {
+        var host = FirstNonEmpty(
+            configuration["Database:Host"],
+            configuration["POSTGRES_HOST"]);
+
+        if (!string.IsNullOrWhiteSpace(host))
+        {
+            builder.Host = host;
+        }
+
+        var portValue = FirstNonEmpty(
+            configuration["Database:Port"],
+            configuration["POSTGRES_PORT"]);
+
+        if (!string.IsNullOrWhiteSpace(portValue))
+        {
+            if (!int.TryParse(portValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var port) || port <= 0)
+            {
+                throw new InvalidOperationException("The configured database port must be a positive integer value.");
+            }
+
+            builder.Port = port;
+        }
+
+        var databaseName = FirstNonEmpty(
+            configuration["Database:Name"],
+            configuration["Database:Database"],
+            configuration["POSTGRES_DB"]);
+
+        if (!string.IsNullOrWhiteSpace(databaseName))
+        {
+            builder.Database = databaseName;
+        }
+
+        var username = FirstNonEmpty(
+            configuration["Database:Username"],
+            configuration["Database:User"],
+            configuration["POSTGRES_USER"]);
+
+        if (!string.IsNullOrWhiteSpace(username))
+        {
+            builder.Username = username;
+        }
+
+        var password = FirstNonEmpty(
+            configuration["Database:Password"],
+            configuration["POSTGRES_PASSWORD"]);
+
+        if (!string.IsNullOrEmpty(password))
+        {
+            builder.Password = password;
+        }
+
+        var sslMode = FirstNonEmpty(
+            configuration["Database:SslMode"],
+            configuration["POSTGRES_SSLMODE"]);
+
+        if (!string.IsNullOrWhiteSpace(sslMode))
+        {
+            builder.SslMode = ParseSslMode(sslMode);
+        }
+    }
+
+    private static SslMode ParseSslMode(string value)
+    {
+        if (Enum.TryParse<SslMode>(value, true, out var parsedValue))
+        {
+            return parsedValue;
+        }
+
+        throw new InvalidOperationException($"Unsupported SSL mode '{value}' configured for the database connection.");
+    }
+
+    private static string? FirstNonEmpty(params string?[] values)
+    {
+        foreach (var value in values)
+        {
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                return value;
+            }
+        }
+
+        return null;
+    }
+}

--- a/feedme.Server/Program.cs
+++ b/feedme.Server/Program.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using feedme.Server.Configuration;
 using feedme.Server.Data;
 using feedme.Server.Extensions;
 using feedme.Server.Repositories;
@@ -29,7 +30,9 @@ public class Program
                 return;
             }
 
-            var connectionString = ResolveConnectionString(configuration);
+            var connectionString = PostgresConnectionStringFactory.Create(
+                configuration,
+                AppDbContext.ConnectionStringName);
 
             options.UseNpgsql(connectionString);
         });
@@ -72,27 +75,6 @@ public class Program
         await app.ApplyMigrationsAsync();
 
         await app.RunAsync();
-    }
-
-    private static string ResolveConnectionString(IConfiguration configuration)
-    {
-        var connectionString = configuration.GetConnectionString(AppDbContext.ConnectionStringName);
-
-        if (!string.IsNullOrWhiteSpace(connectionString))
-        {
-            return connectionString;
-        }
-
-        const string fallbackConnectionName = "Default";
-        var fallbackConnectionString = configuration.GetConnectionString(fallbackConnectionName);
-
-        if (!string.IsNullOrWhiteSpace(fallbackConnectionString))
-        {
-            return fallbackConnectionString;
-        }
-
-        throw new InvalidOperationException(
-            $"Connection string '{AppDbContext.ConnectionStringName}' is not configured. Provide the '{AppDbContext.ConnectionStringName}' connection string or configure the '{fallbackConnectionName}' fallback connection string via configuration or environment variables.");
     }
 
     private static void ConfigureInMemoryDatabase(DbContextOptionsBuilder options, IConfiguration configuration)


### PR DESCRIPTION
## Summary
- add a dedicated PostgreSQL connection string factory that supports overriding individual fields via configuration or environment variables
- plug the factory into the application startup to build the Npgsql connection string consistently
- cover the new factory with unit tests that verify fallback, override, and validation behaviors

## Testing
- `dotnet test` *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cf221eec8c8323bc02ca0bacae119e