### PR TITLE
Fix Angular client build invocation in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ WORKDIR /build
 COPY package.json package-lock.json ./
 COPY feedme.client ./feedme.client
 RUN npm ci --no-audit --no-fund
-RUN npm exec --workspace feedme.client -- ng build --configuration=production --output-path=dist
+WORKDIR /build/feedme.client
+RUN npm run build -- --configuration=production --output-path=dist
 
 
 FROM mcr.microsoft.com/dotnet/sdk:9.0 AS server-build


### PR DESCRIPTION
## Summary
- adjust the client build stage to execute the Angular build from the workspace directory
- use the project npm script instead of npm exec to produce the production bundle

## Testing
- npm run build -- --configuration=production --output-path=dist --no-progress

------
https://chatgpt.com/codex/tasks/task_e_68d25b9c4150832384ef2f96077a13c0