### PR TITLE
feat: derive api base url at runtime

### DIFF
--- a/feedme.client/src/app/config/runtime-environment.config.ts
+++ b/feedme.client/src/app/config/runtime-environment.config.ts
@@ -1,0 +1,86 @@
+import type { EnvironmentConfig } from '../../environments/environment.model';
+
+type FeedmeRuntimeWindow = Window & {
+  __FEEDME_RUNTIME_CONFIG__?: unknown;
+};
+
+export type RuntimeEnvironmentConfig = Partial<EnvironmentConfig>;
+
+const RUNTIME_CONFIG_ENDPOINT = '/assets/runtime-config.json' as const;
+
+export async function loadRuntimeEnvironmentConfig(): Promise<RuntimeEnvironmentConfig> {
+  const inlineConfig = readInlineRuntimeConfig();
+
+  if (inlineConfig) {
+    return inlineConfig;
+  }
+
+  const remoteConfig = await requestRuntimeConfig();
+
+  if (remoteConfig) {
+    return remoteConfig;
+  }
+
+  return {};
+}
+
+function readInlineRuntimeConfig(): RuntimeEnvironmentConfig | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const runtimeWindow = window as FeedmeRuntimeWindow;
+  const parsed = parseRuntimeConfig(runtimeWindow.__FEEDME_RUNTIME_CONFIG__);
+
+  return hasRuntimeOverrides(parsed) ? parsed : null;
+}
+
+async function requestRuntimeConfig(): Promise<RuntimeEnvironmentConfig | null> {
+  if (typeof fetch !== 'function') {
+    return null;
+  }
+
+  try {
+    const response = await fetch(RUNTIME_CONFIG_ENDPOINT, { cache: 'no-store' });
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const parsed = parseRuntimeConfig(await response.json());
+
+    return hasRuntimeOverrides(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function parseRuntimeConfig(raw: unknown): RuntimeEnvironmentConfig {
+  if (typeof raw !== 'object' || raw === null) {
+    return {};
+  }
+
+  const input = raw as Record<string, unknown>;
+  const config: RuntimeEnvironmentConfig = {};
+  const apiBaseUrl = normalizeBaseUrl(input.apiBaseUrl);
+
+  if (apiBaseUrl) {
+    config.apiBaseUrl = apiBaseUrl;
+  }
+
+  return config;
+}
+
+function hasRuntimeOverrides(config: RuntimeEnvironmentConfig): boolean {
+  return typeof config.apiBaseUrl === 'string';
+}
+
+function normalizeBaseUrl(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+
+  return trimmed ? trimmed : undefined;
+}

--- a/feedme.client/src/app/config/runtime-environment.providers.ts
+++ b/feedme.client/src/app/config/runtime-environment.providers.ts
@@ -1,0 +1,13 @@
+import { EnvironmentProviders, makeEnvironmentProviders } from '@angular/core';
+
+import { RUNTIME_ENVIRONMENT } from '../tokens/runtime-environment.token';
+import type { RuntimeEnvironmentConfig } from './runtime-environment.config';
+
+export function provideRuntimeEnvironment(config: RuntimeEnvironmentConfig): EnvironmentProviders {
+  return makeEnvironmentProviders([
+    {
+      provide: RUNTIME_ENVIRONMENT,
+      useValue: config
+    }
+  ]);
+}

--- a/feedme.client/src/app/tokens/api-base-url.token.ts
+++ b/feedme.client/src/app/tokens/api-base-url.token.ts
@@ -1,5 +1,6 @@
-import { InjectionToken } from '@angular/core';
+import { inject, InjectionToken } from '@angular/core';
 import { environment } from '../../environments/environment';
+import { RUNTIME_ENVIRONMENT } from './runtime-environment.token';
 
 /**
  * Токен с базовым адресом API. Значение берётся из Angular environment
@@ -8,10 +9,17 @@ import { environment } from '../../environments/environment';
 export const API_BASE_URL = new InjectionToken<string>('API_BASE_URL', {
   providedIn: 'root',
   factory: () => {
+    const runtimeConfig = inject(RUNTIME_ENVIRONMENT);
+    const runtimeBaseUrl = runtimeConfig.apiBaseUrl?.trim();
+
+    if (runtimeBaseUrl) {
+      return trimTrailingSlashes(runtimeBaseUrl);
+    }
+
     const raw = environment.apiBaseUrl?.trim();
 
     if (raw) {
-      return raw.replace(/\/+$/, '');
+      return trimTrailingSlashes(raw);
     }
 
     const origin = typeof window !== 'undefined' ? window.location.origin : '';
@@ -20,6 +28,10 @@ export const API_BASE_URL = new InjectionToken<string>('API_BASE_URL', {
       throw new Error('API base URL is not configured.');
     }
 
-    return origin.replace(/\/+$/, '');
+    return trimTrailingSlashes(origin);
   }
 });
+
+function trimTrailingSlashes(value: string): string {
+  return value.replace(/\/+$/, '');
+}

--- a/feedme.client/src/app/tokens/runtime-environment.token.ts
+++ b/feedme.client/src/app/tokens/runtime-environment.token.ts
@@ -1,0 +1,8 @@
+import { InjectionToken } from '@angular/core';
+
+import type { RuntimeEnvironmentConfig } from '../config/runtime-environment.config';
+
+export const RUNTIME_ENVIRONMENT = new InjectionToken<RuntimeEnvironmentConfig>('RUNTIME_ENVIRONMENT', {
+  providedIn: 'root',
+  factory: () => ({})
+});

--- a/feedme.client/src/environments/environment.prod.ts
+++ b/feedme.client/src/environments/environment.prod.ts
@@ -1,10 +1,7 @@
 // src/environments/environment.prod.ts
 //
-// Продакшен-сборка также использует фиксированный адрес API, который
-// развёрнут на публичном сервере приложения.
 import type { EnvironmentConfig } from './environment.model';
 
 export const environment: EnvironmentConfig = {
-  production: true,
-  apiBaseUrl: 'http://185.251.90.40:8080'
+  production: true
 };

--- a/feedme.client/src/main.ts
+++ b/feedme.client/src/main.ts
@@ -1,26 +1,35 @@
+import { HttpClientModule } from '@angular/common/http';
 import { enableProdMode, importProvidersFrom } from '@angular/core';
-import { provideRouter } from '@angular/router';
 import { bootstrapApplication } from '@angular/platform-browser';
 import { BrowserModule } from '@angular/platform-browser';
+import { provideRouter } from '@angular/router';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { HttpClientModule } from '@angular/common/http';
 
 import { AppComponent } from './app/app.component';
 import { appRoutes } from './app/app-routing.module';
+import { loadRuntimeEnvironmentConfig } from './app/config/runtime-environment.config';
+import { provideRuntimeEnvironment } from './app/config/runtime-environment.providers';
 import { environment } from './environments/environment';
 
 if (environment.production) {
   enableProdMode();
 }
 
-bootstrapApplication(AppComponent, {
-  providers: [
-    importProvidersFrom(
-      BrowserModule,
-      FormsModule,
-      ReactiveFormsModule,
-      HttpClientModule
-    ),
-    provideRouter(appRoutes)
-  ]
-}).catch(err => console.error(err));
+async function main(): Promise<void> {
+  const runtimeEnvironment = await loadRuntimeEnvironmentConfig();
+
+  await bootstrapApplication(AppComponent, {
+    providers: [
+      importProvidersFrom(
+        BrowserModule,
+        FormsModule,
+        ReactiveFormsModule,
+        HttpClientModule
+      ),
+      provideRouter(appRoutes),
+      provideRuntimeEnvironment(runtimeEnvironment)
+    ]
+  });
+}
+
+main().catch(err => console.error(err));


### PR DESCRIPTION
## Summary
- remove the hard-coded production API host from the Angular environment
- load optional runtime overrides from an inline config object or /assets/runtime-config.json before bootstrapping
- resolve the API base URL through the new runtime environment token so the UI defaults to same-origin requests

## Testing
- CI=1 npm run build -- --configuration=production

------
https://chatgpt.com/codex/tasks/task_e_68d3193378a88323a18f45d907274381