### PR TITLE
Configure development environment to use in-memory database

### DIFF
--- a/feedme.AppHost/Program.cs
+++ b/feedme.AppHost/Program.cs
@@ -12,6 +12,7 @@ var postgres = builder.AddPostgres("postgres")
 var warehouseDb = postgres.AddDatabase("WarehouseDb");
 
 builder.AddProject<Projects.feedme_Server>("feedme-server")
-    .WithReference(warehouseDb);
+    .WithReference(warehouseDb)
+    .WithEnvironment("Database__Provider", "Postgres");
 
 builder.Build().Run();

--- a/feedme.Server/appsettings.Development.json
+++ b/feedme.Server/appsettings.Development.json
@@ -5,6 +5,10 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "Database": {
+    "Provider": "InMemory",
+    "InMemoryName": "feedme-development"
+  },
   "ConnectionStrings": {
     "WarehouseDb": "Host=localhost;Port=5432;Database=feedme_dev;Username=postgres;Password=postgres"
   }


### PR DESCRIPTION
## Summary
- default the development configuration to the Entity Framework in-memory provider so the API works without a local PostgreSQL instance
- ensure the Aspire app host explicitly requests the PostgreSQL provider when launching the distributed application

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d31ce8976c8323bde7e9a22b004f69