### PR TITLE
Fix router configuration exports for standalone bootstrap

### DIFF
--- a/feedme.client/src/app/app-routing.module.ts
+++ b/feedme.client/src/app/app-routing.module.ts
@@ -1,17 +1,17 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
-import { ContentComponent } from './components/content/content.component';
 import { CatalogComponent } from './components/catalog/catalog.component';
+import { ContentComponent } from './components/content/content.component';
 
-const routes: Routes = [
+export const appRoutes: Routes = [
   { path: '', component: ContentComponent },
   { path: 'catalog', component: CatalogComponent },
   { path: '**', redirectTo: '', pathMatch: 'full' }
 ];
 
 @NgModule({
-  imports: [RouterModule.forRoot(routes)],
+  imports: [RouterModule.forRoot(appRoutes)],
   exports: [RouterModule]
 })
-export class AppRoutingModule { }
+export class AppRoutingModule {}

--- a/feedme.client/src/app/app.module.ts
+++ b/feedme.client/src/app/app.module.ts
@@ -1,18 +1,9 @@
 import { NgModule } from '@angular/core';
-import { RouterModule, Routes } from '@angular/router';
 
-export const routes: Routes = [
-  // ваши маршруты, например:
-  // { path: '', component: ContentComponent },
-  // { path: 'catalog', component: CatalogComponent },
-  // { path: '**', redirectTo: '' }
-];
+import { AppRoutingModule } from './app-routing.module';
 
 @NgModule({
-  // оставляем здесь только провайдер роутинга
-  imports: [
-    RouterModule.forRoot(routes)
-  ],
-  exports: [RouterModule]
+  imports: [AppRoutingModule],
+  exports: [AppRoutingModule]
 })
-export class AppModule { }
+export class AppModule {}

--- a/feedme.client/src/main.ts
+++ b/feedme.client/src/main.ts
@@ -1,11 +1,12 @@
 import { enableProdMode, importProvidersFrom } from '@angular/core';
+import { provideRouter } from '@angular/router';
 import { bootstrapApplication } from '@angular/platform-browser';
-import { AppComponent } from './app/app.component';
 import { BrowserModule } from '@angular/platform-browser';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { HttpClientModule } from '@angular/common/http';
-import { RouterModule } from '@angular/router';
-import { routes } from './app/app.module';
+
+import { AppComponent } from './app/app.component';
+import { appRoutes } from './app/app-routing.module';
 import { environment } from './environments/environment';
 
 if (environment.production) {
@@ -18,8 +19,8 @@ bootstrapApplication(AppComponent, {
       BrowserModule,
       FormsModule,
       ReactiveFormsModule,
-      HttpClientModule,
-      RouterModule.forRoot(routes)
-    )
+      HttpClientModule
+    ),
+    provideRouter(appRoutes)
   ]
 }).catch(err => console.error(err));


### PR DESCRIPTION
## Summary
- expose the actual route configuration by exporting `appRoutes` from the routing module
- provide the router in the standalone bootstrap using the shared configuration
- replace the placeholder routing setup in `AppModule` with the concrete `AppRoutingModule`

## Testing
- npm run lint *(fails: Cannot find "lint" target for the specified project)*
- npm run test *(fails: ChromeHeadless cannot start because libatk-1.0.so.0 is missing in the container)*
- CI=true npx ng serve --host 0.0.0.0 --port 4200 --disable-host-check *(manual verification of `/catalog` route activation)*

------
https://chatgpt.com/codex/tasks/task_e_68d2b50aeda883239c5650bea7d38390