### PR TITLE
Improve dev proxy backend resolution

### DIFF
--- a/feedme.client/src/proxy.conf.js
+++ b/feedme.client/src/proxy.conf.js
@@ -1,9 +1,21 @@
 const { env } = require('process');
 
-const target = resolvePreferredEndpoint([
-  'services__feedme-server__http__0',
-  'services__feedme-server__https__0',
-]) ?? 'http://localhost:5016';
+const FALLBACK_ENDPOINTS = ['https://localhost:7221', 'http://localhost:5016'];
+
+const target = [
+  resolvePreferredEndpoint([
+    'services__feedme-server__https__0',
+    'services__feedme-server__http__0'
+  ]),
+  resolveFromUrlsVariable('ASPNETCORE_URLS'),
+  resolveFromPorts('ASPNETCORE_HTTPS_PORTS', 'https'),
+  resolveFromPorts('ASPNETCORE_HTTP_PORTS', 'http'),
+  ...FALLBACK_ENDPOINTS.map((endpoint) => normalizeUrl(endpoint))
+].find(Boolean);
+
+if (!target) {
+  throw new Error('Unable to determine the backend endpoint for the development proxy.');
+}
 
 /**
  * Resolves the first available endpoint from the provided environment variable names.
@@ -14,9 +26,63 @@ const target = resolvePreferredEndpoint([
  * exposes the variables.
  */
 function resolvePreferredEndpoint(variableNames) {
-  return variableNames
-    .map((name) => getEnvironmentValue(name))
-    .find((value) => Boolean(value));
+  for (const name of variableNames) {
+    const candidate = normalizeUrl(getEnvironmentValue(name));
+
+    if (candidate) {
+      return candidate;
+    }
+  }
+
+  return undefined;
+}
+
+function resolveFromUrlsVariable(variableName) {
+  const raw = getEnvironmentValue(variableName);
+
+  if (!raw) {
+    return undefined;
+  }
+
+  return raw
+    .split(/[;,\s]+/)
+    .map((segment) => normalizeUrl(segment))
+    .find(Boolean);
+}
+
+function resolveFromPorts(variableName, scheme) {
+  const raw = getEnvironmentValue(variableName);
+
+  if (!raw) {
+    return undefined;
+  }
+
+  return raw
+    .split(/[;,\s]+/)
+    .map((segment) => normalizeUrl(segment, scheme))
+    .find(Boolean);
+}
+
+function normalizeUrl(value, schemeHint) {
+  if (!value) {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+
+  if (!trimmed) {
+    return undefined;
+  }
+
+  if (/^https?:\/\//i.test(trimmed)) {
+    return trimmed;
+  }
+
+  if (schemeHint && /^\d+$/.test(trimmed)) {
+    return `${schemeHint}://localhost:${trimmed}`;
+  }
+
+  return undefined;
 }
 
 function getEnvironmentValue(variableName) {
@@ -38,8 +104,8 @@ const PROXY_CONFIG = {
   '/api': {
     target,
     secure: false,
-    logLevel: 'error',
-  },
+    logLevel: 'error'
+  }
 };
 
 module.exports = PROXY_CONFIG;


### PR DESCRIPTION
## Summary
- enhance the Angular development proxy to resolve backend endpoints from common ASP.NET Core environment variables
- normalize URL and port values while preferring HTTPS and keep secure fallbacks for local development
- surface configuration errors early when no backend endpoint can be determined

## Testing
- `npm run lint` *(fails: workspace is not configured with an Angular lint target)*
- `CI=1 npm test -- --watch=false --browsers=ChromeHeadlessNoSandbox --progress=false` *(fails: ChromeHeadless cannot start because libatk is missing in the container image)*

------
https://chatgpt.com/codex/tasks/task_e_68d52eda080c83239fc903d72102e12e