### PR TITLE
feat: redesign warehouse UX

### DIFF
--- a/feedme.client/src/app/app-routing.module.ts
+++ b/feedme.client/src/app/app-routing.module.ts
@@ -3,10 +3,12 @@ import { RouterModule, Routes } from '@angular/router';
 
 import { CatalogComponent } from './components/catalog/catalog.component';
 import { ContentComponent } from './components/content/content.component';
+import { WarehousePageComponent } from './warehouse/warehouse-page.component';
 
 export const appRoutes: Routes = [
   { path: '', component: ContentComponent },
   { path: 'catalog', component: CatalogComponent },
+  { path: 'warehouse', component: WarehousePageComponent },
   { path: '**', redirectTo: '', pathMatch: 'full' }
 ];
 

--- a/feedme.client/src/app/warehouse/models.ts
+++ b/feedme.client/src/app/warehouse/models.ts
@@ -1,0 +1,14 @@
+export type StockStatus = 'ok' | 'warning' | 'danger';
+
+export interface SupplyRow {
+  readonly id: number;
+  readonly sku: string;
+  readonly name: string;
+  readonly category: string;
+  readonly qty: number;
+  readonly unit: string;
+  readonly price: number;
+  readonly expiry: string;
+  readonly supplier: string;
+  readonly status: StockStatus;
+}

--- a/feedme.client/src/app/warehouse/ui/empty-state.component.css
+++ b/feedme.client/src/app/warehouse/ui/empty-state.component.css
@@ -1,0 +1,30 @@
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  width: 100%;
+  padding: 48px 0;
+  border: 1px dashed #cbd5f5;
+  border-radius: 16px;
+  background-color: #f8fafc;
+  text-align: center;
+}
+
+.empty-state__icon {
+  font-size: 2rem;
+}
+
+.empty-state__title {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.empty-state__subtitle {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #475569;
+}

--- a/feedme.client/src/app/warehouse/ui/empty-state.component.ts
+++ b/feedme.client/src/app/warehouse/ui/empty-state.component.ts
@@ -1,0 +1,19 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+
+@Component({
+  standalone: true,
+  selector: 'app-empty',
+  template: `
+    <section class="empty-state" role="status">
+      <div class="empty-state__icon">📦</div>
+      <h3 class="empty-state__title">{{ title }}</h3>
+      <p class="empty-state__subtitle">{{ subtitle }}</p>
+    </section>
+  `,
+  styleUrl: './empty-state.component.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class EmptyStateComponent {
+  @Input({ required: true }) title!: string;
+  @Input({ required: true }) subtitle!: string;
+}

--- a/feedme.client/src/app/warehouse/ui/field.component.css
+++ b/feedme.client/src/app/warehouse/ui/field.component.css
@@ -1,0 +1,23 @@
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 12px 16px;
+  border-radius: 12px;
+  background-color: #f8fafc;
+  border: 1px solid #e2e8f0;
+}
+
+.field__label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #94a3b8;
+}
+
+.field__value {
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: #0f172a;
+  word-break: break-word;
+}

--- a/feedme.client/src/app/warehouse/ui/field.component.ts
+++ b/feedme.client/src/app/warehouse/ui/field.component.ts
@@ -1,0 +1,18 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+
+@Component({
+  standalone: true,
+  selector: 'app-field',
+  template: `
+    <div class="field">
+      <span class="field__label">{{ label }}</span>
+      <span class="field__value">{{ value }}</span>
+    </div>
+  `,
+  styleUrl: './field.component.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class FieldComponent {
+  @Input({ required: true }) label!: string;
+  @Input({ required: true }) value!: string;
+}

--- a/feedme.client/src/app/warehouse/ui/metric.component.css
+++ b/feedme.client/src/app/warehouse/ui/metric.component.css
@@ -1,0 +1,39 @@
+.metric {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 20px;
+  border-radius: 16px;
+  background: linear-gradient(180deg, rgba(14, 116, 144, 0.08), rgba(14, 116, 144, 0.02));
+  border: 1px solid rgba(14, 116, 144, 0.18);
+  color: #0f172a;
+}
+
+.metric--warn {
+  background: linear-gradient(180deg, rgba(234, 179, 8, 0.12), rgba(234, 179, 8, 0.04));
+  border-color: rgba(234, 179, 8, 0.3);
+}
+
+.metric--danger {
+  background: linear-gradient(180deg, rgba(239, 68, 68, 0.12), rgba(239, 68, 68, 0.04));
+  border-color: rgba(239, 68, 68, 0.35);
+}
+
+.metric__title {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #0f172a;
+  opacity: 0.7;
+}
+
+.metric__value {
+  font-size: 1.75rem;
+  font-weight: 700;
+}
+
+.metric__hint {
+  margin: 0;
+  font-size: 0.875rem;
+  color: #475569;
+}

--- a/feedme.client/src/app/warehouse/ui/metric.component.ts
+++ b/feedme.client/src/app/warehouse/ui/metric.component.ts
@@ -1,0 +1,21 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+
+@Component({
+  standalone: true,
+  selector: 'app-metric',
+  template: `
+    <article class="metric" [class.metric--warn]="variant === 'warn'" [class.metric--danger]="variant === 'danger'">
+      <header class="metric__title">{{ title }}</header>
+      <div class="metric__value">{{ value }}</div>
+      <p class="metric__hint">{{ hint }}</p>
+    </article>
+  `,
+  styleUrl: './metric.component.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class MetricComponent {
+  @Input({ required: true }) title!: string;
+  @Input({ required: true }) value!: string;
+  @Input({ required: true }) hint!: string;
+  @Input() variant: 'default' | 'warn' | 'danger' = 'default';
+}

--- a/feedme.client/src/app/warehouse/warehouse-page.component.css
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.css
@@ -1,0 +1,478 @@
+:host {
+  display: block;
+  color: #111827;
+}
+
+.warehouse-page {
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  height: 100vh;
+  background-color: #f8fafc;
+}
+
+.warehouse-page__sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 32px 24px;
+  border-right: 1px solid #e2e8f0;
+  background-color: #ffffff;
+  overflow-y: auto;
+}
+
+.warehouse-page__brand {
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.warehouse-page__primary-nav,
+.warehouse-page__locations {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.warehouse-page__primary-link,
+.warehouse-page__location {
+  display: inline-flex;
+  align-items: center;
+  padding: 8px 12px;
+  border-radius: 8px;
+  font-size: 0.875rem;
+  color: #475569;
+  text-decoration: none;
+  transition: background-color 0.2s ease;
+}
+
+.warehouse-page__primary-link:hover,
+.warehouse-page__location:hover {
+  background-color: #f1f5f9;
+  color: #1f2937;
+}
+
+.warehouse-page__primary-link--active,
+.warehouse-page__location--active {
+  background-color: #e2e8f0;
+  color: #0f172a;
+  font-weight: 600;
+}
+
+.warehouse-page__divider {
+  height: 1px;
+  background-color: #e2e8f0;
+}
+
+.warehouse-page__locations-title {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  color: #94a3b8;
+  margin-bottom: 4px;
+}
+
+.warehouse-page__content {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  height: 100vh;
+  overflow-y: auto;
+}
+
+.warehouse-page__top-bar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 32px;
+  background-color: rgba(255, 255, 255, 0.92);
+  border-bottom: 1px solid #e2e8f0;
+  backdrop-filter: blur(8px);
+}
+
+.warehouse-page__breadcrumbs {
+  font-size: 0.875rem;
+  color: #6b7280;
+}
+
+.warehouse-page__breadcrumb-current {
+  color: #111827;
+  font-weight: 600;
+}
+
+.warehouse-page__actions {
+  display: flex;
+  gap: 12px;
+}
+
+.warehouse-page__body {
+  padding: 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.warehouse-page__metrics {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.warehouse-page__tabs {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  background-color: #ffffff;
+  overflow: hidden;
+}
+
+.warehouse-page__tab {
+  padding: 10px 16px;
+  font-size: 0.875rem;
+  color: #4b5563;
+  background: none;
+  border: none;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.warehouse-page__tab:hover {
+  background-color: #f1f5f9;
+}
+
+.warehouse-page__tab--active {
+  background-color: #e2e8f0;
+  color: #111827;
+  font-weight: 600;
+}
+
+.warehouse-page__tab-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.warehouse-page__filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  padding: 20px;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  background-color: #ffffff;
+  align-items: flex-end;
+}
+
+.warehouse-page__filter {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 200px;
+}
+
+.warehouse-page__filter-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #94a3b8;
+}
+
+.warehouse-page__filters-actions {
+  margin-left: auto;
+  display: flex;
+  gap: 12px;
+}
+
+.warehouse-page__bulk {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  font-size: 0.875rem;
+  color: #6b7280;
+}
+
+.warehouse-page__bulk-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.warehouse-page__bulk-count {
+  color: #111827;
+  font-weight: 500;
+}
+
+.warehouse-page__table-card {
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  background-color: #ffffff;
+  display: flex;
+  flex-direction: column;
+}
+
+.warehouse-page__table-header {
+  padding: 16px 24px;
+  font-weight: 600;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.warehouse-page__table-wrapper {
+  max-height: 56vh;
+  overflow: auto;
+}
+
+.warehouse-page__table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  font-size: 0.875rem;
+}
+
+.warehouse-page__table thead tr {
+  position: sticky;
+  top: 0;
+  background-color: #ffffff;
+  box-shadow: inset 0 -1px 0 #e2e8f0;
+  z-index: 1;
+}
+
+.warehouse-page__cell {
+  padding: 12px 16px;
+  text-align: left;
+  color: #374151;
+  border-bottom: 1px solid #f1f5f9;
+  vertical-align: middle;
+}
+
+.warehouse-page__cell--checkbox {
+  width: 48px;
+}
+
+.warehouse-page__cell--numeric {
+  text-align: right;
+}
+
+.warehouse-page__cell--center {
+  text-align: center;
+}
+
+.warehouse-page__cell--icon {
+  width: 44px;
+  text-align: center;
+  color: #94a3b8;
+}
+
+.warehouse-page__cell--mono {
+  font-family: 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  font-size: 0.75rem;
+}
+
+.warehouse-page__cell--link button {
+  color: #2563eb;
+  font-weight: 600;
+  cursor: pointer;
+  background: none;
+  border: none;
+  padding: 0;
+}
+
+.warehouse-page__cell--link button:hover {
+  text-decoration: underline;
+}
+
+.warehouse-page__table tbody tr:hover {
+  background-color: #f8fafc;
+}
+
+.warehouse-page__table-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 24px;
+  border-top: 1px solid #e2e8f0;
+  font-size: 0.875rem;
+  color: #6b7280;
+}
+
+.warehouse-page__pagination {
+  display: flex;
+  gap: 8px;
+}
+
+.warehouse-page__empty {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 48px 0;
+}
+
+.warehouse-page__drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: min(420px, 100%);
+  background-color: #ffffff;
+  border-left: 1px solid #e2e8f0;
+  box-shadow: -12px 0 24px rgba(15, 23, 42, 0.1);
+  padding: 32px;
+  overflow-y: auto;
+  z-index: 40;
+}
+
+.warehouse-page__drawer-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  justify-content: space-between;
+  margin-bottom: 24px;
+}
+
+.warehouse-page__drawer-sku {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #94a3b8;
+  margin-bottom: 4px;
+}
+
+.warehouse-page__drawer-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.warehouse-page__drawer-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.warehouse-page__drawer-actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.warehouse-page__dialog-backdrop {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(15, 23, 42, 0.45);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 24px;
+  z-index: 50;
+}
+
+.warehouse-page__dialog {
+  width: min(720px, 100%);
+  background-color: #ffffff;
+  border-radius: 16px;
+  border: 1px solid #e2e8f0;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.25);
+}
+
+.warehouse-page__dialog-header {
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.warehouse-page__dialog-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 16px;
+}
+
+.warehouse-page__dialog-field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.warehouse-page__dialog-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #94a3b8;
+}
+
+.warehouse-page__dialog-table {
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.warehouse-page__dialog-table > header {
+  padding: 16px 20px;
+  font-weight: 600;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.warehouse-page__dialog-body {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 20px;
+  color: #6b7280;
+}
+
+.warehouse-page__dialog-input-row {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.warehouse-page__dialog-input-row .input {
+  flex: 1;
+}
+
+.warehouse-page__dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+@media (max-width: 1280px) {
+  .warehouse-page {
+    grid-template-columns: 220px 1fr;
+  }
+
+  .warehouse-page__filters-actions {
+    width: 100%;
+    justify-content: flex-end;
+    margin-left: 0;
+  }
+
+  .warehouse-page__bulk {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}
+
+@media (max-width: 1024px) {
+  .warehouse-page {
+    grid-template-columns: 1fr;
+  }
+
+  .warehouse-page__sidebar {
+    position: fixed;
+    inset: 0 0 auto 0;
+    height: 220px;
+    flex-direction: row;
+    flex-wrap: wrap;
+    overflow-y: hidden;
+    border-right: none;
+    border-bottom: 1px solid #e2e8f0;
+  }
+
+  .warehouse-page__content {
+    margin-top: 220px;
+    height: calc(100vh - 220px);
+  }
+}

--- a/feedme.client/src/app/warehouse/warehouse-page.component.html
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.html
@@ -1,0 +1,252 @@
+<div class="warehouse-page">
+  <aside class="warehouse-page__sidebar">
+    <div class="warehouse-page__brand">Rest.Name</div>
+
+    <nav class="warehouse-page__primary-nav">
+      <span class="warehouse-page__primary-link warehouse-page__primary-link--active">Склад</span>
+      <a class="warehouse-page__primary-link" href="javascript:void(0)">Заказы</a>
+      <a class="warehouse-page__primary-link" href="javascript:void(0)">Касса</a>
+      <a class="warehouse-page__primary-link" href="javascript:void(0)">Аналитика</a>
+      <a class="warehouse-page__primary-link" href="javascript:void(0)">Настройки</a>
+    </nav>
+
+    <div class="warehouse-page__divider" aria-hidden="true"></div>
+
+    <section class="warehouse-page__locations">
+      <h2 class="warehouse-page__locations-title">Склады</h2>
+      <span class="warehouse-page__location warehouse-page__location--active">Главный склад</span>
+      <a class="warehouse-page__location" href="javascript:void(0)">Кухня</a>
+      <a class="warehouse-page__location" href="javascript:void(0)">Бар</a>
+      <a class="warehouse-page__location" href="javascript:void(0)">Холодильник</a>
+    </section>
+  </aside>
+
+  <main class="warehouse-page__content">
+    <header class="warehouse-page__top-bar">
+      <div class="warehouse-page__breadcrumbs">
+        Главный склад / <span class="warehouse-page__breadcrumb-current">Поставки</span>
+      </div>
+      <div class="warehouse-page__actions">
+        <button type="button" class="btn btn-outline" (click)="openDialog()">+ Новая поставка</button>
+        <button type="button" class="btn btn-ghost">Ещё</button>
+      </div>
+    </header>
+
+    <section class="warehouse-page__body">
+      <div class="warehouse-page__metrics">
+        <app-metric title="Позиций на складе" value="1 248" hint="активные SKU"></app-metric>
+        <app-metric title="Просрочено" value="2" hint="требует списания" variant="danger"></app-metric>
+        <app-metric title="Скоро срок" value="7" hint="≤ 14 дней" variant="warn"></app-metric>
+        <app-metric title="Ниже минимума" value="5" hint="> авто-заказ" variant="warn"></app-metric>
+      </div>
+
+      <nav class="warehouse-page__tabs" role="tablist">
+        <button
+          type="button"
+          *ngFor="let entry of tabKeys"
+          class="warehouse-page__tab"
+          [class.warehouse-page__tab--active]="activeTab() === entry"
+          (click)="selectTab(entry)"
+          role="tab"
+          [attr.aria-selected]="activeTab() === entry"
+        >
+          {{ tabLabels[entry] }}
+        </button>
+      </nav>
+
+      <section *ngIf="activeTab() === 'supplies'" class="warehouse-page__tab-panel">
+        <form class="warehouse-page__filters" (submit)="$event.preventDefault()">
+          <label class="warehouse-page__filter">
+            <span class="warehouse-page__filter-label">Поиск</span>
+            <input
+              class="input"
+              type="search"
+              placeholder="Название или SKU (/)"
+              [value]="query()"
+              (input)="handleSearchChange($event)"
+            />
+          </label>
+          <label class="warehouse-page__filter">
+            <span class="warehouse-page__filter-label">Статус</span>
+            <select
+              class="select"
+              [value]="status()"
+              (change)="handleStatusChange($event)"
+            >
+              <option value="">Все</option>
+              <option value="ok">Ок</option>
+              <option value="warning">Скоро срок</option>
+              <option value="danger">Просрочено</option>
+            </select>
+          </label>
+          <label class="warehouse-page__filter">
+            <span class="warehouse-page__filter-label">Поставщик</span>
+            <select
+              class="select"
+              [value]="supplier()"
+              (change)="handleSupplierChange($event)"
+            >
+              <option value="">Все поставщики</option>
+              <option *ngFor="let option of suppliers()" [value]="option">{{ option }}</option>
+            </select>
+          </label>
+          <div class="warehouse-page__filters-actions">
+            <button type="button" class="btn btn-outline" (click)="clearFilters()">Сброс</button>
+            <button type="button" class="btn btn-secondary">Экспорт</button>
+          </div>
+        </form>
+
+        <section class="warehouse-page__bulk" aria-live="polite">
+          <ng-container *ngIf="hasSelection(); else selectionHint">
+            <span class="warehouse-page__bulk-count">Выбрано: {{ selectedRows().length }}</span>
+            <div class="warehouse-page__bulk-actions">
+              <button type="button" class="btn btn-outline btn-sm">Списать</button>
+              <button type="button" class="btn btn-outline btn-sm">Переместить</button>
+              <button type="button" class="btn btn-outline btn-sm">Печать</button>
+              <button type="button" class="btn btn-danger btn-sm">Удалить</button>
+            </div>
+          </ng-container>
+          <ng-template #selectionHint>
+            <span class="warehouse-page__bulk-hint">Подсказка: выделите строки для массовых действий</span>
+          </ng-template>
+        </section>
+
+        <section class="warehouse-page__table-card">
+          <header class="warehouse-page__table-header">Последние поставки</header>
+          <div class="warehouse-page__table-wrapper">
+            <table class="warehouse-page__table">
+              <thead>
+                <tr>
+                  <th class="warehouse-page__cell warehouse-page__cell--checkbox">
+                    <input
+                      type="checkbox"
+                      [checked]="allRowsChecked()"
+                      (change)="toggleAllFromEvent($event)"
+                      aria-label="Выбрать все"
+                    />
+                  </th>
+                  <th class="warehouse-page__cell">SKU</th>
+                  <th class="warehouse-page__cell">Название</th>
+                  <th class="warehouse-page__cell">Категория</th>
+                  <th class="warehouse-page__cell warehouse-page__cell--numeric">Кол-во</th>
+                  <th class="warehouse-page__cell warehouse-page__cell--numeric">Цена</th>
+                  <th class="warehouse-page__cell warehouse-page__cell--center">Срок годн.</th>
+                  <th class="warehouse-page__cell">Поставщик</th>
+                  <th class="warehouse-page__cell">Статус</th>
+                  <th class="warehouse-page__cell warehouse-page__cell--icon" aria-hidden="true"></th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr *ngFor="let row of filteredRows(); trackBy: trackByRow">
+                  <td class="warehouse-page__cell warehouse-page__cell--checkbox">
+                    <input
+                      type="checkbox"
+                      [checked]="selectedRows().includes(row.id)"
+                      (change)="handleRowSelection(row.id, $event)"
+                      [attr.aria-label]="'Строка ' + row.sku"
+                    />
+                  </td>
+                  <td class="warehouse-page__cell warehouse-page__cell--mono">{{ row.sku }}</td>
+                  <td class="warehouse-page__cell warehouse-page__cell--link">
+                    <button type="button" (click)="openDrawer(row)">{{ row.name }}</button>
+                  </td>
+                  <td class="warehouse-page__cell">{{ row.category }}</td>
+                  <td class="warehouse-page__cell warehouse-page__cell--numeric">{{ row.qty }} {{ row.unit }}</td>
+                  <td class="warehouse-page__cell warehouse-page__cell--numeric">{{ row.price | number:'1.0-0' }} ₽</td>
+                  <td class="warehouse-page__cell warehouse-page__cell--center">{{ row.expiry }}</td>
+                  <td class="warehouse-page__cell">{{ row.supplier }}</td>
+                  <td class="warehouse-page__cell">
+                    <span *ngIf="row.status === 'ok'" class="badge">Ок</span>
+                    <span *ngIf="row.status === 'warning'" class="badge badge-soft">Скоро срок</span>
+                    <span *ngIf="row.status === 'danger'" class="badge badge-danger">Просрочено</span>
+                  </td>
+                  <td class="warehouse-page__cell warehouse-page__cell--icon">⋯</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <footer class="warehouse-page__table-footer">
+            <span>Показано {{ filteredRows().length }} из {{ rows().length }}</span>
+            <div class="warehouse-page__pagination">
+              <button type="button" class="btn btn-outline btn-sm">Назад</button>
+              <button type="button" class="btn btn-outline btn-sm">Далее</button>
+            </div>
+          </footer>
+        </section>
+      </section>
+
+      <section *ngIf="activeTab() === 'stock'" class="warehouse-page__empty">
+        <app-empty title="Остатки" subtitle="Выберите склад и примените фильтры"></app-empty>
+      </section>
+      <section *ngIf="activeTab() === 'catalog'" class="warehouse-page__empty">
+        <app-empty title="Каталог" subtitle="Импортируйте CSV или создайте первую позицию"></app-empty>
+      </section>
+      <section *ngIf="activeTab() === 'inventory'" class="warehouse-page__empty">
+        <app-empty title="Инвентаризация" subtitle="Создайте обход или запустите экспресс-пересчёт"></app-empty>
+      </section>
+    </section>
+  </main>
+
+  <aside class="warehouse-page__drawer" *ngIf="drawerOpen()">
+    <section class="warehouse-page__drawer-content" *ngIf="selectedRow() as row">
+      <header class="warehouse-page__drawer-header">
+        <div>
+          <div class="warehouse-page__drawer-sku">SKU {{ row.sku }}</div>
+          <div class="warehouse-page__drawer-title">{{ row.name }}</div>
+        </div>
+        <span *ngIf="row.status === 'warning'" class="badge badge-soft">Скоро срок</span>
+        <span *ngIf="row.status === 'danger'" class="badge badge-danger">Просрочено</span>
+      </header>
+      <div class="warehouse-page__drawer-grid">
+        <app-field label="Категория" [value]="row.category"></app-field>
+        <app-field label="Поставщик" [value]="row.supplier"></app-field>
+        <app-field label="Количество" [value]="row.qty + ' ' + row.unit"></app-field>
+        <app-field label="Цена закупки" [value]="row.price + ' ₽'"></app-field>
+        <app-field label="Срок годности" [value]="row.expiry"></app-field>
+      </div>
+      <footer class="warehouse-page__drawer-actions">
+        <button type="button" class="btn btn-outline btn-sm">Списать</button>
+        <button type="button" class="btn btn-outline btn-sm">Переместить</button>
+        <button type="button" class="btn btn-sm">Печать ярлыков</button>
+        <button type="button" class="btn btn-ghost btn-sm" (click)="closeDrawer()">Закрыть</button>
+      </footer>
+    </section>
+  </aside>
+
+  <div class="warehouse-page__dialog-backdrop" *ngIf="dialogOpen()">
+    <section class="warehouse-page__dialog" role="dialog" aria-modal="true" aria-labelledby="new-supply-title">
+      <header class="warehouse-page__dialog-header" id="new-supply-title">Новая поставка</header>
+      <div class="warehouse-page__dialog-grid">
+        <label class="warehouse-page__dialog-field">
+          <span class="warehouse-page__dialog-label">Поставщик</span>
+          <select class="select">
+            <option>Выберите поставщика</option>
+            <option *ngFor="let option of suppliers()">{{ option }}</option>
+          </select>
+        </label>
+        <label class="warehouse-page__dialog-field">
+          <span class="warehouse-page__dialog-label">Склад</span>
+          <select class="select">
+            <option>Главный склад</option>
+            <option>Кухня</option>
+            <option>Бар</option>
+          </select>
+        </label>
+      </div>
+      <section class="warehouse-page__dialog-table">
+        <header>Позиции</header>
+        <div class="warehouse-page__dialog-body">
+          <div class="warehouse-page__dialog-input-row">
+            <input class="input" placeholder="Сканируйте штрих-код или введите SKU" />
+            <button type="button" class="btn btn-secondary">Добавить</button>
+          </div>
+          <p class="warehouse-page__dialog-empty">Пока пусто. Добавьте первую позицию.</p>
+        </div>
+      </section>
+      <footer class="warehouse-page__dialog-actions">
+        <button type="button" class="btn btn-outline" (click)="closeDialog()">Отмена</button>
+        <button type="button" class="btn" disabled>Создать приход</button>
+      </footer>
+    </section>
+  </div>
+</div>

--- a/feedme.client/src/app/warehouse/warehouse-page.component.ts
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.ts
@@ -1,0 +1,153 @@
+import { NgFor, NgIf } from '@angular/common';
+import { ChangeDetectionStrategy, Component, computed, signal } from '@angular/core';
+
+import { SupplyRow } from './models';
+import { WarehouseService } from './warehouse.service';
+import { FieldComponent } from './ui/field.component';
+import { MetricComponent } from './ui/metric.component';
+import { EmptyStateComponent } from './ui/empty-state.component';
+
+@Component({
+  standalone: true,
+  selector: 'app-warehouse-page',
+  imports: [
+    NgFor,
+    NgIf,
+    MetricComponent,
+    FieldComponent,
+    EmptyStateComponent,
+  ],
+  templateUrl: './warehouse-page.component.html',
+  styleUrl: './warehouse-page.component.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class WarehousePageComponent {
+  readonly activeTab = signal<'supplies' | 'stock' | 'catalog' | 'inventory'>('supplies');
+  readonly query = signal('');
+  readonly status = signal<'ok' | 'warning' | 'danger' | ''>('');
+  readonly supplier = signal('');
+  readonly selectedRows = signal<number[]>([]);
+  readonly drawerOpen = signal(false);
+  readonly dialogOpen = signal(false);
+  readonly selectedRow = signal<SupplyRow | null>(null);
+
+  readonly rows = this.warehouseService.list();
+
+  readonly tabKeys = ['supplies', 'stock', 'catalog', 'inventory'] as const;
+
+  readonly suppliers = computed(() => {
+    const unique = new Set(this.rows().map((row) => row.supplier));
+    return Array.from(unique).sort((a, b) => a.localeCompare(b));
+  });
+
+  readonly filteredRows = computed(() => {
+    const search = this.query().trim().toLowerCase();
+    const statusFilter = this.status();
+    const supplierFilter = this.supplier();
+
+    return this.rows().filter((row) => {
+      const matchesSearch = search
+        ? `${row.name}${row.sku}`.toLowerCase().includes(search)
+        : true;
+      const matchesStatus = statusFilter ? row.status === statusFilter : true;
+      const matchesSupplier = supplierFilter ? row.supplier === supplierFilter : true;
+
+      return matchesSearch && matchesStatus && matchesSupplier;
+    });
+  });
+
+  readonly allRowsChecked = computed(
+    () =>
+      this.filteredRows().length > 0 &&
+      this.selectedRows().length === this.filteredRows().length,
+  );
+
+  readonly hasSelection = computed(() => this.selectedRows().length > 0);
+
+  constructor(private readonly warehouseService: WarehouseService) {}
+
+  readonly tabLabels: Record<'supplies' | 'stock' | 'catalog' | 'inventory', string> = {
+    supplies: 'Поставки',
+    stock: 'Остатки',
+    catalog: 'Каталог',
+    inventory: 'Инвентаризация',
+  };
+
+  trackByRow = (_: number, row: SupplyRow) => row.id;
+
+  toggleRowSelection(id: number, checked: boolean): void {
+    const selection = new Set(this.selectedRows());
+    if (checked) {
+      selection.add(id);
+    } else {
+      selection.delete(id);
+    }
+    this.selectedRows.set(Array.from(selection).sort((a, b) => a - b));
+  }
+
+  toggleAll(checked: boolean): void {
+    if (checked) {
+      this.selectedRows.set(this.filteredRows().map((row) => row.id));
+      return;
+    }
+    this.selectedRows.set([]);
+  }
+
+  toggleAllFromEvent(event: Event): void {
+    const checkbox = event.target as HTMLInputElement | null;
+    this.toggleAll(checkbox?.checked ?? false);
+  }
+
+  openDrawer(row: SupplyRow): void {
+    this.selectedRow.set(row);
+    this.drawerOpen.set(true);
+  }
+
+  closeDrawer(): void {
+    this.drawerOpen.set(false);
+    this.selectedRow.set(null);
+  }
+
+  openDialog(): void {
+    this.dialogOpen.set(true);
+  }
+
+  closeDialog(): void {
+    this.dialogOpen.set(false);
+  }
+
+  clearFilters(): void {
+    this.query.set('');
+    this.status.set('');
+    this.supplier.set('');
+  }
+
+  selectTab(tab: 'supplies' | 'stock' | 'catalog' | 'inventory'): void {
+    this.activeTab.set(tab);
+  }
+
+  handleSearchChange(event: Event): void {
+    const input = event.target as HTMLInputElement | null;
+    this.query.set(input?.value ?? '');
+  }
+
+  handleStatusChange(event: Event): void {
+    const select = event.target as HTMLSelectElement | null;
+    const value = select?.value ?? '';
+    if (value === 'ok' || value === 'warning' || value === 'danger') {
+      this.status.set(value);
+      return;
+    }
+    this.status.set('');
+  }
+
+  handleSupplierChange(event: Event): void {
+    const select = event.target as HTMLSelectElement | null;
+    this.supplier.set(select?.value ?? '');
+  }
+
+  handleRowSelection(id: number, event: Event): void {
+    const checkbox = event.target as HTMLInputElement | null;
+    this.toggleRowSelection(id, checkbox?.checked ?? false);
+  }
+}

--- a/feedme.client/src/app/warehouse/warehouse.service.ts
+++ b/feedme.client/src/app/warehouse/warehouse.service.ts
@@ -1,0 +1,59 @@
+import { Injectable, signal } from '@angular/core';
+
+import { SupplyRow } from './models';
+
+@Injectable({ providedIn: 'root' })
+export class WarehouseService {
+  private readonly rowsSignal = signal<SupplyRow[]>([
+    {
+      id: 1,
+      sku: 'MEAT-001',
+      name: 'Курица охлажд.',
+      category: 'Мясные заготовки',
+      qty: 120,
+      unit: 'кг',
+      price: 220,
+      expiry: '2025-10-03',
+      supplier: 'ООО Куры Дуры',
+      status: 'ok',
+    },
+    {
+      id: 2,
+      sku: 'MEAT-002',
+      name: 'Говядина',
+      category: 'Мясные заготовки',
+      qty: 11,
+      unit: 'кг',
+      price: 450,
+      expiry: '2025-09-28',
+      supplier: 'Ферма №5',
+      status: 'warning',
+    },
+    {
+      id: 3,
+      sku: 'VEG-011',
+      name: 'Лук репчатый',
+      category: 'Овощи',
+      qty: 35,
+      unit: 'кг',
+      price: 28,
+      expiry: '2025-10-15',
+      supplier: 'ОвощБаза',
+      status: 'ok',
+    },
+    {
+      id: 4,
+      sku: 'DAIRY-004',
+      name: 'Сливки 33%',
+      category: 'Молочные',
+      qty: 12,
+      unit: 'л',
+      price: 155,
+      expiry: '2025-10-01',
+      supplier: 'МолКомбинат',
+      status: 'danger',
+    },
+  ]);
+
+  readonly list = () => this.rowsSignal.asReadonly();
+}

--- a/feedme.client/src/styles.css
+++ b/feedme.client/src/styles.css
@@ -12,6 +12,12 @@ html, body {
   height: 100%;
   font-family: Arial, sans-serif;
 }
+
+button,
+input,
+select {
+  font-family: inherit;
+}
 /* form layout */
 .form-grid {
   display: flex;
@@ -76,6 +82,135 @@ html, body {
   color: #fff;
 }
 
-  .save-btn:hover {
-    background-color: var(--accent-hover-color);
-  }
+.save-btn:hover {
+  background-color: var(--accent-hover-color);
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border-radius: 10px;
+  border: none;
+  padding: 10px 18px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  color: #ffffff;
+  box-shadow: 0 8px 16px rgba(37, 99, 235, 0.25);
+}
+
+.btn:hover:not(:disabled) {
+  background: linear-gradient(135deg, #1d4ed8, #1e3a8a);
+}
+
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.btn-sm {
+  padding: 6px 12px;
+  font-size: 0.8125rem;
+  border-radius: 8px;
+  box-shadow: none;
+}
+
+.btn-outline {
+  background: #ffffff;
+  color: #1d4ed8;
+  border: 1px solid rgba(29, 78, 216, 0.4);
+  box-shadow: none;
+}
+
+.btn-outline:hover:not(:disabled) {
+  background: rgba(29, 78, 216, 0.08);
+}
+
+.btn-secondary {
+  background: linear-gradient(135deg, #10b981, #059669);
+  color: #ffffff;
+  box-shadow: 0 8px 16px rgba(16, 185, 129, 0.25);
+}
+
+.btn-secondary:hover:not(:disabled) {
+  background: linear-gradient(135deg, #059669, #047857);
+}
+
+.btn-danger {
+  background: linear-gradient(135deg, #ef4444, #dc2626);
+  color: #ffffff;
+  box-shadow: 0 8px 16px rgba(239, 68, 68, 0.25);
+}
+
+.btn-danger:hover:not(:disabled) {
+  background: linear-gradient(135deg, #dc2626, #b91c1c);
+}
+
+.btn-ghost {
+  background: transparent;
+  color: #1f2937;
+  box-shadow: none;
+}
+
+.btn-ghost:hover:not(:disabled) {
+  background: rgba(15, 23, 42, 0.06);
+}
+
+.input,
+.select {
+  width: 100%;
+  border-radius: 10px;
+  border: 1px solid #d1d5db;
+  background-color: #ffffff;
+  padding: 10px 14px;
+  font-size: 0.95rem;
+  color: #111827;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  box-sizing: border-box;
+}
+
+.input:focus,
+.select:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.25);
+}
+
+.select {
+  appearance: none;
+  background-image: linear-gradient(45deg, transparent 50%, #1f2937 50%),
+    linear-gradient(135deg, #1f2937 50%, transparent 50%);
+  background-position: calc(100% - 18px) calc(1rem + 2px), calc(100% - 13px) calc(1rem + 2px);
+  background-size: 5px 5px, 5px 5px;
+  background-repeat: no-repeat;
+  padding-right: 36px;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background-color: rgba(16, 185, 129, 0.18);
+  color: #047857;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.badge-soft {
+  background-color: rgba(234, 179, 8, 0.18);
+  color: #b45309;
+}
+
+.badge-danger {
+  background-color: rgba(239, 68, 68, 0.18);
+  color: #b91c1c;
+}


### PR DESCRIPTION
## Summary
- add a standalone warehouse page route with sidebar navigation and metrics cards
- implement supplies filtering, table interactions, and product drawer using new UI components
- scaffold the new supply dialog experience and shared button/input/badge utilities

## Testing
- npm run test *(fails: ChromeHeadless missing libatk-1.0.so.0 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d877f9b9888323901d023e98c9622b