### PR TITLE
Fix dev API base URL to point to backend port

### DIFF
--- a/feedme.client/src/environments/environment.ts
+++ b/feedme.client/src/environments/environment.ts
@@ -1,10 +1,12 @@
 // src/environments/environment.ts
 //
-// В режиме разработки базовый адрес API берём из origin браузера. Это
-// гарантирует, что прокси или локальный backend будут использоваться без
-// дополнительной конфигурации.
+// В режиме разработки API-сервер запускается отдельно от Angular Dev Server,
+// поэтому явно указываем его базовый адрес. Это устраняет обращения к
+// несуществующему эндпоинту `http://localhost:4200/api` и направляет запросы
+// напрямую на ASP.NET Core backend.
 import type { EnvironmentConfig } from './environment.model';
 
 export const environment: EnvironmentConfig = {
-  production: false
+  production: false,
+  apiBaseUrl: 'http://localhost:5016'
 };


### PR DESCRIPTION
## Summary
- configure the Angular development environment to call the ASP.NET Core backend instead of the dev server
- document the reason for the explicit base URL so catalog requests stop targeting localhost:4200

## Testing
- npm test *(fails: ChromeHeadless cannot start because libatk-1.0.so.0 is missing in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d67362d19483239f0904aa7942f968