### PR TITLE
feat: redesign supplies tab UX

### DIFF
--- a/feedme.client/src/app/warehouse/models.ts
+++ b/feedme.client/src/app/warehouse/models.ts
@@ -1,7 +1,11 @@
-export type StockStatus = 'ok' | 'warning' | 'danger';
+export type SupplyStatus = 'ok' | 'warning' | 'danger';
 
 export interface SupplyRow {
   readonly id: number;
+  readonly docNo: string;
+  readonly arrivalDate: string;
+  readonly warehouse: string;
+  readonly responsible: string;
   readonly sku: string;
   readonly name: string;
   readonly category: string;
@@ -10,5 +14,5 @@ export interface SupplyRow {
   readonly price: number;
   readonly expiry: string;
   readonly supplier: string;
-  readonly status: StockStatus;
+  readonly status: SupplyStatus;
 }

--- a/feedme.client/src/app/warehouse/warehouse-page.component.css
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.css
@@ -171,6 +171,10 @@
   min-width: 200px;
 }
 
+.warehouse-page__filter--date {
+  min-width: 180px;
+}
+
 .warehouse-page__filter-label {
   font-size: 0.75rem;
   text-transform: uppercase;
@@ -200,6 +204,11 @@
 .warehouse-page__bulk-count {
   color: #111827;
   font-weight: 500;
+}
+
+.warehouse-page__bulk-hint {
+  font-size: 0.875rem;
+  color: #94a3b8;
 }
 
 .warehouse-page__table-card {
@@ -262,6 +271,16 @@
   color: #94a3b8;
 }
 
+.warehouse-page__cell--status {
+  white-space: nowrap;
+}
+
+.warehouse-page__empty-row {
+  text-align: center;
+  padding: 32px 16px;
+  color: #94a3b8;
+}
+
 .warehouse-page__cell--mono {
   font-family: 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
   font-size: 0.75rem;
@@ -282,6 +301,62 @@
 
 .warehouse-page__table tbody tr:hover {
   background-color: #f8fafc;
+}
+
+.warehouse-page__row-menu {
+  position: relative;
+  display: inline-block;
+}
+
+.warehouse-page__row-menu-trigger {
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: 8px;
+  background-color: transparent;
+  color: #94a3b8;
+  cursor: pointer;
+  font-size: 1.5rem;
+  line-height: 1;
+}
+
+.warehouse-page__row-menu-trigger:hover,
+.warehouse-page__row-menu-trigger:focus-visible {
+  background-color: #f1f5f9;
+  color: #1f2937;
+  outline: none;
+}
+
+.warehouse-page__row-menu-panel {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 4px);
+  display: flex;
+  flex-direction: column;
+  background-color: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.12);
+  padding: 4px;
+  min-width: 160px;
+  z-index: 5;
+}
+
+.warehouse-page__row-menu-panel button {
+  border: none;
+  background: none;
+  padding: 8px 12px;
+  text-align: left;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  color: #1f2937;
+  cursor: pointer;
+}
+
+.warehouse-page__row-menu-panel button:hover,
+.warehouse-page__row-menu-panel button:focus-visible {
+  background-color: #f1f5f9;
+  outline: none;
 }
 
 .warehouse-page__table-footer {
@@ -341,6 +416,12 @@
   font-weight: 600;
 }
 
+.warehouse-page__drawer-meta {
+  font-size: 0.875rem;
+  color: #64748b;
+  margin-top: 4px;
+}
+
 .warehouse-page__drawer-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
@@ -378,6 +459,16 @@
   box-shadow: 0 24px 48px rgba(15, 23, 42, 0.25);
 }
 
+.warehouse-page__dialog--confirm {
+  width: min(420px, 100%);
+}
+
+.warehouse-page__dialog-form {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
 .warehouse-page__dialog-header {
   font-size: 1.25rem;
   font-weight: 600;
@@ -393,6 +484,11 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
+}
+
+.warehouse-page__field-error {
+  font-size: 0.75rem;
+  color: #dc2626;
 }
 
 .warehouse-page__dialog-label {
@@ -435,6 +531,14 @@
 .warehouse-page__dialog-actions {
   display: flex;
   justify-content: flex-end;
+  gap: 12px;
+}
+
+.warehouse-page__dialog-content {
+  font-size: 0.95rem;
+  color: #374151;
+  display: flex;
+  flex-direction: column;
   gap: 12px;
 }
 

--- a/feedme.client/src/app/warehouse/warehouse-page.component.html
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.html
@@ -27,7 +27,7 @@
         Главный склад / <span class="warehouse-page__breadcrumb-current">Поставки</span>
       </div>
       <div class="warehouse-page__actions">
-        <button type="button" class="btn btn-outline" (click)="openDialog()">+ Новая поставка</button>
+        <button type="button" class="btn btn-outline" (click)="openCreateDialog()">+ Новая поставка</button>
         <button type="button" class="btn btn-ghost">Ещё</button>
       </div>
     </header>
@@ -59,11 +59,12 @@
           <label class="warehouse-page__filter">
             <span class="warehouse-page__filter-label">Поиск</span>
             <input
+              #searchInput
               class="input"
               type="search"
-              placeholder="Название или SKU (/)"
+              placeholder="№ документа, название или SKU (/)"
               [value]="query()"
-              (input)="handleSearchChange($event)"
+              (input)="updateQuery(($event.target as HTMLInputElement).value)"
             />
           </label>
           <label class="warehouse-page__filter">
@@ -71,7 +72,7 @@
             <select
               class="select"
               [value]="status()"
-              (change)="handleStatusChange($event)"
+              (change)="updateStatus(($event.target as HTMLSelectElement).value)"
             >
               <option value="">Все</option>
               <option value="ok">Ок</option>
@@ -84,11 +85,40 @@
             <select
               class="select"
               [value]="supplier()"
-              (change)="handleSupplierChange($event)"
+              (change)="updateSupplier(($event.target as HTMLSelectElement).value)"
             >
               <option value="">Все поставщики</option>
               <option *ngFor="let option of suppliers()" [value]="option">{{ option }}</option>
             </select>
+          </label>
+          <label class="warehouse-page__filter">
+            <span class="warehouse-page__filter-label">Склад</span>
+            <select
+              class="select"
+              [value]="warehouseFilter()"
+              (change)="updateWarehouse(($event.target as HTMLSelectElement).value)"
+            >
+              <option value="">Все склады</option>
+              <option *ngFor="let option of warehouses()" [value]="option">{{ option }}</option>
+            </select>
+          </label>
+          <label class="warehouse-page__filter warehouse-page__filter--date">
+            <span class="warehouse-page__filter-label">Дата прихода от</span>
+            <input
+              class="input"
+              type="date"
+              [value]="dateFrom()"
+              (change)="updateDateFrom(($event.target as HTMLInputElement).value)"
+            />
+          </label>
+          <label class="warehouse-page__filter warehouse-page__filter--date">
+            <span class="warehouse-page__filter-label">Дата прихода до</span>
+            <input
+              class="input"
+              type="date"
+              [value]="dateTo()"
+              (change)="updateDateTo(($event.target as HTMLInputElement).value)"
+            />
           </label>
           <div class="warehouse-page__filters-actions">
             <button type="button" class="btn btn-outline" (click)="clearFilters()">Сброс</button>
@@ -96,20 +126,18 @@
           </div>
         </form>
 
-        <section class="warehouse-page__bulk" aria-live="polite">
-          <ng-container *ngIf="hasSelection(); else selectionHint">
-            <span class="warehouse-page__bulk-count">Выбрано: {{ selectedRows().length }}</span>
-            <div class="warehouse-page__bulk-actions">
-              <button type="button" class="btn btn-outline btn-sm">Списать</button>
-              <button type="button" class="btn btn-outline btn-sm">Переместить</button>
-              <button type="button" class="btn btn-outline btn-sm">Печать</button>
-              <button type="button" class="btn btn-danger btn-sm">Удалить</button>
-            </div>
-          </ng-container>
-          <ng-template #selectionHint>
-            <span class="warehouse-page__bulk-hint">Подсказка: выделите строки для массовых действий</span>
-          </ng-template>
+        <section class="warehouse-page__bulk" *ngIf="hasSelection(); else bulkHint" aria-live="polite">
+          <span class="warehouse-page__bulk-count">Выбрано: {{ checkedIds().length }}</span>
+          <div class="warehouse-page__bulk-actions">
+            <button type="button" class="btn btn-outline btn-sm">Списать</button>
+            <button type="button" class="btn btn-outline btn-sm">Переместить</button>
+            <button type="button" class="btn btn-outline btn-sm">Печать</button>
+            <button type="button" class="btn btn-danger btn-sm" (click)="openDeleteDialogForSelection()">Удалить</button>
+          </div>
         </section>
+        <ng-template #bulkHint>
+          <p class="warehouse-page__bulk-hint">Выберите строки для массовых действий</p>
+        </ng-template>
 
         <section class="warehouse-page__table-card">
           <header class="warehouse-page__table-header">Последние поставки</header>
@@ -120,53 +148,105 @@
                   <th class="warehouse-page__cell warehouse-page__cell--checkbox">
                     <input
                       type="checkbox"
-                      [checked]="allRowsChecked()"
+                      [checked]="allFilteredChecked()"
                       (change)="toggleAllFromEvent($event)"
                       aria-label="Выбрать все"
                     />
                   </th>
+                  <th class="warehouse-page__cell">№ док.</th>
+                  <th class="warehouse-page__cell warehouse-page__cell--center">Дата прихода</th>
+                  <th class="warehouse-page__cell">Склад</th>
+                  <th class="warehouse-page__cell">Ответственный</th>
                   <th class="warehouse-page__cell">SKU</th>
                   <th class="warehouse-page__cell">Название</th>
                   <th class="warehouse-page__cell">Категория</th>
                   <th class="warehouse-page__cell warehouse-page__cell--numeric">Кол-во</th>
                   <th class="warehouse-page__cell warehouse-page__cell--numeric">Цена</th>
-                  <th class="warehouse-page__cell warehouse-page__cell--center">Срок годн.</th>
+                  <th class="warehouse-page__cell warehouse-page__cell--numeric">Сумма</th>
+                  <th class="warehouse-page__cell warehouse-page__cell--center">Срок годности</th>
                   <th class="warehouse-page__cell">Поставщик</th>
-                  <th class="warehouse-page__cell">Статус</th>
+                  <th class="warehouse-page__cell warehouse-page__cell--status">Статус</th>
                   <th class="warehouse-page__cell warehouse-page__cell--icon" aria-hidden="true"></th>
                 </tr>
               </thead>
               <tbody>
-                <tr *ngFor="let row of filteredRows(); trackBy: trackByRow">
+                <tr *ngFor="let row of filteredRows(); trackBy: trackByRow" (dblclick)="openDrawer(row)">
                   <td class="warehouse-page__cell warehouse-page__cell--checkbox">
                     <input
                       type="checkbox"
-                      [checked]="selectedRows().includes(row.id)"
-                      (change)="handleRowSelection(row.id, $event)"
-                      [attr.aria-label]="'Строка ' + row.sku"
+                      [checked]="checkedIds().includes(row.id)"
+                      (change)="handleRowCheckbox(row.id, $event)"
+                      [attr.aria-label]="'Строка ' + row.docNo"
                     />
                   </td>
+                  <td class="warehouse-page__cell warehouse-page__cell--mono">{{ row.docNo }}</td>
+                  <td class="warehouse-page__cell warehouse-page__cell--center">{{ row.arrivalDate | date: 'dd.MM.yyyy' }}</td>
+                  <td class="warehouse-page__cell">{{ row.warehouse }}</td>
+                  <td class="warehouse-page__cell">{{ row.responsible }}</td>
                   <td class="warehouse-page__cell warehouse-page__cell--mono">{{ row.sku }}</td>
                   <td class="warehouse-page__cell warehouse-page__cell--link">
                     <button type="button" (click)="openDrawer(row)">{{ row.name }}</button>
                   </td>
                   <td class="warehouse-page__cell">{{ row.category }}</td>
-                  <td class="warehouse-page__cell warehouse-page__cell--numeric">{{ row.qty }} {{ row.unit }}</td>
-                  <td class="warehouse-page__cell warehouse-page__cell--numeric">{{ row.price | number:'1.0-0' }} ₽</td>
-                  <td class="warehouse-page__cell warehouse-page__cell--center">{{ row.expiry }}</td>
-                  <td class="warehouse-page__cell">{{ row.supplier }}</td>
-                  <td class="warehouse-page__cell">
-                    <span *ngIf="row.status === 'ok'" class="badge">Ок</span>
-                    <span *ngIf="row.status === 'warning'" class="badge badge-soft">Скоро срок</span>
-                    <span *ngIf="row.status === 'danger'" class="badge badge-danger">Просрочено</span>
+                  <td class="warehouse-page__cell warehouse-page__cell--numeric">
+                    {{ row.qty | number: '1.0-3' }} {{ row.unit }}
                   </td>
-                  <td class="warehouse-page__cell warehouse-page__cell--icon">⋯</td>
+                  <td class="warehouse-page__cell warehouse-page__cell--numeric">
+                    {{ formatCurrency(row.price) }}
+                  </td>
+                  <td class="warehouse-page__cell warehouse-page__cell--numeric">
+                    {{ formatCurrency(rowTotal(row)) }}
+                  </td>
+                  <td class="warehouse-page__cell warehouse-page__cell--center">{{ row.expiry | date: 'dd.MM.yyyy' }}</td>
+                  <td class="warehouse-page__cell">{{ row.supplier }}</td>
+                  <td class="warehouse-page__cell warehouse-page__cell--status">
+                    <span
+                      class="badge"
+                      [ngClass]="{
+                        'badge-soft': row.status === 'warning',
+                        'badge-danger': row.status === 'danger'
+                      }"
+                    >
+                      {{ row.status === 'ok' ? 'Ок' : row.status === 'warning' ? 'Скоро срок' : 'Просрочено' }}
+                    </span>
+                  </td>
+                  <td class="warehouse-page__cell warehouse-page__cell--icon">
+                    <div class="warehouse-page__row-menu">
+                      <button
+                        type="button"
+                        class="warehouse-page__row-menu-trigger"
+                        (click)="toggleRowMenu(row.id, $event)"
+                        aria-haspopup="menu"
+                        aria-label="Действия строки"
+                      >
+                        ⋯
+                      </button>
+                      <div
+                        class="warehouse-page__row-menu-panel"
+                        *ngIf="menuRowId() === row.id"
+                        role="menu"
+                        (click)="$event.stopPropagation()"
+                      >
+                        <button type="button" role="menuitem" (click)="openDrawer(row)">Открыть</button>
+                        <button type="button" role="menuitem" (click)="startEdit(row)">Редактировать</button>
+                        <button type="button" role="menuitem" (click)="openDeleteDialogForRow(row)">Удалить</button>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+                <tr *ngIf="filteredRows().length === 0">
+                  <td class="warehouse-page__cell warehouse-page__empty-row" colspan="15">
+                    Нет поставок по текущим фильтрам
+                  </td>
                 </tr>
               </tbody>
             </table>
           </div>
           <footer class="warehouse-page__table-footer">
-            <span>Показано {{ filteredRows().length }} из {{ rows().length }}</span>
+            <span>
+              Показано {{ filteredRows().length }} из {{ rows().length }}.
+              Итог по сумме: {{ formatCurrency(totalSum()) }}
+            </span>
             <div class="warehouse-page__pagination">
               <button type="button" class="btn btn-outline btn-sm">Назад</button>
               <button type="button" class="btn btn-outline btn-sm">Далее</button>
@@ -187,65 +267,139 @@
     </section>
   </main>
 
-  <aside class="warehouse-page__drawer" *ngIf="drawerOpen()">
-    <section class="warehouse-page__drawer-content" *ngIf="selectedRow() as row">
+  <aside class="warehouse-page__drawer" *ngIf="drawerOpen() && selectedRow() as row">
+    <section class="warehouse-page__drawer-content">
       <header class="warehouse-page__drawer-header">
         <div>
-          <div class="warehouse-page__drawer-sku">SKU {{ row.sku }}</div>
+          <div class="warehouse-page__drawer-sku">Документ {{ row.docNo }}</div>
           <div class="warehouse-page__drawer-title">{{ row.name }}</div>
+          <div class="warehouse-page__drawer-meta">SKU {{ row.sku }}</div>
         </div>
-        <span *ngIf="row.status === 'warning'" class="badge badge-soft">Скоро срок</span>
-        <span *ngIf="row.status === 'danger'" class="badge badge-danger">Просрочено</span>
+        <span
+          class="badge"
+          [ngClass]="{
+            'badge-soft': row.status === 'warning',
+            'badge-danger': row.status === 'danger'
+          }"
+        >
+          {{ row.status === 'ok' ? 'Ок' : row.status === 'warning' ? 'Скоро срок' : 'Просрочено' }}
+        </span>
       </header>
       <div class="warehouse-page__drawer-grid">
-        <app-field label="Категория" [value]="row.category"></app-field>
+        <app-field label="Склад" [value]="row.warehouse"></app-field>
+        <app-field label="Ответственный" [value]="row.responsible"></app-field>
         <app-field label="Поставщик" [value]="row.supplier"></app-field>
-        <app-field label="Количество" [value]="row.qty + ' ' + row.unit"></app-field>
-        <app-field label="Цена закупки" [value]="row.price + ' ₽'"></app-field>
-        <app-field label="Срок годности" [value]="row.expiry"></app-field>
+        <app-field label="Категория" [value]="row.category"></app-field>
+        <app-field label="Кол-во" [value]="row.qty + ' ' + row.unit"></app-field>
+        <app-field label="Цена" [value]="formatCurrency(row.price)"></app-field>
+        <app-field label="Сумма" [value]="formatCurrency(rowTotal(row))"></app-field>
+        <app-field label="Дата прихода" [value]="(row.arrivalDate | date: 'dd.MM.yyyy') ?? row.arrivalDate"></app-field>
+        <app-field label="Срок годности" [value]="(row.expiry | date: 'dd.MM.yyyy') ?? row.expiry"></app-field>
       </div>
       <footer class="warehouse-page__drawer-actions">
         <button type="button" class="btn btn-outline btn-sm">Списать</button>
         <button type="button" class="btn btn-outline btn-sm">Переместить</button>
         <button type="button" class="btn btn-sm">Печать ярлыков</button>
+        <button type="button" class="btn btn-outline btn-sm" (click)="startEdit(row)">Редактировать</button>
+        <button type="button" class="btn btn-danger btn-sm" (click)="openDeleteDialogForRow(row)">Удалить</button>
         <button type="button" class="btn btn-ghost btn-sm" (click)="closeDrawer()">Закрыть</button>
       </footer>
     </section>
   </aside>
 
-  <div class="warehouse-page__dialog-backdrop" *ngIf="dialogOpen()">
-    <section class="warehouse-page__dialog" role="dialog" aria-modal="true" aria-labelledby="new-supply-title">
-      <header class="warehouse-page__dialog-header" id="new-supply-title">Новая поставка</header>
-      <div class="warehouse-page__dialog-grid">
-        <label class="warehouse-page__dialog-field">
-          <span class="warehouse-page__dialog-label">Поставщик</span>
-          <select class="select">
-            <option>Выберите поставщика</option>
-            <option *ngFor="let option of suppliers()">{{ option }}</option>
-          </select>
-        </label>
-        <label class="warehouse-page__dialog-field">
-          <span class="warehouse-page__dialog-label">Склад</span>
-          <select class="select">
-            <option>Главный склад</option>
-            <option>Кухня</option>
-            <option>Бар</option>
-          </select>
-        </label>
-      </div>
-      <section class="warehouse-page__dialog-table">
-        <header>Позиции</header>
-        <div class="warehouse-page__dialog-body">
-          <div class="warehouse-page__dialog-input-row">
-            <input class="input" placeholder="Сканируйте штрих-код или введите SKU" />
-            <button type="button" class="btn btn-secondary">Добавить</button>
-          </div>
-          <p class="warehouse-page__dialog-empty">Пока пусто. Добавьте первую позицию.</p>
+  <div class="warehouse-page__dialog-backdrop" *ngIf="editDialogOpen()">
+    <section class="warehouse-page__dialog" role="dialog" aria-modal="true" aria-labelledby="edit-supply-title">
+      <header class="warehouse-page__dialog-header" id="edit-supply-title">
+        {{ editingRowId() ? 'Редактирование поставки' : 'Новая поставка' }}
+      </header>
+      <form class="warehouse-page__dialog-form" [formGroup]="editForm" (ngSubmit)="submitEdit()">
+        <div class="warehouse-page__dialog-grid">
+          <label class="warehouse-page__dialog-field">
+            <span class="warehouse-page__dialog-label">№ документа</span>
+            <input class="input" formControlName="docNo" />
+          </label>
+          <label class="warehouse-page__dialog-field">
+            <span class="warehouse-page__dialog-label">Дата прихода</span>
+            <input class="input" type="date" formControlName="arrivalDate" />
+          </label>
+          <label class="warehouse-page__dialog-field">
+            <span class="warehouse-page__dialog-label">Склад</span>
+            <input class="input" formControlName="warehouse" />
+          </label>
+          <label class="warehouse-page__dialog-field">
+            <span class="warehouse-page__dialog-label">Ответственный</span>
+            <input class="input" formControlName="responsible" />
+          </label>
+          <label class="warehouse-page__dialog-field">
+            <span class="warehouse-page__dialog-label">Поставщик</span>
+            <input class="input" formControlName="supplier" />
+          </label>
+          <label class="warehouse-page__dialog-field">
+            <span class="warehouse-page__dialog-label">SKU</span>
+            <input class="input" formControlName="sku" />
+          </label>
+          <label class="warehouse-page__dialog-field">
+            <span class="warehouse-page__dialog-label">Название</span>
+            <input class="input" formControlName="name" />
+          </label>
+          <label class="warehouse-page__dialog-field">
+            <span class="warehouse-page__dialog-label">Категория</span>
+            <input class="input" formControlName="category" />
+          </label>
+          <label class="warehouse-page__dialog-field">
+            <span class="warehouse-page__dialog-label">Кол-во</span>
+            <input class="input" type="number" step="0.001" min="0" formControlName="qty" />
+          </label>
+          <label class="warehouse-page__dialog-field">
+            <span class="warehouse-page__dialog-label">Единица измерения</span>
+            <input class="input" formControlName="unit" />
+          </label>
+          <label class="warehouse-page__dialog-field">
+            <span class="warehouse-page__dialog-label">Цена</span>
+            <input class="input" type="number" step="0.01" min="0" formControlName="price" />
+          </label>
+          <label class="warehouse-page__dialog-field">
+            <span class="warehouse-page__dialog-label">Срок годности</span>
+            <input class="input" type="date" formControlName="expiry" />
+            <span class="warehouse-page__field-error" *ngIf="editForm.controls.expiry.touched && editForm.controls.expiry.hasError('dateOrder')">
+              Срок годности не может быть раньше даты прихода
+            </span>
+          </label>
+          <label class="warehouse-page__dialog-field">
+            <span class="warehouse-page__dialog-label">Статус</span>
+            <select class="select" formControlName="status">
+              <option value="ok">Ок</option>
+              <option value="warning">Скоро срок</option>
+              <option value="danger">Просрочено</option>
+            </select>
+          </label>
         </div>
-      </section>
+        <footer class="warehouse-page__dialog-actions">
+          <button type="button" class="btn btn-outline" (click)="closeEditDialog()">Отмена</button>
+          <button type="submit" class="btn" [disabled]="editForm.invalid">Сохранить</button>
+        </footer>
+      </form>
+    </section>
+  </div>
+
+  <div class="warehouse-page__dialog-backdrop" *ngIf="deleteDialogOpen()">
+    <section class="warehouse-page__dialog warehouse-page__dialog--confirm" role="dialog" aria-modal="true" aria-labelledby="delete-supply-title">
+      <header class="warehouse-page__dialog-header" id="delete-supply-title">Удалить поставку</header>
+      <div class="warehouse-page__dialog-content">
+        <ng-container *ngIf="deleteTargetIds().length === 1; else deleteMany">
+          <ng-container *ngIf="getRowById(deleteTargetIds()[0]) as deletingRow">
+            <p>
+              Удалить поставку <strong>{{ deletingRow.docNo }}</strong> — {{ deletingRow.name }} ({{ deletingRow.sku }})?
+            </p>
+          </ng-container>
+        </ng-container>
+        <ng-template #deleteMany>
+          <p>Удалить выбранные {{ deleteTargetIds().length }} поставок? Действие необратимо.</p>
+        </ng-template>
+      </div>
       <footer class="warehouse-page__dialog-actions">
-        <button type="button" class="btn btn-outline" (click)="closeDialog()">Отмена</button>
-        <button type="button" class="btn" disabled>Создать приход</button>
+        <button type="button" class="btn btn-outline" (click)="closeDeleteDialog()">Отмена</button>
+        <button type="button" class="btn btn-danger" (click)="confirmDelete()">Удалить</button>
       </footer>
     </section>
   </div>

--- a/feedme.client/src/app/warehouse/warehouse-page.component.spec.ts
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.spec.ts
@@ -1,0 +1,284 @@
+import { signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { WarehousePageComponent } from './warehouse-page.component';
+import { SupplyRow } from './models';
+import { WarehouseService } from './warehouse.service';
+
+class InMemoryWarehouseService {
+  private readonly initialRows: SupplyRow[] = [
+    {
+      id: 1,
+      docNo: 'PO-000851',
+      arrivalDate: '2025-09-25',
+      warehouse: 'Главный склад',
+      responsible: 'Иванов И.',
+      sku: 'MEAT-001',
+      name: 'Курица охлажд.',
+      category: 'Мясные заготовки',
+      qty: 120,
+      unit: 'кг',
+      price: 220,
+      expiry: '2025-10-03',
+      supplier: 'ООО Куры Дуры',
+      status: 'ok',
+    },
+    {
+      id: 2,
+      docNo: 'PO-000852',
+      arrivalDate: '2025-09-27',
+      warehouse: 'Кухня',
+      responsible: 'Петров П.',
+      sku: 'MEAT-002',
+      name: 'Говядина',
+      category: 'Мясные заготовки',
+      qty: 11,
+      unit: 'кг',
+      price: 450,
+      expiry: '2025-09-28',
+      supplier: 'Ферма №5',
+      status: 'warning',
+    },
+    {
+      id: 3,
+      docNo: 'PO-000853',
+      arrivalDate: '2025-09-26',
+      warehouse: 'Главный склад',
+      responsible: 'Иванов И.',
+      sku: 'VEG-011',
+      name: 'Лук репчатый',
+      category: 'Овощи',
+      qty: 35,
+      unit: 'кг',
+      price: 28,
+      expiry: '2025-10-15',
+      supplier: 'ОвощБаза',
+      status: 'ok',
+    },
+    {
+      id: 4,
+      docNo: 'PO-000854',
+      arrivalDate: '2025-09-20',
+      warehouse: 'Бар',
+      responsible: 'Сидоров С.',
+      sku: 'DAIRY-004',
+      name: 'Сливки 33%',
+      category: 'Молочные',
+      qty: 12,
+      unit: 'л',
+      price: 155,
+      expiry: '2025-10-01',
+      supplier: 'МолКомбинат',
+      status: 'danger',
+    },
+  ];
+
+  private readonly rowsSignal = signal<SupplyRow[]>(structuredClone(this.initialRows));
+
+  readonly list = () => this.rowsSignal.asReadonly();
+
+  addRow(row: Omit<SupplyRow, 'id'>): void {
+    this.rowsSignal.update((rows) => {
+      const nextId = rows.reduce((max, current) => Math.max(max, current.id), 0) + 1;
+      return [...rows, { id: nextId, ...row }];
+    });
+  }
+
+  updateRow(updatedRow: SupplyRow): void {
+    this.rowsSignal.update((rows) =>
+      rows.map((row) => (row.id === updatedRow.id ? { ...updatedRow } : row)),
+    );
+  }
+
+  removeRowsById(ids: readonly number[]): void {
+    const idSet = new Set(ids);
+    this.rowsSignal.update((rows) => rows.filter((row) => !idSet.has(row.id)));
+  }
+
+  reset(): void {
+    this.rowsSignal.set(structuredClone(this.initialRows));
+  }
+}
+
+function getTableRows(nativeElement: HTMLElement): HTMLTableRowElement[] {
+  return Array.from(nativeElement.querySelectorAll('tbody tr')) as HTMLTableRowElement[];
+}
+
+describe('WarehousePageComponent', () => {
+  let fixture: ComponentFixture<WarehousePageComponent>;
+  let component: WarehousePageComponent;
+  let service: InMemoryWarehouseService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [WarehousePageComponent],
+      providers: [
+        InMemoryWarehouseService,
+        {
+          provide: WarehouseService,
+          useExisting: InMemoryWarehouseService,
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(WarehousePageComponent);
+    component = fixture.componentInstance;
+    service = TestBed.inject(InMemoryWarehouseService);
+    service.reset();
+    fixture.detectChanges();
+  });
+
+  it('filters rows by search query', () => {
+    const input = fixture.nativeElement.querySelector('input[type="search"]') as HTMLInputElement;
+    input.value = 'MEAT-001';
+    input.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+
+    const rows = getTableRows(fixture.nativeElement);
+    expect(rows.length).toBe(1);
+    expect(rows[0].textContent).toContain('MEAT-001');
+  });
+
+  it('filters rows by status', () => {
+    const selects = fixture.nativeElement.querySelectorAll('select') as NodeListOf<HTMLSelectElement>;
+    const statusSelect = selects[0];
+    statusSelect.value = 'warning';
+    statusSelect.dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+
+    const rows = getTableRows(fixture.nativeElement);
+    expect(rows.length).toBe(1);
+    expect(rows[0].textContent).toContain('Скоро срок');
+  });
+
+  it('filters rows by warehouse', () => {
+    const selects = fixture.nativeElement.querySelectorAll('select') as NodeListOf<HTMLSelectElement>;
+    const warehouseSelect = selects[2];
+    warehouseSelect.value = 'Кухня';
+    warehouseSelect.dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+
+    const rows = getTableRows(fixture.nativeElement);
+    expect(rows.length).toBe(1);
+    expect(rows[0].textContent).toContain('Кухня');
+  });
+
+  it('filters rows by arrival date range', () => {
+    const dateInputs = fixture.nativeElement.querySelectorAll(
+      '.warehouse-page__filters input[type="date"]',
+    ) as NodeListOf<HTMLInputElement>;
+    const from = dateInputs[0];
+    const to = dateInputs[1];
+
+    from.value = '2025-09-27';
+    from.dispatchEvent(new Event('change'));
+    to.value = '2025-09-27';
+    to.dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+
+    const rows = getTableRows(fixture.nativeElement);
+    expect(rows.length).toBe(1);
+    expect(rows[0].textContent).toContain('27.09.2025');
+  });
+
+  it('shows row sum calculated from qty and price', () => {
+    const firstRow = service.list()()[0];
+    service.updateRow({ ...firstRow, qty: 10, price: 20 });
+    fixture.detectChanges();
+
+    const input = fixture.nativeElement.querySelector('input[type="search"]') as HTMLInputElement;
+    input.value = firstRow.docNo;
+    input.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+
+    const [tableRow] = getTableRows(fixture.nativeElement);
+    const sumCell = tableRow.querySelectorAll('td')[10];
+    const text = sumCell?.textContent?.replace(/ /g, ' ').trim();
+    expect(text).toBe('200 ₽');
+  });
+
+  it('computes total sum for filtered rows', () => {
+    const selects = fixture.nativeElement.querySelectorAll('select') as NodeListOf<HTMLSelectElement>;
+    const statusSelect = selects[0];
+    statusSelect.value = 'ok';
+    statusSelect.dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+
+    const expected = component
+      .filteredRows()
+      .reduce((total, row) => total + row.qty * row.price, 0);
+    expect(component.totalSum()).toBe(expected);
+  });
+
+  it('selects and clears all rows via header checkbox', () => {
+    const headerCheckbox = fixture.nativeElement.querySelector(
+      'thead input[type="checkbox"]',
+    ) as HTMLInputElement;
+
+    headerCheckbox.click();
+    fixture.detectChanges();
+    expect(component.checkedIds().length).toBe(component.filteredRows().length);
+
+    headerCheckbox.click();
+    fixture.detectChanges();
+    expect(component.checkedIds().length).toBe(0);
+  });
+
+  it('opens drawer on row double click', () => {
+    const [row] = getTableRows(fixture.nativeElement);
+    row.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
+    fixture.detectChanges();
+
+    const drawer = fixture.nativeElement.querySelector('.warehouse-page__drawer') as HTMLElement;
+    expect(drawer).toBeTruthy();
+    expect(drawer.textContent).toContain(component.filteredRows()[0].docNo);
+  });
+
+  it('removes a single row after delete confirmation', () => {
+    const initialRows = getTableRows(fixture.nativeElement).length;
+    const menuButton = fixture.nativeElement.querySelector(
+      '.warehouse-page__row-menu-trigger',
+    ) as HTMLButtonElement;
+    menuButton.click();
+    fixture.detectChanges();
+
+    const deleteButton = fixture.nativeElement.querySelector(
+      '.warehouse-page__row-menu-panel button:last-child',
+    ) as HTMLButtonElement;
+    deleteButton.click();
+    fixture.detectChanges();
+
+    const confirmButton = fixture.nativeElement.querySelector(
+      '.warehouse-page__dialog--confirm .btn-danger',
+    ) as HTMLButtonElement;
+    confirmButton.click();
+    fixture.detectChanges();
+
+    expect(getTableRows(fixture.nativeElement).length).toBe(initialRows - 1);
+  });
+
+  it('removes all selected rows using bulk action', () => {
+    const headerCheckbox = fixture.nativeElement.querySelector(
+      'thead input[type="checkbox"]',
+    ) as HTMLInputElement;
+    headerCheckbox.click();
+    fixture.detectChanges();
+
+    const bulkDeleteButton = fixture.nativeElement.querySelector(
+      '.warehouse-page__bulk-actions .btn-danger',
+    ) as HTMLButtonElement;
+    bulkDeleteButton.click();
+    fixture.detectChanges();
+
+    const confirmButton = fixture.nativeElement.querySelector(
+      '.warehouse-page__dialog--confirm .btn-danger',
+    ) as HTMLButtonElement;
+    confirmButton.click();
+    fixture.detectChanges();
+
+    expect(component.rows().length).toBe(0);
+    expect(component.checkedIds().length).toBe(0);
+    const emptyRow = fixture.nativeElement.querySelector('.warehouse-page__empty-row');
+    expect(emptyRow?.textContent).toContain('Нет поставок');
+  });
+});

--- a/feedme.client/src/app/warehouse/warehouse-page.component.ts
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.ts
@@ -1,11 +1,32 @@
-import { NgFor, NgIf } from '@angular/common';
-import { ChangeDetectionStrategy, Component, computed, signal } from '@angular/core';
+import { NgClass, NgFor, NgIf } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  HostListener,
+  ViewChild,
+  computed,
+  effect,
+  inject,
+  signal,
+} from '@angular/core';
+import {
+  NonNullableFormBuilder,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
 
-import { SupplyRow } from './models';
+import { SupplyRow, SupplyStatus } from './models';
 import { WarehouseService } from './warehouse.service';
+import { EmptyStateComponent } from './ui/empty-state.component';
 import { FieldComponent } from './ui/field.component';
 import { MetricComponent } from './ui/metric.component';
-import { EmptyStateComponent } from './ui/empty-state.component';
+
+const RUB_FORMATTER = new Intl.NumberFormat('ru-RU', {
+  style: 'currency',
+  currency: 'RUB',
+  maximumFractionDigits: 0,
+});
 
 @Component({
   standalone: true,
@@ -13,6 +34,8 @@ import { EmptyStateComponent } from './ui/empty-state.component';
   imports: [
     NgFor,
     NgIf,
+    NgClass,
+    ReactiveFormsModule,
     MetricComponent,
     FieldComponent,
     EmptyStateComponent,
@@ -22,50 +45,94 @@ import { EmptyStateComponent } from './ui/empty-state.component';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class WarehousePageComponent {
+  private readonly warehouseService = inject(WarehouseService);
+  private readonly fb = inject(NonNullableFormBuilder);
+
+  @ViewChild('searchInput') private readonly searchInput?: ElementRef<HTMLInputElement>;
+
   readonly activeTab = signal<'supplies' | 'stock' | 'catalog' | 'inventory'>('supplies');
   readonly query = signal('');
-  readonly status = signal<'ok' | 'warning' | 'danger' | ''>('');
+  readonly status = signal<SupplyStatus | ''>('');
   readonly supplier = signal('');
-  readonly selectedRows = signal<number[]>([]);
+  readonly warehouseFilter = signal('');
+  readonly dateFrom = signal('');
+  readonly dateTo = signal('');
+  readonly checkedIds = signal<number[]>([]);
+  readonly drawerRowId = signal<number | null>(null);
   readonly drawerOpen = signal(false);
-  readonly dialogOpen = signal(false);
-  readonly selectedRow = signal<SupplyRow | null>(null);
+  readonly editDialogOpen = signal(false);
+  readonly deleteDialogOpen = signal(false);
+  readonly editingRowId = signal<number | null>(null);
+  readonly deleteTargetIds = signal<number[]>([]);
+  readonly menuRowId = signal<number | null>(null);
 
   readonly rows = this.warehouseService.list();
 
-  readonly tabKeys = ['supplies', 'stock', 'catalog', 'inventory'] as const;
+  readonly suppliers = computed(() =>
+    Array.from(new Set(this.rows().map((row) => row.supplier))).sort((a, b) =>
+      a.localeCompare(b),
+    ),
+  );
 
-  readonly suppliers = computed(() => {
-    const unique = new Set(this.rows().map((row) => row.supplier));
-    return Array.from(unique).sort((a, b) => a.localeCompare(b));
-  });
+  readonly warehouses = computed(() =>
+    Array.from(new Set(this.rows().map((row) => row.warehouse))).sort((a, b) =>
+      a.localeCompare(b),
+    ),
+  );
 
   readonly filteredRows = computed(() => {
     const search = this.query().trim().toLowerCase();
     const statusFilter = this.status();
     const supplierFilter = this.supplier();
+    const warehouseFilter = this.warehouseFilter();
+    const from = this.dateFrom();
+    const to = this.dateTo();
 
     return this.rows().filter((row) => {
-      const matchesSearch = search
-        ? `${row.name}${row.sku}`.toLowerCase().includes(search)
+      const matchesQuery = search
+        ? `${row.docNo}${row.name}${row.sku}`.toLowerCase().includes(search)
         : true;
       const matchesStatus = statusFilter ? row.status === statusFilter : true;
       const matchesSupplier = supplierFilter ? row.supplier === supplierFilter : true;
+      const matchesWarehouse = warehouseFilter ? row.warehouse === warehouseFilter : true;
+      const matchesFrom = from ? row.arrivalDate >= from : true;
+      const matchesTo = to ? row.arrivalDate <= to : true;
 
-      return matchesSearch && matchesStatus && matchesSupplier;
+      return (
+        matchesQuery &&
+        matchesStatus &&
+        matchesSupplier &&
+        matchesWarehouse &&
+        matchesFrom &&
+        matchesTo
+      );
     });
   });
 
-  readonly allRowsChecked = computed(
-    () =>
-      this.filteredRows().length > 0 &&
-      this.selectedRows().length === this.filteredRows().length,
+  readonly totalSum = computed(() =>
+    this.filteredRows().reduce((acc, row) => acc + row.qty * row.price, 0),
   );
 
-  readonly hasSelection = computed(() => this.selectedRows().length > 0);
+  readonly hasSelection = computed(() => this.checkedIds().length > 0);
 
-  constructor(private readonly warehouseService: WarehouseService) {}
+  readonly allFilteredChecked = computed(() => {
+    const filtered = this.filteredRows();
+    if (!filtered.length) {
+      return false;
+    }
+    const selected = new Set(this.checkedIds());
+    return filtered.every((row) => selected.has(row.id));
+  });
 
+  readonly selectedRow = computed(() => {
+    const id = this.drawerRowId();
+    if (id === null) {
+      return null;
+    }
+    return this.rows().find((row) => row.id === id) ?? null;
+  });
+
+  readonly tabKeys = ['supplies', 'stock', 'catalog', 'inventory'] as const;
   readonly tabLabels: Record<'supplies' | 'stock' | 'catalog' | 'inventory', string> = {
     supplies: 'Поставки',
     stock: 'Остатки',
@@ -73,67 +140,68 @@ export class WarehousePageComponent {
     inventory: 'Инвентаризация',
   };
 
+  readonly editForm = this.fb.group({
+    docNo: this.fb.control('', { validators: [Validators.required] }),
+    arrivalDate: this.fb.control('', { validators: [Validators.required] }),
+    warehouse: this.fb.control('', { validators: [Validators.required] }),
+    responsible: this.fb.control('', { validators: [Validators.required] }),
+    supplier: this.fb.control('', { validators: [Validators.required] }),
+    sku: this.fb.control('', { validators: [Validators.required] }),
+    name: this.fb.control('', { validators: [Validators.required] }),
+    category: this.fb.control('', { validators: [Validators.required] }),
+    qty: this.fb.control(0, {
+      validators: [Validators.required, Validators.min(0)],
+    }),
+    unit: this.fb.control('', { validators: [Validators.required] }),
+    price: this.fb.control(0, {
+      validators: [Validators.required, Validators.min(0)],
+    }),
+    expiry: this.fb.control('', { validators: [Validators.required] }),
+    status: this.fb.control<SupplyStatus>('ok', { validators: [Validators.required] }),
+  });
+
+  constructor() {
+    effect(() => {
+      const availableIds = new Set(this.rows().map((row) => row.id));
+      const filteredSelection = this.checkedIds().filter((id) => availableIds.has(id));
+      if (filteredSelection.length !== this.checkedIds().length) {
+        this.checkedIds.set(filteredSelection);
+      }
+
+      if (this.drawerOpen() && !this.selectedRow()) {
+        this.closeDrawer();
+      }
+    });
+  }
+
+  @HostListener('document:click')
+  onDocumentClick(): void {
+    this.menuRowId.set(null);
+  }
+
+  @HostListener('document:keydown', ['$event'])
+  onDocumentKeydown(event: KeyboardEvent): void {
+    if (event.key === '/' && !event.defaultPrevented) {
+      const input = this.searchInput?.nativeElement;
+      if (input && document.activeElement !== input) {
+        event.preventDefault();
+        input.focus();
+        input.select();
+      }
+    }
+  }
+
   trackByRow = (_: number, row: SupplyRow) => row.id;
-
-  toggleRowSelection(id: number, checked: boolean): void {
-    const selection = new Set(this.selectedRows());
-    if (checked) {
-      selection.add(id);
-    } else {
-      selection.delete(id);
-    }
-    this.selectedRows.set(Array.from(selection).sort((a, b) => a - b));
-  }
-
-  toggleAll(checked: boolean): void {
-    if (checked) {
-      this.selectedRows.set(this.filteredRows().map((row) => row.id));
-      return;
-    }
-    this.selectedRows.set([]);
-  }
-
-  toggleAllFromEvent(event: Event): void {
-    const checkbox = event.target as HTMLInputElement | null;
-    this.toggleAll(checkbox?.checked ?? false);
-  }
-
-  openDrawer(row: SupplyRow): void {
-    this.selectedRow.set(row);
-    this.drawerOpen.set(true);
-  }
-
-  closeDrawer(): void {
-    this.drawerOpen.set(false);
-    this.selectedRow.set(null);
-  }
-
-  openDialog(): void {
-    this.dialogOpen.set(true);
-  }
-
-  closeDialog(): void {
-    this.dialogOpen.set(false);
-  }
-
-  clearFilters(): void {
-    this.query.set('');
-    this.status.set('');
-    this.supplier.set('');
-  }
 
   selectTab(tab: 'supplies' | 'stock' | 'catalog' | 'inventory'): void {
     this.activeTab.set(tab);
   }
 
-  handleSearchChange(event: Event): void {
-    const input = event.target as HTMLInputElement | null;
-    this.query.set(input?.value ?? '');
+  updateQuery(value: string): void {
+    this.query.set(value);
   }
 
-  handleStatusChange(event: Event): void {
-    const select = event.target as HTMLSelectElement | null;
-    const value = select?.value ?? '';
+  updateStatus(value: string): void {
     if (value === 'ok' || value === 'warning' || value === 'danger') {
       this.status.set(value);
       return;
@@ -141,13 +209,249 @@ export class WarehousePageComponent {
     this.status.set('');
   }
 
-  handleSupplierChange(event: Event): void {
-    const select = event.target as HTMLSelectElement | null;
-    this.supplier.set(select?.value ?? '');
+  updateSupplier(value: string): void {
+    this.supplier.set(value);
   }
 
-  handleRowSelection(id: number, event: Event): void {
+  updateWarehouse(value: string): void {
+    this.warehouseFilter.set(value);
+  }
+
+  updateDateFrom(value: string): void {
+    this.dateFrom.set(value);
+  }
+
+  updateDateTo(value: string): void {
+    this.dateTo.set(value);
+  }
+
+  clearFilters(): void {
+    this.query.set('');
+    this.status.set('');
+    this.supplier.set('');
+    this.warehouseFilter.set('');
+    this.dateFrom.set('');
+    this.dateTo.set('');
+  }
+
+  toggleRowSelection(id: number, checked: boolean): void {
+    const selection = new Set(this.checkedIds());
+    if (checked) {
+      selection.add(id);
+    } else {
+      selection.delete(id);
+    }
+    this.checkedIds.set(Array.from(selection).sort((a, b) => a - b));
+  }
+
+  toggleAll(checked: boolean): void {
+    if (checked) {
+      this.checkedIds.set(this.filteredRows().map((row) => row.id));
+      return;
+    }
+    this.checkedIds.set([]);
+  }
+
+  toggleAllFromEvent(event: Event): void {
+    const checkbox = event.target as HTMLInputElement | null;
+    this.toggleAll(checkbox?.checked ?? false);
+  }
+
+  handleRowCheckbox(id: number, event: Event): void {
     const checkbox = event.target as HTMLInputElement | null;
     this.toggleRowSelection(id, checkbox?.checked ?? false);
+  }
+
+  openDrawer(row: SupplyRow): void {
+    this.drawerRowId.set(row.id);
+    this.drawerOpen.set(true);
+    this.menuRowId.set(null);
+  }
+
+  closeDrawer(): void {
+    this.drawerOpen.set(false);
+    this.drawerRowId.set(null);
+  }
+
+  toggleRowMenu(rowId: number, event: MouseEvent): void {
+    event.stopPropagation();
+    const current = this.menuRowId();
+    this.menuRowId.set(current === rowId ? null : rowId);
+  }
+
+  openCreateDialog(): void {
+    this.editForm.reset({
+      docNo: '',
+      arrivalDate: '',
+      warehouse: '',
+      responsible: '',
+      supplier: '',
+      sku: '',
+      name: '',
+      category: '',
+      qty: 0,
+      unit: '',
+      price: 0,
+      expiry: '',
+      status: 'ok' as SupplyStatus,
+    });
+    this.clearDateOrderError();
+    this.editingRowId.set(null);
+    this.editDialogOpen.set(true);
+    this.menuRowId.set(null);
+  }
+
+  startEdit(row: SupplyRow): void {
+    this.populateEditForm(row);
+    this.clearDateOrderError();
+    this.editingRowId.set(row.id);
+    this.editDialogOpen.set(true);
+    this.menuRowId.set(null);
+  }
+
+  closeEditDialog(): void {
+    this.editDialogOpen.set(false);
+    this.editingRowId.set(null);
+    this.editForm.reset({
+      docNo: '',
+      arrivalDate: '',
+      warehouse: '',
+      responsible: '',
+      supplier: '',
+      sku: '',
+      name: '',
+      category: '',
+      qty: 0,
+      unit: '',
+      price: 0,
+      expiry: '',
+      status: 'ok' as SupplyStatus,
+    });
+    this.clearDateOrderError();
+  }
+
+  submitEdit(): void {
+    this.clearDateOrderError();
+
+    const raw = this.editForm.getRawValue();
+    if (raw.arrivalDate && raw.expiry && raw.arrivalDate > raw.expiry) {
+      this.setDateOrderError();
+    }
+
+    if (this.editForm.invalid) {
+      this.editForm.markAllAsTouched();
+      return;
+    }
+
+    const base = {
+      docNo: raw.docNo.trim(),
+      arrivalDate: raw.arrivalDate,
+      warehouse: raw.warehouse.trim(),
+      responsible: raw.responsible.trim(),
+      supplier: raw.supplier.trim(),
+      sku: raw.sku.trim(),
+      name: raw.name.trim(),
+      category: raw.category.trim(),
+      qty: Number(raw.qty),
+      unit: raw.unit.trim(),
+      price: Number(raw.price),
+      expiry: raw.expiry,
+      status: raw.status,
+    } satisfies Omit<SupplyRow, 'id'>;
+
+    if (this.editingRowId() === null) {
+      this.warehouseService.addRow(base);
+    } else {
+      const updated: SupplyRow = { id: this.editingRowId()!, ...base };
+      this.warehouseService.updateRow(updated);
+
+      if (this.drawerOpen() && this.drawerRowId() === updated.id) {
+        this.drawerRowId.set(updated.id);
+      }
+    }
+
+    this.closeEditDialog();
+  }
+
+  openDeleteDialogForRow(row: SupplyRow): void {
+    this.deleteTargetIds.set([row.id]);
+    this.deleteDialogOpen.set(true);
+    this.menuRowId.set(null);
+  }
+
+  openDeleteDialogForSelection(): void {
+    if (!this.checkedIds().length) {
+      return;
+    }
+    this.deleteTargetIds.set([...this.checkedIds()]);
+    this.deleteDialogOpen.set(true);
+  }
+
+  closeDeleteDialog(): void {
+    this.deleteDialogOpen.set(false);
+    this.deleteTargetIds.set([]);
+  }
+
+  confirmDelete(): void {
+    const ids = this.deleteTargetIds();
+    if (!ids.length) {
+      return;
+    }
+
+    this.warehouseService.removeRowsById(ids);
+    const remainingSelection = this.checkedIds().filter((id) => !ids.includes(id));
+    this.checkedIds.set(remainingSelection);
+
+    if (this.drawerRowId() !== null && ids.includes(this.drawerRowId()!)) {
+      this.closeDrawer();
+    }
+
+    this.closeDeleteDialog();
+  }
+
+  formatCurrency(value: number): string {
+    return RUB_FORMATTER.format(value);
+  }
+
+  rowTotal(row: SupplyRow): number {
+    return row.qty * row.price;
+  }
+
+  getRowById(id: number): SupplyRow | undefined {
+    return this.rows().find((row) => row.id === id);
+  }
+
+  private populateEditForm(row: SupplyRow): void {
+    this.editForm.setValue({
+      docNo: row.docNo,
+      arrivalDate: row.arrivalDate,
+      warehouse: row.warehouse,
+      responsible: row.responsible,
+      supplier: row.supplier,
+      sku: row.sku,
+      name: row.name,
+      category: row.category,
+      qty: row.qty,
+      unit: row.unit,
+      price: row.price,
+      expiry: row.expiry,
+      status: row.status,
+    });
+  }
+
+  private setDateOrderError(): void {
+    const expiryControl = this.editForm.controls.expiry;
+    const errors = { ...(expiryControl.errors ?? {}) };
+    errors['dateOrder'] = true;
+    expiryControl.setErrors(errors);
+  }
+
+  private clearDateOrderError(): void {
+    const expiryControl = this.editForm.controls.expiry;
+    const errors = { ...(expiryControl.errors ?? {}) };
+    if ('dateOrder' in errors) {
+      delete errors['dateOrder'];
+      expiryControl.setErrors(Object.keys(errors).length ? errors : null);
+    }
   }
 }

--- a/feedme.client/src/app/warehouse/warehouse.service.ts
+++ b/feedme.client/src/app/warehouse/warehouse.service.ts
@@ -7,6 +7,10 @@ export class WarehouseService {
   private readonly rowsSignal = signal<SupplyRow[]>([
     {
       id: 1,
+      docNo: 'PO-000851',
+      arrivalDate: '2025-09-25',
+      warehouse: 'Главный склад',
+      responsible: 'Иванов И.',
       sku: 'MEAT-001',
       name: 'Курица охлажд.',
       category: 'Мясные заготовки',
@@ -19,6 +23,10 @@ export class WarehouseService {
     },
     {
       id: 2,
+      docNo: 'PO-000852',
+      arrivalDate: '2025-09-27',
+      warehouse: 'Кухня',
+      responsible: 'Петров П.',
       sku: 'MEAT-002',
       name: 'Говядина',
       category: 'Мясные заготовки',
@@ -31,6 +39,10 @@ export class WarehouseService {
     },
     {
       id: 3,
+      docNo: 'PO-000853',
+      arrivalDate: '2025-09-26',
+      warehouse: 'Главный склад',
+      responsible: 'Иванов И.',
       sku: 'VEG-011',
       name: 'Лук репчатый',
       category: 'Овощи',
@@ -43,6 +55,10 @@ export class WarehouseService {
     },
     {
       id: 4,
+      docNo: 'PO-000854',
+      arrivalDate: '2025-09-20',
+      warehouse: 'Бар',
+      responsible: 'Сидоров С.',
       sku: 'DAIRY-004',
       name: 'Сливки 33%',
       category: 'Молочные',
@@ -56,4 +72,22 @@ export class WarehouseService {
   ]);
 
   readonly list = () => this.rowsSignal.asReadonly();
+
+  addRow(row: Omit<SupplyRow, 'id'>): void {
+    this.rowsSignal.update((rows) => {
+      const nextId = rows.reduce((max, current) => Math.max(max, current.id), 0) + 1;
+      return [...rows, { id: nextId, ...row }];
+    });
+  }
+
+  updateRow(updatedRow: SupplyRow): void {
+    this.rowsSignal.update((rows) =>
+      rows.map((row) => (row.id === updatedRow.id ? { ...updatedRow } : row)),
+    );
+  }
+
+  removeRowsById(ids: readonly number[]): void {
+    const idSet = new Set(ids);
+    this.rowsSignal.update((rows) => rows.filter((row) => !idSet.has(row.id)));
+  }
 }


### PR DESCRIPTION
## Summary
- expand the supply data model and service to support warehouses, documents, totals, create/update/delete flows
- rebuild the supplies page component with full filter state, bulk selection, dialogs, drawer, and currency formatting
- redesign the supplies tab markup and styles for the new layout and add comprehensive interaction tests

## Testing
- `npm test` *(fails: ChromeHeadless missing libatk runtime in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d8802192d88323b81482572ddfd977