### PR TITLE
Configure frontend proxy to target production API

### DIFF
--- a/feedme.client/angular.json
+++ b/feedme.client/angular.json
@@ -43,7 +43,8 @@
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
-            "buildTarget": "feedme:build"
+            "buildTarget": "feedme:build",
+            "proxyConfig": "src/proxy.conf.js"
           },
           "configurations": {
             "production": {

--- a/feedme.client/src/proxy.conf.js
+++ b/feedme.client/src/proxy.conf.js
@@ -1,15 +1,22 @@
 const { env } = require('process');
 
-const target = env["services__feedme-server__https__0"] ?? 'https://localhost:7221';
+const DEFAULT_TARGET = 'http://185.251.90.40';
+const target =
+  env.FEEDME_API_BASE_URL ??
+  env["services__feedme-server__https__0"] ??
+  env["services__feedme-server__http__0"] ??
+  DEFAULT_TARGET;
 
 const PROXY_CONFIG = [
   {
     context: [
-      "/weatherforecast",
+      '/api',
+      '/weatherforecast',
     ],
     target,
-    secure: false
-  }
-]
+    secure: false,
+    changeOrigin: true,
+  },
+];
 
 module.exports = PROXY_CONFIG;


### PR DESCRIPTION
## Summary
- update the Angular development proxy to forward API requests to the backend at 185.251.90.40 with optional environment overrides
- register the proxy configuration with the dev server so local builds use the remote backend automatically

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d863cb03448323a248cf6feb3ef409