### PR TITLE
Fix Angular client build by excluding obj output directories

### DIFF
--- a/feedme.client/tsconfig.app.json
+++ b/feedme.client/tsconfig.app.json
@@ -4,6 +4,21 @@
     "outDir": "./out-tsc/app",
     "types": []
   },
-  "files": [ "src/main.ts", "src/polyfills.ts" ],
-  "include": [ "src/**/*.d.ts" ]
+  "files": [
+    "src/main.ts",
+    "src/polyfills.ts"
+  ],
+  "include": [
+    "src/**/*.d.ts"
+  ],
+  "exclude": [
+    "src/**/*.spec.ts",
+    "src/test.ts",
+    "dist",
+    "tmp",
+    "obj",
+    "obj/**/*",
+    "out-tsc",
+    "node_modules"
+  ]
 }

--- a/feedme.client/tsconfig.json
+++ b/feedme.client/tsconfig.json
@@ -14,6 +14,13 @@
   "files": [],
   "include": [],
 
-  "exclude": ["dist", "node_modules", "tmp", "obj", "out-tsc"]
+  "exclude": [
+    "dist",
+    "node_modules",
+    "tmp",
+    "obj",
+    "obj/**/*",
+    "out-tsc"
+  ]
 
 }


### PR DESCRIPTION
## Summary
- broaden the Angular workspace tsconfig exclusion list so transient obj folders are never scanned
- extend the application tsconfig to explicitly ignore obj and other generated directories during compilation

## Testing
- npm run build -- --configuration=production --output-path=dist

------
https://chatgpt.com/codex/tasks/task_e_68d2813052c48323847053a62513a8bc