### PR TITLE
Add EF Core in-memory provider dependency

### DIFF
--- a/feedme.Server/feedme.Server.csproj
+++ b/feedme.Server/feedme.Server.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="9.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Summary
- add the Microsoft.EntityFrameworkCore.InMemory package reference to the server project so the fallback database provider can load successfully

## Testing
- dotnet restore feedme.sln *(fails: dotnet: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d459185b1c8323908be69692082bbe