### PR TITLE
Handle AppHost port conflicts

### DIFF
--- a/feedme.AppHost.Tests/AspireEndpointPortAllocatorTests.cs
+++ b/feedme.AppHost.Tests/AspireEndpointPortAllocatorTests.cs
@@ -1,0 +1,96 @@
+using System.Net;
+using System.Net.Sockets;
+using feedme.AppHost;
+using Xunit;
+
+namespace feedme.AppHost.Tests;
+
+public class AspireEndpointPortAllocatorTests
+{
+    [Fact]
+    public void EnsureEndpointPortAvailable_ChangesPortWhenOriginalPortIsBusy()
+    {
+        const string variableName = "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL";
+
+        using var occupiedListener = new TcpListener(IPAddress.Loopback, 0);
+        occupiedListener.Start();
+        var occupiedPort = ((IPEndPoint)occupiedListener.LocalEndpoint).Port;
+
+        var originalUri = new UriBuilder(Uri.UriSchemeHttps, IPAddress.Loopback.ToString(), occupiedPort).Uri.ToString();
+
+        try
+        {
+            Environment.SetEnvironmentVariable(variableName, originalUri);
+
+            AspireEndpointPortAllocator.EnsureEndpointPortAvailable(variableName);
+
+            var updatedValue = Environment.GetEnvironmentVariable(variableName);
+            Assert.NotNull(updatedValue);
+            Assert.NotEqual(originalUri, updatedValue);
+
+            var updatedUri = new Uri(updatedValue);
+            Assert.NotEqual(occupiedPort, updatedUri.Port);
+            Assert.True(IsPortCurrentlyAvailable(updatedUri), "Allocated port is unexpectedly unavailable.");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(variableName, null);
+        }
+    }
+
+    [Fact]
+    public void EnsureEndpointPortAvailable_PreservesPortWhenItIsFree()
+    {
+        const string variableName = "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL";
+
+        var freePort = GetFreePort();
+        var originalValue = $"http://127.0.0.1:{freePort}";
+
+        try
+        {
+            Environment.SetEnvironmentVariable(variableName, originalValue);
+
+            AspireEndpointPortAllocator.EnsureEndpointPortAvailable(variableName);
+
+            var updatedValue = Environment.GetEnvironmentVariable(variableName);
+            Assert.Equal(originalValue, updatedValue);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(variableName, null);
+        }
+    }
+
+    private static int GetFreePort()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    private static bool IsPortCurrentlyAvailable(Uri uri)
+    {
+        var address = IPAddress.TryParse(uri.Host, out var parsedAddress)
+            ? parsedAddress
+            : IPAddress.Loopback;
+
+        TcpListener? listener = null;
+
+        try
+        {
+            listener = new TcpListener(address, uri.Port);
+            listener.Start();
+            return true;
+        }
+        catch (SocketException)
+        {
+            return false;
+        }
+        finally
+        {
+            listener?.Stop();
+        }
+    }
+}

--- a/feedme.AppHost.Tests/AssemblyInfo.cs
+++ b/feedme.AppHost.Tests/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/feedme.AppHost.Tests/feedme.AppHost.Tests.csproj
+++ b/feedme.AppHost.Tests/feedme.AppHost.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\feedme.AppHost\feedme.AppHost.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/feedme.AppHost/AspireEndpointPortAllocator.cs
+++ b/feedme.AppHost/AspireEndpointPortAllocator.cs
@@ -1,0 +1,179 @@
+using System.Net;
+using System.Net.Sockets;
+
+namespace feedme.AppHost;
+
+internal static class AspireEndpointPortAllocator
+{
+    private static readonly string[] EndpointVariableNames =
+    [
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL"
+    ];
+
+    public static void EnsureRequiredPortsAreAvailable()
+    {
+        foreach (var variableName in EndpointVariableNames)
+        {
+            EnsureEndpointPortAvailable(variableName);
+        }
+    }
+
+    internal static void EnsureEndpointPortAvailable(string variableName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(variableName);
+
+        var rawValue = Environment.GetEnvironmentVariable(variableName);
+
+        if (string.IsNullOrWhiteSpace(rawValue))
+        {
+            return;
+        }
+
+        if (!Uri.TryCreate(rawValue, UriKind.Absolute, out var endpointUri))
+        {
+            return;
+        }
+
+        if (!IsSupportedScheme(endpointUri.Scheme) || endpointUri.Port <= 0)
+        {
+            return;
+        }
+
+        var addresses = ResolveAddresses(endpointUri);
+
+        if (addresses.Count == 0)
+        {
+            return;
+        }
+
+        if (IsPortAvailable(addresses, endpointUri.Port))
+        {
+            return;
+        }
+
+        var newPort = FindAvailablePort(addresses);
+
+        if (newPort == endpointUri.Port)
+        {
+            return;
+        }
+
+        var builder = new UriBuilder(endpointUri)
+        {
+            Port = newPort
+        };
+
+        Environment.SetEnvironmentVariable(variableName, builder.Uri.ToString());
+    }
+
+    private static bool IsSupportedScheme(string scheme)
+    {
+        return string.Equals(scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
+               || string.Equals(scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static IReadOnlyList<IPAddress> ResolveAddresses(Uri endpointUri)
+    {
+        if (string.Equals(endpointUri.Host, "localhost", StringComparison.OrdinalIgnoreCase))
+        {
+            return new[] { IPAddress.Loopback, IPAddress.IPv6Loopback };
+        }
+
+        if (IPAddress.TryParse(endpointUri.Host, out var ipAddress))
+        {
+            return new[] { ipAddress };
+        }
+
+        return Array.Empty<IPAddress>();
+    }
+
+    private static bool IsPortAvailable(IEnumerable<IPAddress> addresses, int port)
+    {
+        foreach (var address in addresses)
+        {
+            if (!IsPortAvailable(address, port))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool IsPortAvailable(IPAddress address, int port)
+    {
+        TcpListener? listener = null;
+
+        try
+        {
+            listener = new TcpListener(address, port);
+            listener.Start();
+            return true;
+        }
+        catch (SocketException)
+        {
+            return false;
+        }
+        finally
+        {
+            listener?.Stop();
+        }
+    }
+
+    private static int FindAvailablePort(IReadOnlyList<IPAddress> addresses)
+    {
+        if (addresses.Count == 0)
+        {
+            throw new ArgumentException("At least one address is required to allocate a port.", nameof(addresses));
+        }
+
+        if (addresses.Count > 1 && ContainsLoopbackPair(addresses))
+        {
+            return ReserveDualModeLoopbackPort();
+        }
+
+        return ReservePort(addresses[0]);
+    }
+
+    private static bool ContainsLoopbackPair(IReadOnlyList<IPAddress> addresses)
+    {
+        var containsIpv4 = false;
+        var containsIpv6 = false;
+
+        foreach (var address in addresses)
+        {
+            containsIpv4 |= address.Equals(IPAddress.Loopback);
+            containsIpv6 |= address.Equals(IPAddress.IPv6Loopback);
+        }
+
+        return containsIpv4 && containsIpv6;
+    }
+
+    private static int ReserveDualModeLoopbackPort()
+    {
+        using var socket = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp)
+        {
+            DualMode = true
+        };
+
+        socket.Bind(new IPEndPoint(IPAddress.IPv6Loopback, 0));
+        return ((IPEndPoint)socket.LocalEndPoint!).Port;
+    }
+
+    private static int ReservePort(IPAddress address)
+    {
+        TcpListener? listener = null;
+
+        try
+        {
+            listener = new TcpListener(address, 0);
+            listener.Start();
+            return ((IPEndPoint)listener.LocalEndpoint).Port;
+        }
+        finally
+        {
+            listener?.Stop();
+        }
+    }
+}

--- a/feedme.AppHost/AssemblyInfo.cs
+++ b/feedme.AppHost/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("feedme.AppHost.Tests")]

--- a/feedme.AppHost/Program.cs
+++ b/feedme.AppHost/Program.cs
@@ -1,4 +1,7 @@
 using Aspire.Hosting;
+using feedme.AppHost;
+
+AspireEndpointPortAllocator.EnsureRequiredPortsAreAvailable();
 
 var builder = DistributedApplication.CreateBuilder(args);
 

--- a/feedme.sln
+++ b/feedme.sln
@@ -12,6 +12,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "feedme.ServiceDefaults", "f
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "feedme.Server.Tests", "feedme.Server.Tests\feedme.Server.Tests.csproj", "{F0A6E850-48DE-416B-A46D-FC62DE8977FF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "feedme.AppHost.Tests", "feedme.AppHost.Tests\feedme.AppHost.Tests.csproj", "{232457EA-E701-4A3F-836C-6A77DE364BEB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -38,6 +40,10 @@ Global
 		{F0A6E850-48DE-416B-A46D-FC62DE8977FF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F0A6E850-48DE-416B-A46D-FC62DE8977FF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F0A6E850-48DE-416B-A46D-FC62DE8977FF}.Release|Any CPU.Build.0 = Release|Any CPU
+                {232457EA-E701-4A3F-836C-6A77DE364BEB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {232457EA-E701-4A3F-836C-6A77DE364BEB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {232457EA-E701-4A3F-836C-6A77DE364BEB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {232457EA-E701-4A3F-836C-6A77DE364BEB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- add a dedicated allocator that checks Aspire dashboard and resource service endpoints for occupied ports before the host starts
- expose the allocator to tests, register an AppHost-focused test project, and cover both conflict and non-conflict scenarios
- wire the allocator into the AppHost startup and include the new test project in the solution

## Testing
- dotnet test (fails: feedme.Server.Tests.CatalogApiTests.DeleteCatalogItem_ReturnsNotFoundForInvalidIdentifier -> expected NotFound, actual MethodNotAllowed)
- dotnet test feedme.AppHost.Tests/feedme.AppHost.Tests.csproj


------
https://chatgpt.com/codex/tasks/task_e_68cf251dee74832392413dd896aef0c3