### PR TITLE
Fix Angular Docker build by constraining tsconfig includes

### DIFF
--- a/feedme.client/tsconfig.json
+++ b/feedme.client/tsconfig.json
@@ -5,10 +5,11 @@
     "moduleResolution": "node",
     "baseUrl": "./",
     "paths": {
-      // если вы захотите делать алиасы, например:
-      "@app/*": [ "src/app/*" ]
+      "@app/*": ["src/app/*"]
     },
-    // остальные настройки…
     "skipLibCheck": true
-  }
+  },
+  "files": [],
+  "include": [],
+  "exclude": ["node_modules", "dist", "obj", "bin"]
 }


### PR DESCRIPTION
## Summary
- prevent the Angular workspace tsconfig from scanning generated build folders by explicitly defining empty files/include lists
- ignore node_modules, dist, obj, and bin so the production client build no longer trips over missing obj/Debug paths during Docker builds

## Testing
- npm run build -- --configuration=production --output-path=dist
- docker build -t feedme:latest . *(fails: docker is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d26f4c968c8323b26d44238fb69925