### PR TITLE
Configure Angular proxy to target production API host

### DIFF
--- a/feedme.client/angular.json
+++ b/feedme.client/angular.json
@@ -43,7 +43,8 @@
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
-            "buildTarget": "feedme:build"
+            "buildTarget": "feedme:build",
+            "proxyConfig": "src/proxy.conf.js"
           },
           "configurations": {
             "production": {

--- a/feedme.client/src/proxy.conf.js
+++ b/feedme.client/src/proxy.conf.js
@@ -1,15 +1,35 @@
 const { env } = require('process');
 
-const target = env["services__feedme-server__https__0"] ?? 'https://localhost:7221';
+const normalizeTarget = (rawValue) => {
+  if (!rawValue) {
+    return null;
+  }
+
+  try {
+    const url = new URL(rawValue.startsWith('http') ? rawValue : `http://${rawValue}`);
+    return url.toString().replace(/\/?$/, '');
+  } catch (error) {
+    return null;
+  }
+};
+
+const defaultTarget = 'http://185.251.90.40';
+const target =
+  normalizeTarget(env.API_BASE_URL) ||
+  normalizeTarget(env.services__feedme_server__http__0) ||
+  normalizeTarget(env.services__feedme_server__https__0) ||
+  normalizeTarget(env['services__feedme-server__http__0']) ||
+  normalizeTarget(env['services__feedme-server__https__0']) ||
+  defaultTarget;
 
 const PROXY_CONFIG = [
   {
-    context: [
-      "/weatherforecast",
-    ],
+    context: ['/api', '/weatherforecast'],
     target,
-    secure: false
-  }
-]
+    secure: false,
+    changeOrigin: true,
+    logLevel: 'info',
+  },
+];
 
 module.exports = PROXY_CONFIG;


### PR DESCRIPTION
## Summary
- route Angular dev-server API requests through the proxy to the production backend at 185.251.90.40
- allow environment overrides when resolving the proxy destination and apply it to both /api and /weatherforecast routes
- ensure the dev server loads the proxy configuration by wiring src/proxy.conf.js into angular.json

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d863cb03448323a248cf6feb3ef409