### PR TITLE
Add resilient database migrations and improve catalog delete endpoint

### DIFF
--- a/feedme.Server.Tests/Extensions/DatabaseMigrationRetryPolicyTests.cs
+++ b/feedme.Server.Tests/Extensions/DatabaseMigrationRetryPolicyTests.cs
@@ -1,0 +1,109 @@
+using feedme.Server.Infrastructure;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace feedme.Server.Tests.Extensions;
+
+public class DatabaseMigrationRetryPolicyTests
+{
+    private static readonly ILogger Logger = NullLogger.Instance;
+
+    [Fact]
+    public async Task ExecuteAsync_SucceedsWithoutRetry_WhenOperationSucceeds()
+    {
+        var attempts = 0;
+        var delayInvocations = 0;
+
+        await DatabaseMigrationRetryPolicy.ExecuteAsync(
+            _ =>
+            {
+                attempts++;
+                return Task.CompletedTask;
+            },
+            Logger,
+            (_, _) =>
+            {
+                delayInvocations++;
+                return Task.CompletedTask;
+            },
+            CancellationToken.None);
+
+        Assert.Equal(1, attempts);
+        Assert.Equal(0, delayInvocations);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_RetriesUntilSuccess_WhenTransientErrorsOccur()
+    {
+        var attempts = 0;
+        var delayInvocations = 0;
+        const int failuresBeforeSuccess = 2;
+
+        await DatabaseMigrationRetryPolicy.ExecuteAsync(
+            _ =>
+            {
+                if (attempts++ < failuresBeforeSuccess)
+                {
+                    throw new TimeoutException("Simulated transient failure.");
+                }
+
+                return Task.CompletedTask;
+            },
+            Logger,
+            (_, _) =>
+            {
+                delayInvocations++;
+                return Task.CompletedTask;
+            },
+            CancellationToken.None);
+
+        Assert.Equal(failuresBeforeSuccess + 1, attempts);
+        Assert.Equal(failuresBeforeSuccess, delayInvocations);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ThrowsAfterMaxAttempts_WhenFailuresPersist()
+    {
+        var attempts = 0;
+        var delayInvocations = 0;
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            DatabaseMigrationRetryPolicy.ExecuteAsync(
+                _ =>
+                {
+                    attempts++;
+                    throw new TimeoutException("Persistent transient failure.");
+                },
+                Logger,
+                (_, _) =>
+                {
+                    delayInvocations++;
+                    return Task.CompletedTask;
+                },
+                CancellationToken.None));
+
+        Assert.IsType<TimeoutException>(exception.InnerException);
+        Assert.Equal(DatabaseMigrationRetryPolicy.MaxRetryAttempts, attempts);
+        Assert.Equal(DatabaseMigrationRetryPolicy.MaxRetryAttempts - 1, delayInvocations);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DoesNotRetry_WhenExceptionIsNotTransient()
+    {
+        var attempts = 0;
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            DatabaseMigrationRetryPolicy.ExecuteAsync(
+                _ =>
+                {
+                    attempts++;
+                    throw new InvalidOperationException("Non-transient failure.");
+                },
+                Logger,
+                (_, _) => Task.CompletedTask,
+                CancellationToken.None));
+
+        Assert.Equal(1, attempts);
+    }
+}

--- a/feedme.Server/Controllers/CatalogController.cs
+++ b/feedme.Server/Controllers/CatalogController.cs
@@ -33,15 +33,17 @@ public class CatalogController : ControllerBase
         return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
     }
 
-    [HttpDelete("{id}")]
-    public async Task<IActionResult> Delete(string id)
+    [HttpDelete("{id?}")]
+    public async Task<IActionResult> Delete(string? id)
     {
-        if (string.IsNullOrWhiteSpace(id))
+        var normalizedId = id?.Trim();
+
+        if (string.IsNullOrWhiteSpace(normalizedId))
         {
             return NotFound();
         }
 
-        var deleted = await _repository.DeleteAsync(id);
+        var deleted = await _repository.DeleteAsync(normalizedId!);
         return deleted ? NoContent() : NotFound();
     }
 }

--- a/feedme.Server/Infrastructure/DatabaseMigrationRetryPolicy.cs
+++ b/feedme.Server/Infrastructure/DatabaseMigrationRetryPolicy.cs
@@ -1,0 +1,109 @@
+using System.Data.Common;
+using System.IO;
+using System.Net.Sockets;
+using Microsoft.Extensions.Logging;
+
+namespace feedme.Server.Infrastructure;
+
+internal static class DatabaseMigrationRetryPolicy
+{
+    internal const int MaxRetryAttempts = 5;
+    private static readonly TimeSpan InitialDelay = TimeSpan.FromSeconds(2);
+    private static readonly TimeSpan MaxDelay = TimeSpan.FromSeconds(30);
+
+    public static Task ExecuteAsync(
+        Func<CancellationToken, Task> operation,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        return ExecuteAsync(operation, logger, TaskDelayAsync, cancellationToken);
+    }
+
+    internal static async Task ExecuteAsync(
+        Func<CancellationToken, Task> operation,
+        ILogger logger,
+        Func<TimeSpan, CancellationToken, Task> delayStrategy,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+        ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(delayStrategy);
+
+        var delay = InitialDelay;
+        Exception? lastException = null;
+
+        for (var attempt = 1; attempt <= MaxRetryAttempts; attempt++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                await operation(cancellationToken).ConfigureAwait(false);
+
+                if (logger.IsEnabled(LogLevel.Information))
+                {
+                    logger.LogInformation(
+                        "Database migration completed on attempt {Attempt}/{MaxAttempts}.",
+                        attempt,
+                        MaxRetryAttempts);
+                }
+
+                return;
+            }
+            catch (Exception ex) when (IsTransient(ex))
+            {
+                lastException = ex;
+
+                if (attempt == MaxRetryAttempts)
+                {
+                    break;
+                }
+
+                logger.LogWarning(
+                    ex,
+                    "Transient failure while applying database migrations (attempt {Attempt}/{MaxAttempts}). Retrying in {DelaySeconds} seconds...",
+                    attempt,
+                    MaxRetryAttempts,
+                    delay.TotalSeconds);
+
+                await delayStrategy(delay, cancellationToken).ConfigureAwait(false);
+
+                var nextDelaySeconds = Math.Min(delay.TotalSeconds * 2, MaxDelay.TotalSeconds);
+                delay = TimeSpan.FromSeconds(nextDelaySeconds);
+            }
+        }
+
+        logger.LogError(
+            lastException,
+            "Unable to apply database migrations after {MaxAttempts} attempts.",
+            MaxRetryAttempts);
+
+        throw new InvalidOperationException(
+            $"Unable to apply database migrations after {MaxRetryAttempts} attempts. See inner exception for details.",
+            lastException ?? new InvalidOperationException("Unknown database migration failure."));
+    }
+
+    private static Task TaskDelayAsync(TimeSpan delay, CancellationToken cancellationToken)
+        => Task.Delay(delay, cancellationToken);
+
+    private static bool IsTransient(Exception? exception)
+    {
+        if (exception is null)
+        {
+            return false;
+        }
+
+        return exception switch
+        {
+            TimeoutException => true,
+            DbException => true,
+            IOException => true,
+            SocketException => true,
+            _ when exception.InnerException is not null => IsTransient(exception.InnerException),
+            _ => false
+        };
+    }
+}

--- a/feedme.Server/Properties/AssemblyInfo.cs
+++ b/feedme.Server/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("feedme.Server.Tests")]


### PR DESCRIPTION
## Summary
- add a reusable database migration retry policy to wait for transient PostgreSQL startup issues before the API begins serving requests
- update the web application migration bootstrapper to rely on the retry policy
- trim and validate catalog delete identifiers so missing or whitespace IDs return 404 instead of a 405
- expose internals for testing and cover the migration retry policy with unit tests

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68d31ce8976c8323bde7e9a22b004f69