### PR TITLE
Add EF Core InMemory provider for development

### DIFF
--- a/feedme.Server/feedme.Server.csproj
+++ b/feedme.Server/feedme.Server.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Negotiate" Version="9.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Summary
- add the Microsoft.EntityFrameworkCore.InMemory package so the development profile can start with the in-memory database

## Testing
- `dotnet test` *(fails: command not found in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4688eb59883239f3f6f41fb87f24e