### PR TITLE
Enable development in-memory database fallback

### DIFF
--- a/feedme.Server.Tests/Configuration/DatabaseProviderResolverTests.cs
+++ b/feedme.Server.Tests/Configuration/DatabaseProviderResolverTests.cs
@@ -1,0 +1,88 @@
+using feedme.Server.Configuration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace feedme.Server.Tests.Configuration;
+
+public class DatabaseProviderResolverTests
+{
+    [Fact]
+    public void Resolve_ReturnsConfiguredPostgresProvider()
+    {
+        var configuration = BuildConfiguration([new KeyValuePair<string, string?>("Database:Provider", "Postgres")]);
+        var environment = new TestHostEnvironment { EnvironmentName = Environments.Production };
+
+        var provider = DatabaseProviderResolver.Resolve(configuration, environment);
+
+        Assert.Equal(DatabaseProvider.Postgres, provider);
+    }
+
+    [Theory]
+    [InlineData("InMemory")]
+    [InlineData("inmemory")]
+    public void Resolve_ReturnsInMemoryProvider_WhenExplicitlyConfigured(string value)
+    {
+        var configuration = BuildConfiguration([new KeyValuePair<string, string?>("Database:Provider", value)]);
+        var environment = new TestHostEnvironment { EnvironmentName = Environments.Production };
+
+        var provider = DatabaseProviderResolver.Resolve(configuration, environment);
+
+        Assert.Equal(DatabaseProvider.InMemory, provider);
+    }
+
+    [Theory]
+    [InlineData("PostgreSql")]
+    [InlineData("Npgsql")]
+    public void Resolve_SupportsPostgresAliases(string value)
+    {
+        var configuration = BuildConfiguration([new KeyValuePair<string, string?>("Database:Provider", value)]);
+        var environment = new TestHostEnvironment { EnvironmentName = Environments.Production };
+
+        var provider = DatabaseProviderResolver.Resolve(configuration, environment);
+
+        Assert.Equal(DatabaseProvider.Postgres, provider);
+    }
+
+    [Fact]
+    public void Resolve_DefaultsToInMemoryInDevelopment_WhenProviderNotConfigured()
+    {
+        var configuration = BuildConfiguration(Array.Empty<KeyValuePair<string, string?>>());
+        var environment = new TestHostEnvironment { EnvironmentName = Environments.Development };
+
+        var provider = DatabaseProviderResolver.Resolve(configuration, environment);
+
+        Assert.Equal(DatabaseProvider.InMemory, provider);
+    }
+
+    [Fact]
+    public void Resolve_ThrowsInvalidOperationException_WhenProviderMissingInProduction()
+    {
+        var configuration = BuildConfiguration(Array.Empty<KeyValuePair<string, string?>>());
+        var environment = new TestHostEnvironment { EnvironmentName = Environments.Production };
+
+        Assert.Throws<InvalidOperationException>(() => DatabaseProviderResolver.Resolve(configuration, environment));
+    }
+
+    [Fact]
+    public void ParseProvider_ThrowsInvalidOperationException_ForUnsupportedProvider()
+    {
+        Assert.Throws<InvalidOperationException>(() => DatabaseProviderResolver.ParseProvider("sqlserver"));
+    }
+
+    private static IConfiguration BuildConfiguration(IEnumerable<KeyValuePair<string, string?>> values)
+    {
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+    }
+
+    private sealed class TestHostEnvironment : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = Environments.Production;
+        public string ApplicationName { get; set; } = typeof(DatabaseProviderResolverTests).Assembly.GetName().Name!;
+        public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+    }
+}

--- a/feedme.Server/Configuration/DatabaseProvider.cs
+++ b/feedme.Server/Configuration/DatabaseProvider.cs
@@ -1,0 +1,7 @@
+namespace feedme.Server.Configuration;
+
+internal enum DatabaseProvider
+{
+    Postgres,
+    InMemory
+}

--- a/feedme.Server/Configuration/DatabaseProviderResolver.cs
+++ b/feedme.Server/Configuration/DatabaseProviderResolver.cs
@@ -1,0 +1,51 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+
+namespace feedme.Server.Configuration;
+
+internal static class DatabaseProviderResolver
+{
+    private static readonly string[] PostgresProviderAliases = ["Postgres", "PostgreSql", "Npgsql"];
+
+    public static DatabaseProvider Resolve(IConfiguration configuration, IHostEnvironment environment)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentNullException.ThrowIfNull(environment);
+
+        var providerValue = configuration["Database:Provider"];
+
+        if (!string.IsNullOrWhiteSpace(providerValue))
+        {
+            return ParseProvider(providerValue);
+        }
+
+        if (environment.IsDevelopment())
+        {
+            return DatabaseProvider.InMemory;
+        }
+
+        throw new InvalidOperationException(
+            "Database provider is not configured. Set the 'Database:Provider' configuration value to 'Postgres' or 'InMemory'.");
+    }
+
+    public static DatabaseProvider ParseProvider(string providerValue)
+    {
+        if (string.IsNullOrWhiteSpace(providerValue))
+        {
+            throw new InvalidOperationException("Database provider name cannot be null or whitespace.");
+        }
+
+        if (string.Equals(providerValue, "InMemory", StringComparison.OrdinalIgnoreCase))
+        {
+            return DatabaseProvider.InMemory;
+        }
+
+        if (PostgresProviderAliases.Any(alias => string.Equals(providerValue, alias, StringComparison.OrdinalIgnoreCase)))
+        {
+            return DatabaseProvider.Postgres;
+        }
+
+        throw new InvalidOperationException(
+            $"Unsupported database provider '{providerValue}'. Supported providers: 'Postgres' and 'InMemory'.");
+    }
+}

--- a/feedme.Server/appsettings.Development.json
+++ b/feedme.Server/appsettings.Development.json
@@ -5,6 +5,10 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "Database": {
+    "Provider": "InMemory",
+    "InMemoryName": "feedme-development"
+  },
   "ConnectionStrings": {
     "WarehouseDb": "Host=localhost;Port=5432;Database=feedme_dev;Username=postgres;Password=postgres"
   }

--- a/feedme.Server/appsettings.json
+++ b/feedme.Server/appsettings.json
@@ -6,6 +6,9 @@
     }
   },
   "AllowedHosts": "*",
+  "Database": {
+    "Provider": "Postgres"
+  },
   "ConnectionStrings": {
     "WarehouseDb": "Host=localhost;Port=5432;Database=feedme;Username=postgres;Password=postgres"
   }

--- a/feedme.Server/feedme.Server.csproj
+++ b/feedme.Server/feedme.Server.csproj
@@ -16,6 +16,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="9.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.0" />


### PR DESCRIPTION
## Summary
- add a database provider resolver so the API picks the right provider and falls back to the in-memory store for development
- update configuration and dependencies to support the in-memory provider
- add unit tests that verify provider resolution rules

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68d32980005c832389c66d0d5ea16847