### PR TITLE
Improve Aspire port allocation resiliency

### DIFF
--- a/feedme.AppHost.Tests/AspireEndpointPortAllocatorTests.cs
+++ b/feedme.AppHost.Tests/AspireEndpointPortAllocatorTests.cs
@@ -61,6 +61,30 @@ public class AspireEndpointPortAllocatorTests
         }
     }
 
+    [Fact]
+    public void EnsureEndpointPortAvailable_AssignsPortWhenVariableIsMissing()
+    {
+        const string variableName = "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL";
+
+        try
+        {
+            Environment.SetEnvironmentVariable(variableName, null);
+
+            AspireEndpointPortAllocator.EnsureEndpointPortAvailable(variableName);
+
+            var updatedValue = Environment.GetEnvironmentVariable(variableName);
+            Assert.False(string.IsNullOrWhiteSpace(updatedValue));
+
+            var updatedUri = new Uri(updatedValue!);
+            Assert.True(updatedUri.Port > 0);
+            Assert.True(IsPortCurrentlyAvailable(updatedUri), "Allocated port is unexpectedly unavailable.");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(variableName, null);
+        }
+    }
+
     private static int GetFreePort()
     {
         using var listener = new TcpListener(IPAddress.Loopback, 0);


### PR DESCRIPTION
## Summary
- add endpoint metadata so Aspire port allocation can fall back to safe defaults
- update the allocator to assign fresh ports when variables are missing or invalid
- extend unit tests to cover the new fallback behaviour

## Testing
- `dotnet test` *(fails: `dotnet` CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfbd7f0f94832391124d39cd87de7b