### PR TITLE
Add docker compose deployment and align production frontend config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,75 @@
+# FeedMe — развёртывание в Docker
+
+Ниже описан минимальный и воспроизводимый способ собрать production-образ,
+запустить сервер вместе с PostgreSQL и убедиться, что встроенный Angular-фронт
+корректно работает через тот же HTTP-ендпойнт.
+
+## Предварительные требования
+
+* Docker 24+ и Docker Compose v2.
+* Открытый TCP-порт `8080` на хосте, где будут запускаться контейнеры.
+
+## Структура репозитория
+
+* `Dockerfile` — мультистейдж-образ, собирающий Angular-фронт и .NET backend.
+* `docker-compose.yml` — оркестрация backend + PostgreSQL.
+* `feedme.client/src/environments` — конфигурации Angular. Production-сборка
+  теперь по умолчанию использует origin браузера, поэтому фронт автоматически
+  подключается к тому же домену, откуда был загружен.
+
+## Сборка production-образа
+
+```bash
+docker compose build server
+```
+
+Команда выполнит `npm ci`, `ng build`, затем `dotnet publish` и соберёт финальный
+слой с ASP.NET Core приложением, статикой Angular и миграциями БД.
+
+## Запуск стека
+
+```bash
+docker compose up -d
+```
+
+Compose поднимет два контейнера:
+
+* `feedme-postgres` — PostgreSQL 16 с базой `feedme` и пользователем `feedme`.
+* `feedme-server` — ASP.NET Core 9.0 с включёнными автоматическими миграциями,
+  доступный на `http://localhost:8080`.
+
+Backend ждёт инициализации БД через `depends_on` с healthcheck и стартует только
+после того, как PostgreSQL готов к работе.
+
+## Проверка работы
+
+1. Откройте `http://localhost:8080` в браузере. Angular-приложение загрузится
+   из того же контейнера.
+2. Любые API-запросы отправляются на origin страницы, поэтому дополнительных
+   настроек CORS не требуется.
+3. Для проверки здоровья сервера используйте `http://localhost:8080/health`.
+
+## Настройка под своё окружение
+
+Все параметры БД пробрасываются через переменные окружения `Database__*` в
+контейнере `feedme-server`. При необходимости измените их в `docker-compose.yml`
+или прокиньте через `.env`:
+
+```env
+Database__Password=secure-password
+POSTGRES_PASSWORD=secure-password
+```
+
+Если фронт должен ходить на внешний API, перед сборкой Angular пропишите
+абсолютный адрес в `feedme.client/src/environments/environment.prod.ts`,
+указав `apiBaseUrl`. При отсутствии этого параметра используется origin
+страницы.
+
+## Остановка и очистка
+
+```bash
+docker compose down
+```
+
+Чтобы удалить данные PostgreSQL, добавьте `-v` к команде выше.
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '3.9'
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: feedme-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: feedme
+      POSTGRES_USER: feedme
+      POSTGRES_PASSWORD: feedme
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U feedme"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  server:
+    build:
+      context: .
+    container_name: feedme-server
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      ASPNETCORE_ENVIRONMENT: Production
+      Database__Provider: Postgres
+      Database__Host: postgres
+      Database__Port: '5432'
+      Database__Name: feedme
+      Database__Username: feedme
+      Database__Password: feedme
+    ports:
+      - "8080:8080"
+    restart: unless-stopped
+
+volumes:
+  postgres-data:

--- a/feedme.client/src/environments/environment.prod.ts
+++ b/feedme.client/src/environments/environment.prod.ts
@@ -1,10 +1,9 @@
 // src/environments/environment.prod.ts
 //
-// Продакшен-сборка также использует фиксированный адрес API, который
-// развёрнут на публичном сервере приложения.
+// Продакшен-сборка использует тот же origin, что и фронт. При необходимости
+// можно задать `apiBaseUrl` и направить запросы на внешний backend.
 import type { EnvironmentConfig } from './environment.model';
 
 export const environment: EnvironmentConfig = {
-  production: true,
-  apiBaseUrl: 'http://185.251.90.40:8080'
+  production: true
 };


### PR DESCRIPTION
## Summary
- add a docker-compose stack that runs the ASP.NET Core backend together with PostgreSQL
- document step-by-step Docker deployment flow for the combined backend and Angular frontend
- let the production Angular build resolve the API URL from the page origin by default

## Testing
- dotnet test *(fails: dotnet CLI is not installed in the execution environment)*
- npm ci
- npm run lint *(fails: Angular workspace has no lint target configured)*
- npm run test *(fails: ChromeHeadless cannot start because system libraries such as libatk-1.0.so.0 are unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68d52067568c8323a29c197d8abd1e92