### PR TITLE
chore: support container ports in dev proxy

### DIFF
--- a/feedme.client/src/proxy.conf.js
+++ b/feedme.client/src/proxy.conf.js
@@ -1,6 +1,12 @@
 const { env } = require('process');
 
-const FALLBACK_ENDPOINTS = ['https://localhost:7221', 'http://localhost:5016'];
+const FALLBACK_ENDPOINTS = [
+  // HTTPS ports are listed first so that secure endpoints take precedence.
+  'https://localhost:8081',
+  'https://localhost:7221',
+  'http://localhost:8080',
+  'http://localhost:5016'
+];
 
 const target = [
   resolvePreferredEndpoint([


### PR DESCRIPTION
## Summary
- add the container profile ports to the development proxy fallback list so Angular can reach the API
- document the precedence of secure endpoints when choosing a proxy target

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5716882a083239f2eae8c07d4c9da