### PR TITLE
Add configurable database provider with in-memory fallback

### DIFF
--- a/feedme.AppHost/Program.cs
+++ b/feedme.AppHost/Program.cs
@@ -12,6 +12,7 @@ var postgres = builder.AddPostgres("postgres")
 var warehouseDb = postgres.AddDatabase("WarehouseDb");
 
 builder.AddProject<Projects.feedme_Server>("feedme-server")
+    .WithEnvironment("Database__Provider", "Postgres")
     .WithReference(warehouseDb);
 
 builder.Build().Run();

--- a/feedme.Server.Tests/FeedmeApplicationFactory.cs
+++ b/feedme.Server.Tests/FeedmeApplicationFactory.cs
@@ -1,4 +1,5 @@
 using feedme.Server;
+using feedme.Server.Configuration;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Configuration;
@@ -13,8 +14,8 @@ internal sealed class FeedmeApplicationFactory : WebApplicationFactory<Program>
         {
             configurationBuilder.AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["Database:Provider"] = "InMemory",
-                ["Database:InMemoryName"] = $"feedme-tests-{Guid.NewGuid():N}"
+                [$"{DatabaseOptions.SectionName}:{nameof(DatabaseOptions.Provider)}"] = DatabaseProvider.InMemory.ToString(),
+                [$"{DatabaseOptions.SectionName}:{nameof(DatabaseOptions.InMemoryName)}"] = $"feedme-tests-{Guid.NewGuid():N}"
             });
         });
     }

--- a/feedme.Server/Configuration/DatabaseOptions.cs
+++ b/feedme.Server/Configuration/DatabaseOptions.cs
@@ -1,0 +1,39 @@
+namespace feedme.Server.Configuration;
+
+public enum DatabaseProvider
+{
+    InMemory,
+    Postgres
+}
+
+public sealed class DatabaseOptions
+{
+    public const string SectionName = "Database";
+    public const string DefaultInMemoryDatabaseName = "feedme";
+
+    public string? Provider { get; set; }
+
+    public string? InMemoryName { get; set; }
+
+    public DatabaseProvider ResolveProvider(DatabaseProvider fallbackProvider)
+    {
+        if (string.IsNullOrWhiteSpace(Provider))
+        {
+            return fallbackProvider;
+        }
+
+        if (Enum.TryParse<DatabaseProvider>(Provider, true, out var provider))
+        {
+            return provider;
+        }
+
+        throw new InvalidOperationException(
+            $"Unsupported database provider '{Provider}'. Set '{SectionName}:{nameof(Provider)}' to one of the supported values: {string.Join(", ", Enum.GetNames(typeof(DatabaseProvider)))}.");
+    }
+
+    public string ResolveInMemoryDatabaseName()
+        => string.IsNullOrWhiteSpace(InMemoryName)
+            ? DefaultInMemoryDatabaseName
+            : InMemoryName;
+
+}


### PR DESCRIPTION
## Summary
- introduce strongly typed database options with provider selection and safe parsing
- update server startup to choose the EF Core provider dynamically and warn when falling back to in-memory storage
- configure the Aspire host and integration tests to use the new configuration keys explicitly

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68d32980005c832389c66d0d5ea16847