### PR TITLE
Configure frontend to target remote backend

### DIFF
--- a/feedme.client/src/environments/environment.prod.ts
+++ b/feedme.client/src/environments/environment.prod.ts
@@ -1,9 +1,11 @@
 // src/environments/environment.prod.ts
 //
-// Продакшен-сборка использует тот же origin, что и фронт. При необходимости
-// можно задать `apiBaseUrl` и направить запросы на внешний backend.
+// Продакшен-сборка сразу направляет запросы на внешний backend без прокси.
+// Это гарантирует, что опубликованный фронтенд и backend взаимодействуют
+// через один и тот же домен 185.251.90.40:8080.
 import type { EnvironmentConfig } from './environment.model';
 
 export const environment: EnvironmentConfig = {
-  production: true
+  production: true,
+  apiBaseUrl: 'http://185.251.90.40:8080'
 };

--- a/feedme.client/src/environments/environment.ts
+++ b/feedme.client/src/environments/environment.ts
@@ -1,12 +1,12 @@
 // src/environments/environment.ts
 //
-// Для локальной разработки мы полагаемся на прокси-конфигурацию Angular,
-// которая перенаправляет запросы с origin дев-сервера (`http://localhost:4200`)
-// на актуальный backend, независимо от того, запускается ли он через `dotnet`
-// или внутри Docker. Поэтому базовый адрес API здесь не задаём — токен
-// `API_BASE_URL` автоматически возьмёт origin окна браузера.
+// Для локальной разработки мы явно указываем внешний backend, чтобы клиент
+// не пытался обращаться к порту дев-сервера (`http://localhost:4200`).
+// Это позволяет без прокси-перенаправления использовать опубликованный API,
+// который доступен по адресу 185.251.90.40:8080.
 import type { EnvironmentConfig } from './environment.model';
 
 export const environment: EnvironmentConfig = {
-  production: false
+  production: false,
+  apiBaseUrl: 'http://185.251.90.40:8080'
 };


### PR DESCRIPTION
## Summary
- point both development and production Angular environments to the remote backend at 185.251.90.40:8080 so API requests no longer hit localhost

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d867896a688323a039ae06c80cef96