### PR TITLE
Fix EndpointContext named parameter casing

### DIFF
--- a/feedme.AppHost/AspireEndpointPortAllocator.cs
+++ b/feedme.AppHost/AspireEndpointPortAllocator.cs
@@ -77,7 +77,7 @@ internal static class AspireEndpointPortAllocator
 
             if (addresses.Count > 0 && hasSupportedScheme && hasValidPort)
             {
-                return new EndpointContext(endpointUri, addresses, requiresUpdate: false);
+                return new EndpointContext(endpointUri, addresses, RequiresUpdate: false);
             }
 
             if (definition is null)
@@ -90,7 +90,7 @@ internal static class AspireEndpointPortAllocator
                 ? endpointUri
                 : definition.CreateFallbackUri();
 
-            return new EndpointContext(fallbackUri, fallbackAddresses, requiresUpdate: true);
+            return new EndpointContext(fallbackUri, fallbackAddresses, RequiresUpdate: true);
         }
 
         if (definition is null)
@@ -98,7 +98,7 @@ internal static class AspireEndpointPortAllocator
             return null;
         }
 
-        return new EndpointContext(definition.CreateFallbackUri(), definition.Addresses, requiresUpdate: true);
+        return new EndpointContext(definition.CreateFallbackUri(), definition.Addresses, RequiresUpdate: true);
     }
 
     private static bool IsSupportedScheme(string scheme)


### PR DESCRIPTION
## Summary
- fix the named argument casing when creating `EndpointContext` instances so the record constructor resolves correctly

## Testing
- dotnet build feedme.sln
- dotnet test feedme.sln *(fails: feedme.Server.Tests.CatalogApiTests.DeleteCatalogItem_ReturnsNotFoundForInvalidIdentifier returns MethodNotAllowed)*

------
https://chatgpt.com/codex/tasks/task_e_68cfc1a36204832397abee648145fd79