### PR TITLE
Ensure Angular client build succeeds in Docker

### DIFF
--- a/feedme.client/.gitignore
+++ b/feedme.client/.gitignore
@@ -4,6 +4,7 @@
 /dist
 /tmp
 /out-tsc
+/obj
 /bazel-out
 
 # Node

--- a/feedme.client/package.json
+++ b/feedme.client/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "prebuild": "node ./scripts/prepare-build-folders.mjs",
     "pretest": "npm ci || npm i",
     "start": "npx ng serve --open",
     "build": "npx ng build",

--- a/feedme.client/scripts/prepare-build-folders.mjs
+++ b/feedme.client/scripts/prepare-build-folders.mjs
@@ -1,0 +1,25 @@
+import { mkdir } from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const currentFilePath = fileURLToPath(import.meta.url);
+const projectRoot = path.resolve(path.dirname(currentFilePath), '..');
+const targetRoot = path.join(projectRoot, 'obj');
+const configurations = new Set(['Debug', 'Release']);
+
+async function ensureAngularBuildDirectories() {
+  await mkdir(targetRoot, { recursive: true });
+
+  for (const configuration of configurations) {
+    const configurationPath = path.join(targetRoot, configuration);
+    await mkdir(configurationPath, { recursive: true });
+  }
+}
+
+try {
+  await ensureAngularBuildDirectories();
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`Failed to prepare Angular build directories: ${message}\n`);
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary
- add a prebuild script that prepares the Angular obj/Debug and obj/Release folders expected during the production build
- ignore the obj directory in the client workspace to keep generated build folders out of version control

## Testing
- npm run build -- --configuration=production --output-path=dist

------
https://chatgpt.com/codex/tasks/task_e_68d282c585bc832399dddc8ae8895d75