### PR TITLE
Handle null receipt items gracefully

### DIFF
--- a/feedme.Server/Controllers/ReceiptsController.cs
+++ b/feedme.Server/Controllers/ReceiptsController.cs
@@ -1,6 +1,7 @@
 using feedme.Server.Models;
 using feedme.Server.Repositories;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 
 namespace feedme.Server.Controllers;
 
@@ -32,7 +33,18 @@ public class ReceiptsController : ControllerBase
     [HttpPost]
     public async Task<ActionResult<Receipt>> Create([FromBody] Receipt receipt)
     {
-        var created = await _repository.AddAsync(receipt);
-        return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
+        try
+        {
+            var created = await _repository.AddAsync(receipt);
+            return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
+        }
+        catch (ArgumentException ex)
+        {
+            var modelState = new ModelStateDictionary();
+            var key = string.IsNullOrWhiteSpace(ex.ParamName) ? string.Empty : ex.ParamName!;
+            modelState.AddModelError(key, ex.Message);
+
+            return ValidationProblem(modelState);
+        }
     }
 }

--- a/feedme.Server/Models/Receipt.cs
+++ b/feedme.Server/Models/Receipt.cs
@@ -23,5 +23,7 @@ public class Receipt
     [MinLength(1, ErrorMessage = "A receipt must contain at least one item.")]
     public List<ReceiptLine> Items { get; set; } = new();
 
-    public decimal TotalAmount => Items.Sum(item => item.TotalCost);
+    public decimal TotalAmount => Items?
+        .Where(item => item is not null)
+        .Sum(item => item.TotalCost) ?? 0m;
 }

--- a/feedme.Server/Repositories/PostgresReceiptRepository.cs
+++ b/feedme.Server/Repositories/PostgresReceiptRepository.cs
@@ -45,6 +45,13 @@ public class PostgresReceiptRepository(AppDbContext context) : IReceiptRepositor
             throw new ArgumentNullException(nameof(receipt));
         }
 
+        var items = receipt.Items ?? new List<ReceiptLine>();
+
+        if (items.Any(item => item is null))
+        {
+            throw new ArgumentException("Receipt items cannot contain null entries.", nameof(Receipt.Items));
+        }
+
         var normalized = new Receipt
         {
             Id = NormalizeIdentifier(receipt.Id),
@@ -52,7 +59,7 @@ public class PostgresReceiptRepository(AppDbContext context) : IReceiptRepositor
             Supplier = Sanitize(receipt.Supplier),
             Warehouse = Sanitize(receipt.Warehouse),
             ReceivedAt = NormalizeTimestamp(receipt.ReceivedAt),
-            Items = (receipt.Items ?? new List<ReceiptLine>())
+            Items = items
                 .Select(NormalizeItem)
                 .ToList()
         };
@@ -62,6 +69,11 @@ public class PostgresReceiptRepository(AppDbContext context) : IReceiptRepositor
 
     private static ReceiptLine NormalizeItem(ReceiptLine item)
     {
+        if (item is null)
+        {
+            throw new ArgumentNullException(nameof(item), "Receipt item cannot be null.");
+        }
+
         return new ReceiptLine
         {
             CatalogItemId = Sanitize(item.CatalogItemId),
@@ -90,5 +102,5 @@ public class PostgresReceiptRepository(AppDbContext context) : IReceiptRepositor
         };
     }
 
-    private static string Sanitize(string value) => value?.Trim() ?? string.Empty;
+    private static string Sanitize(string? value) => value?.Trim() ?? string.Empty;
 }


### PR DESCRIPTION
## Summary
- validate receipt item collections before normalization and raise descriptive errors
- surface argument validation issues from the create endpoint as structured 400 responses
- harden receipt total calculation and add an API regression test covering null line items

## Testing
- /workspace/dotnet9/dotnet test feedme.Server.Tests/feedme.Server.Tests.csproj --filter FullyQualifiedName~ReceiptsApiTests.PostReceipt_WithNullItem_ReturnsBadRequest

------
https://chatgpt.com/codex/tasks/task_e_68d3171a91148323a472a27a3c98596c