### PR TITLE
feat: redesign supplies tab UX

### DIFF
--- a/feedme.client/src/app/warehouse/models.ts
+++ b/feedme.client/src/app/warehouse/models.ts
@@ -1,7 +1,11 @@
-export type StockStatus = 'ok' | 'warning' | 'danger';
+export type SupplyStatus = 'ok' | 'warning' | 'danger';
 
 export interface SupplyRow {
   readonly id: number;
+  readonly docNo: string;
+  readonly arrivalDate: string;
+  readonly warehouse: string;
+  readonly responsible: string;
   readonly sku: string;
   readonly name: string;
   readonly category: string;
@@ -10,5 +14,5 @@ export interface SupplyRow {
   readonly price: number;
   readonly expiry: string;
   readonly supplier: string;
-  readonly status: StockStatus;
+  readonly status: SupplyStatus;
 }

--- a/feedme.client/src/app/warehouse/ui/rub-currency.pipe.ts
+++ b/feedme.client/src/app/warehouse/ui/rub-currency.pipe.ts
@@ -1,0 +1,18 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'rubCurrency',
+  standalone: true,
+})
+export class RubCurrencyPipe implements PipeTransform {
+  private readonly formatter = new Intl.NumberFormat('ru-RU', {
+    style: 'currency',
+    currency: 'RUB',
+    maximumFractionDigits: 2,
+  });
+
+  transform(value: number | null | undefined): string {
+    const numeric = typeof value === 'number' ? value : Number(value ?? 0);
+    return this.formatter.format(Number.isFinite(numeric) ? numeric : 0);
+  }
+}

--- a/feedme.client/src/app/warehouse/warehouse-page.component.css
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.css
@@ -195,11 +195,16 @@
 .warehouse-page__bulk-actions {
   display: flex;
   gap: 8px;
+  flex-wrap: wrap;
 }
 
 .warehouse-page__bulk-count {
   color: #111827;
   font-weight: 500;
+}
+
+.warehouse-page__bulk-hint {
+  color: #94a3b8;
 }
 
 .warehouse-page__table-card {
@@ -267,17 +272,8 @@
   font-size: 0.75rem;
 }
 
-.warehouse-page__cell--link button {
-  color: #2563eb;
-  font-weight: 600;
+.warehouse-page__table tbody tr {
   cursor: pointer;
-  background: none;
-  border: none;
-  padding: 0;
-}
-
-.warehouse-page__cell--link button:hover {
-  text-decoration: underline;
 }
 
 .warehouse-page__table tbody tr:hover {
@@ -328,7 +324,7 @@
   margin-bottom: 24px;
 }
 
-.warehouse-page__drawer-sku {
+.warehouse-page__drawer-doc {
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -339,6 +335,12 @@
 .warehouse-page__drawer-title {
   font-size: 1.25rem;
   font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.warehouse-page__drawer-meta {
+  font-size: 0.875rem;
+  color: #6b7280;
 }
 
 .warehouse-page__drawer-grid {
@@ -378,9 +380,19 @@
   box-shadow: 0 24px 48px rgba(15, 23, 42, 0.25);
 }
 
+.warehouse-page__dialog--confirm {
+  width: min(420px, 100%);
+}
+
 .warehouse-page__dialog-header {
   font-size: 1.25rem;
   font-weight: 600;
+}
+
+.warehouse-page__dialog-form {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
 }
 
 .warehouse-page__dialog-grid {
@@ -402,40 +414,77 @@
   color: #94a3b8;
 }
 
-.warehouse-page__dialog-table {
-  border: 1px solid #e2e8f0;
-  border-radius: 12px;
-  overflow: hidden;
+.warehouse-page__dialog-error {
+  color: #dc2626;
+  font-size: 0.875rem;
 }
 
-.warehouse-page__dialog-table > header {
-  padding: 16px 20px;
-  font-weight: 600;
-  border-bottom: 1px solid #e2e8f0;
-}
-
-.warehouse-page__dialog-body {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-  padding: 20px;
-  color: #6b7280;
-}
-
-.warehouse-page__dialog-input-row {
-  display: flex;
-  gap: 12px;
-  align-items: center;
-}
-
-.warehouse-page__dialog-input-row .input {
-  flex: 1;
+.warehouse-page__dialog-message {
+  font-size: 0.95rem;
+  color: #374151;
 }
 
 .warehouse-page__dialog-actions {
   display: flex;
   justify-content: flex-end;
   gap: 12px;
+}
+
+.row-menu {
+  position: relative;
+  display: inline-flex;
+}
+
+.row-menu__trigger {
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  border: none;
+  background-color: transparent;
+  color: #6b7280;
+  cursor: pointer;
+  font-size: 1.25rem;
+  line-height: 1;
+}
+
+.row-menu__trigger:hover,
+.row-menu__trigger:focus {
+  background-color: #f1f5f9;
+  color: #111827;
+}
+
+.row-menu__popover {
+  position: absolute;
+  top: 36px;
+  right: 0;
+  min-width: 160px;
+  display: flex;
+  flex-direction: column;
+  background-color: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.12);
+  padding: 8px;
+  z-index: 2;
+}
+
+.row-menu__popover button {
+  text-align: left;
+  background: none;
+  border: none;
+  padding: 8px 12px;
+  border-radius: 6px;
+  color: #374151;
+  font-size: 0.875rem;
+  cursor: pointer;
+}
+
+.row-menu__popover button:hover {
+  background-color: #f8fafc;
+}
+
+.row-menu__danger {
+  color: #dc2626;
 }
 
 @media (max-width: 1280px) {

--- a/feedme.client/src/app/warehouse/warehouse-page.component.html
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.html
@@ -27,8 +27,7 @@
         Главный склад / <span class="warehouse-page__breadcrumb-current">Поставки</span>
       </div>
       <div class="warehouse-page__actions">
-        <button type="button" class="btn btn-outline" (click)="openDialog()">+ Новая поставка</button>
-        <button type="button" class="btn btn-ghost">Ещё</button>
+        <button type="button" class="btn btn-ghost" (click)="focusSearch()">Найти поставку (/)</button>
       </div>
     </header>
 
@@ -59,9 +58,11 @@
           <label class="warehouse-page__filter">
             <span class="warehouse-page__filter-label">Поиск</span>
             <input
+              #searchInput
+              data-testid="supplies-search"
               class="input"
               type="search"
-              placeholder="Название или SKU (/)"
+              placeholder="№ документа, название или SKU (/)"
               [value]="query()"
               (input)="handleSearchChange($event)"
             />
@@ -69,6 +70,7 @@
           <label class="warehouse-page__filter">
             <span class="warehouse-page__filter-label">Статус</span>
             <select
+              data-testid="supplies-status-filter"
               class="select"
               [value]="status()"
               (change)="handleStatusChange($event)"
@@ -82,6 +84,7 @@
           <label class="warehouse-page__filter">
             <span class="warehouse-page__filter-label">Поставщик</span>
             <select
+              data-testid="supplies-supplier-filter"
               class="select"
               [value]="supplier()"
               (change)="handleSupplierChange($event)"
@@ -90,20 +93,59 @@
               <option *ngFor="let option of suppliers()" [value]="option">{{ option }}</option>
             </select>
           </label>
+          <label class="warehouse-page__filter">
+            <span class="warehouse-page__filter-label">Склад</span>
+            <select
+              data-testid="supplies-warehouse-filter"
+              class="select"
+              [value]="warehouse()"
+              (change)="handleWarehouseChange($event)"
+            >
+              <option value="">Все склады</option>
+              <option *ngFor="let option of warehouses()" [value]="option">{{ option }}</option>
+            </select>
+          </label>
+          <label class="warehouse-page__filter">
+            <span class="warehouse-page__filter-label">Дата от</span>
+            <input
+              data-testid="supplies-date-from"
+              class="input"
+              type="date"
+              [value]="dateFrom()"
+              (change)="handleDateFromChange($event)"
+            />
+          </label>
+          <label class="warehouse-page__filter">
+            <span class="warehouse-page__filter-label">Дата до</span>
+            <input
+              data-testid="supplies-date-to"
+              class="input"
+              type="date"
+              [value]="dateTo()"
+              (change)="handleDateToChange($event)"
+            />
+          </label>
           <div class="warehouse-page__filters-actions">
             <button type="button" class="btn btn-outline" (click)="clearFilters()">Сброс</button>
-            <button type="button" class="btn btn-secondary">Экспорт</button>
+            <button type="button" class="btn btn-secondary" (click)="exportFiltered()">Экспорт</button>
           </div>
         </form>
 
         <section class="warehouse-page__bulk" aria-live="polite">
           <ng-container *ngIf="hasSelection(); else selectionHint">
-            <span class="warehouse-page__bulk-count">Выбрано: {{ selectedRows().length }}</span>
+            <span class="warehouse-page__bulk-count">Выбрано: {{ checkedIds().length }}</span>
             <div class="warehouse-page__bulk-actions">
-              <button type="button" class="btn btn-outline btn-sm">Списать</button>
-              <button type="button" class="btn btn-outline btn-sm">Переместить</button>
-              <button type="button" class="btn btn-outline btn-sm">Печать</button>
-              <button type="button" class="btn btn-danger btn-sm">Удалить</button>
+              <button type="button" class="btn btn-outline btn-sm" (click)="handleMassWriteOff()">Списать</button>
+              <button type="button" class="btn btn-outline btn-sm" (click)="handleMassMove()">Переместить</button>
+              <button type="button" class="btn btn-outline btn-sm" (click)="handleMassPrint()">Печать</button>
+              <button
+                type="button"
+                data-testid="bulk-delete"
+                class="btn btn-danger btn-sm"
+                (click)="openBulkDelete()"
+              >
+                Удалить
+              </button>
             </div>
           </ng-container>
           <ng-template #selectionHint>
@@ -112,64 +154,113 @@
         </section>
 
         <section class="warehouse-page__table-card">
-          <header class="warehouse-page__table-header">Последние поставки</header>
+          <header class="warehouse-page__table-header">Поставки</header>
           <div class="warehouse-page__table-wrapper">
             <table class="warehouse-page__table">
               <thead>
                 <tr>
                   <th class="warehouse-page__cell warehouse-page__cell--checkbox">
                     <input
+                      data-testid="supplies-header-checkbox"
                       type="checkbox"
                       [checked]="allRowsChecked()"
                       (change)="toggleAllFromEvent($event)"
                       aria-label="Выбрать все"
                     />
                   </th>
-                  <th class="warehouse-page__cell">SKU</th>
+                  <th class="warehouse-page__cell warehouse-page__cell--mono">№ док.</th>
+                  <th class="warehouse-page__cell warehouse-page__cell--center">Дата прихода</th>
+                  <th class="warehouse-page__cell">Склад</th>
+                  <th class="warehouse-page__cell">Ответственный</th>
+                  <th class="warehouse-page__cell warehouse-page__cell--mono">SKU</th>
                   <th class="warehouse-page__cell">Название</th>
                   <th class="warehouse-page__cell">Категория</th>
                   <th class="warehouse-page__cell warehouse-page__cell--numeric">Кол-во</th>
                   <th class="warehouse-page__cell warehouse-page__cell--numeric">Цена</th>
+                  <th class="warehouse-page__cell warehouse-page__cell--numeric">Сумма</th>
                   <th class="warehouse-page__cell warehouse-page__cell--center">Срок годн.</th>
                   <th class="warehouse-page__cell">Поставщик</th>
                   <th class="warehouse-page__cell">Статус</th>
-                  <th class="warehouse-page__cell warehouse-page__cell--icon" aria-hidden="true"></th>
+                  <th class="warehouse-page__cell warehouse-page__cell--icon" aria-label="Действия"></th>
                 </tr>
               </thead>
               <tbody>
-                <tr *ngFor="let row of filteredRows(); trackBy: trackByRow">
+                <tr
+                  *ngFor="let row of filteredRows(); trackBy: trackByRow"
+                  (dblclick)="handleRowDoubleClick(row)"
+                >
                   <td class="warehouse-page__cell warehouse-page__cell--checkbox">
                     <input
+                      data-testid="supplies-row-checkbox"
                       type="checkbox"
-                      [checked]="selectedRows().includes(row.id)"
-                      (change)="handleRowSelection(row.id, $event)"
-                      [attr.aria-label]="'Строка ' + row.sku"
+                      [checked]="isRowChecked(row.id)"
+                      (click)="$event.stopPropagation()"
+                      (change)="handleRowCheckboxChange(row, $event)"
+                      [attr.aria-label]="'Строка ' + row.docNo"
                     />
                   </td>
+                  <td class="warehouse-page__cell warehouse-page__cell--mono">{{ row.docNo }}</td>
+                  <td class="warehouse-page__cell warehouse-page__cell--center">{{ row.arrivalDate }}</td>
+                  <td class="warehouse-page__cell">{{ row.warehouse }}</td>
+                  <td class="warehouse-page__cell">{{ row.responsible }}</td>
                   <td class="warehouse-page__cell warehouse-page__cell--mono">{{ row.sku }}</td>
-                  <td class="warehouse-page__cell warehouse-page__cell--link">
-                    <button type="button" (click)="openDrawer(row)">{{ row.name }}</button>
-                  </td>
+                  <td class="warehouse-page__cell">{{ row.name }}</td>
                   <td class="warehouse-page__cell">{{ row.category }}</td>
                   <td class="warehouse-page__cell warehouse-page__cell--numeric">{{ row.qty }} {{ row.unit }}</td>
-                  <td class="warehouse-page__cell warehouse-page__cell--numeric">{{ row.price | number:'1.0-0' }} ₽</td>
+                  <td class="warehouse-page__cell warehouse-page__cell--numeric">{{ row.price | rubCurrency }}</td>
+                  <td
+                    class="warehouse-page__cell warehouse-page__cell--numeric"
+                    [attr.data-testid]="'sum-' + row.id"
+                  >
+                    {{ calculateRowTotal(row) | rubCurrency }}
+                  </td>
                   <td class="warehouse-page__cell warehouse-page__cell--center">{{ row.expiry }}</td>
                   <td class="warehouse-page__cell">{{ row.supplier }}</td>
                   <td class="warehouse-page__cell">
-                    <span *ngIf="row.status === 'ok'" class="badge">Ок</span>
-                    <span *ngIf="row.status === 'warning'" class="badge badge-soft">Скоро срок</span>
-                    <span *ngIf="row.status === 'danger'" class="badge badge-danger">Просрочено</span>
+                    <span [ngClass]="badgeClass(row.status)">{{ statusLabel(row.status) }}</span>
                   </td>
-                  <td class="warehouse-page__cell warehouse-page__cell--icon">⋯</td>
+                  <td class="warehouse-page__cell warehouse-page__cell--icon">
+                    <div class="row-menu" (click)="$event.stopPropagation()">
+                      <button
+                        type="button"
+                        class="row-menu__trigger"
+                        data-testid="row-menu-{{ row.id }}"
+                        aria-haspopup="true"
+                        [attr.aria-expanded]="openedMenuId() === row.id"
+                        (click)="toggleRowMenu(row.id, $event)"
+                      >
+                        ⋯
+                      </button>
+                      <div
+                        *ngIf="openedMenuId() === row.id"
+                        class="row-menu__popover"
+                        (keydown.escape)="closeRowMenu()"
+                      >
+                        <button type="button" (click)="handleRowMenuAction(row, 'open', $event)">Открыть</button>
+                        <button type="button" (click)="handleRowMenuAction(row, 'edit', $event)">Редактировать</button>
+                        <button
+                          type="button"
+                          class="row-menu__danger"
+                          [attr.data-testid]="'row-menu-delete-' + row.id"
+                          (click)="handleRowMenuAction(row, 'delete', $event)"
+                        >
+                          Удалить
+                        </button>
+                      </div>
+                    </div>
+                  </td>
                 </tr>
               </tbody>
             </table>
           </div>
           <footer class="warehouse-page__table-footer">
-            <span>Показано {{ filteredRows().length }} из {{ rows().length }}</span>
+            <span data-testid="supplies-summary">
+              Показано {{ filteredRows().length }} из {{ rows().length }}. Итог по сумме:
+              {{ totalSum() | rubCurrency }}
+            </span>
             <div class="warehouse-page__pagination">
-              <button type="button" class="btn btn-outline btn-sm">Назад</button>
-              <button type="button" class="btn btn-outline btn-sm">Далее</button>
+              <button type="button" class="btn btn-outline btn-sm" disabled>Назад</button>
+              <button type="button" class="btn btn-outline btn-sm" disabled>Далее</button>
             </div>
           </footer>
         </section>
@@ -187,65 +278,118 @@
     </section>
   </main>
 
-  <aside class="warehouse-page__drawer" *ngIf="drawerOpen()">
-    <section class="warehouse-page__drawer-content" *ngIf="selectedRow() as row">
+  <aside class="warehouse-page__drawer" *ngIf="drawerRow() as row">
+    <section class="warehouse-page__drawer-content">
       <header class="warehouse-page__drawer-header">
         <div>
-          <div class="warehouse-page__drawer-sku">SKU {{ row.sku }}</div>
+          <div class="warehouse-page__drawer-doc">№ {{ row.docNo }}</div>
           <div class="warehouse-page__drawer-title">{{ row.name }}</div>
+          <div class="warehouse-page__drawer-meta">Поступление {{ row.arrivalDate }} • {{ row.warehouse }}</div>
         </div>
-        <span *ngIf="row.status === 'warning'" class="badge badge-soft">Скоро срок</span>
-        <span *ngIf="row.status === 'danger'" class="badge badge-danger">Просрочено</span>
+        <span [ngClass]="badgeClass(row.status)">{{ statusLabel(row.status) }}</span>
       </header>
       <div class="warehouse-page__drawer-grid">
-        <app-field label="Категория" [value]="row.category"></app-field>
+        <app-field label="Склад" [value]="row.warehouse"></app-field>
+        <app-field label="Ответственный" [value]="row.responsible"></app-field>
         <app-field label="Поставщик" [value]="row.supplier"></app-field>
+        <app-field label="SKU" [value]="row.sku"></app-field>
+        <app-field label="Категория" [value]="row.category"></app-field>
         <app-field label="Количество" [value]="row.qty + ' ' + row.unit"></app-field>
-        <app-field label="Цена закупки" [value]="row.price + ' ₽'"></app-field>
+        <app-field label="Цена закупки" [value]="(row.price | rubCurrency)"></app-field>
+        <app-field label="Сумма" [value]="(calculateRowTotal(row) | rubCurrency)"></app-field>
         <app-field label="Срок годности" [value]="row.expiry"></app-field>
       </div>
       <footer class="warehouse-page__drawer-actions">
-        <button type="button" class="btn btn-outline btn-sm">Списать</button>
-        <button type="button" class="btn btn-outline btn-sm">Переместить</button>
-        <button type="button" class="btn btn-sm">Печать ярлыков</button>
+        <button type="button" class="btn btn-outline btn-sm" (click)="handleMassWriteOff([row.id])">Списать</button>
+        <button type="button" class="btn btn-outline btn-sm" (click)="handleMassMove([row.id])">Переместить</button>
+        <button type="button" class="btn btn-sm" (click)="handleMassPrint([row.id])">Печать ярлыков</button>
+        <button type="button" class="btn btn-ghost btn-sm" (click)="openEditDialog(row)">Редактировать</button>
+        <button type="button" class="btn btn-danger btn-sm" (click)="openDeleteDialog([row.id], row.docNo + ' · ' + row.name)">Удалить</button>
         <button type="button" class="btn btn-ghost btn-sm" (click)="closeDrawer()">Закрыть</button>
       </footer>
     </section>
   </aside>
 
-  <div class="warehouse-page__dialog-backdrop" *ngIf="dialogOpen()">
-    <section class="warehouse-page__dialog" role="dialog" aria-modal="true" aria-labelledby="new-supply-title">
-      <header class="warehouse-page__dialog-header" id="new-supply-title">Новая поставка</header>
-      <div class="warehouse-page__dialog-grid">
-        <label class="warehouse-page__dialog-field">
-          <span class="warehouse-page__dialog-label">Поставщик</span>
-          <select class="select">
-            <option>Выберите поставщика</option>
-            <option *ngFor="let option of suppliers()">{{ option }}</option>
-          </select>
-        </label>
-        <label class="warehouse-page__dialog-field">
-          <span class="warehouse-page__dialog-label">Склад</span>
-          <select class="select">
-            <option>Главный склад</option>
-            <option>Кухня</option>
-            <option>Бар</option>
-          </select>
-        </label>
-      </div>
-      <section class="warehouse-page__dialog-table">
-        <header>Позиции</header>
-        <div class="warehouse-page__dialog-body">
-          <div class="warehouse-page__dialog-input-row">
-            <input class="input" placeholder="Сканируйте штрих-код или введите SKU" />
-            <button type="button" class="btn btn-secondary">Добавить</button>
-          </div>
-          <p class="warehouse-page__dialog-empty">Пока пусто. Добавьте первую позицию.</p>
+  <div class="warehouse-page__dialog-backdrop" *ngIf="editDialogVisible">
+    <section class="warehouse-page__dialog" role="dialog" aria-modal="true" aria-labelledby="edit-supply-title">
+      <header class="warehouse-page__dialog-header" id="edit-supply-title">Редактирование поставки</header>
+      <form class="warehouse-page__dialog-form" [formGroup]="editForm" (ngSubmit)="saveEdit()">
+        <div class="warehouse-page__dialog-grid">
+          <label class="warehouse-page__dialog-field">
+            <span class="warehouse-page__dialog-label">№ документа</span>
+            <input class="input" formControlName="docNo" />
+          </label>
+          <label class="warehouse-page__dialog-field">
+            <span class="warehouse-page__dialog-label">Дата прихода</span>
+            <input class="input" type="date" formControlName="arrivalDate" />
+          </label>
+          <label class="warehouse-page__dialog-field">
+            <span class="warehouse-page__dialog-label">Склад</span>
+            <input class="input" formControlName="warehouse" />
+          </label>
+          <label class="warehouse-page__dialog-field">
+            <span class="warehouse-page__dialog-label">Ответственный</span>
+            <input class="input" formControlName="responsible" />
+          </label>
+          <label class="warehouse-page__dialog-field">
+            <span class="warehouse-page__dialog-label">Поставщик</span>
+            <input class="input" formControlName="supplier" />
+          </label>
+          <label class="warehouse-page__dialog-field">
+            <span class="warehouse-page__dialog-label">SKU</span>
+            <input class="input" formControlName="sku" />
+          </label>
+          <label class="warehouse-page__dialog-field">
+            <span class="warehouse-page__dialog-label">Название</span>
+            <input class="input" formControlName="name" />
+          </label>
+          <label class="warehouse-page__dialog-field">
+            <span class="warehouse-page__dialog-label">Категория</span>
+            <input class="input" formControlName="category" />
+          </label>
+          <label class="warehouse-page__dialog-field">
+            <span class="warehouse-page__dialog-label">Количество</span>
+            <input class="input" type="number" min="0" formControlName="qty" />
+          </label>
+          <label class="warehouse-page__dialog-field">
+            <span class="warehouse-page__dialog-label">Ед. изм.</span>
+            <input class="input" formControlName="unit" />
+          </label>
+          <label class="warehouse-page__dialog-field">
+            <span class="warehouse-page__dialog-label">Цена</span>
+            <input class="input" type="number" min="0" formControlName="price" />
+          </label>
+          <label class="warehouse-page__dialog-field">
+            <span class="warehouse-page__dialog-label">Срок годности</span>
+            <input class="input" type="date" formControlName="expiry" />
+          </label>
+          <label class="warehouse-page__dialog-field">
+            <span class="warehouse-page__dialog-label">Статус</span>
+            <select class="select" formControlName="status">
+              <option value="ok">Ок</option>
+              <option value="warning">Скоро срок</option>
+              <option value="danger">Просрочено</option>
+            </select>
+          </label>
         </div>
-      </section>
+        <p class="warehouse-page__dialog-error" *ngIf="editForm.hasError('dateRange')">
+          Дата прихода не может быть позже срока годности.
+        </p>
+        <footer class="warehouse-page__dialog-actions">
+          <button type="button" class="btn btn-outline" (click)="closeEditDialog()">Отмена</button>
+          <button type="submit" class="btn">Сохранить</button>
+        </footer>
+      </form>
+    </section>
+  </div>
+
+  <div class="warehouse-page__dialog-backdrop" *ngIf="deleteDialog as dialog">
+    <section class="warehouse-page__dialog warehouse-page__dialog--confirm" role="dialog" aria-modal="true" aria-labelledby="delete-supply-title">
+      <header class="warehouse-page__dialog-header" id="delete-supply-title">Удаление поставки</header>
+      <p class="warehouse-page__dialog-message">Вы уверены, что хотите удалить {{ dialog.title }}?</p>
       <footer class="warehouse-page__dialog-actions">
-        <button type="button" class="btn btn-outline" (click)="closeDialog()">Отмена</button>
-        <button type="button" class="btn" disabled>Создать приход</button>
+        <button type="button" class="btn btn-outline" (click)="closeDeleteDialog()">Отмена</button>
+        <button type="button" class="btn btn-danger" (click)="confirmDelete()">Удалить</button>
       </footer>
     </section>
   </div>

--- a/feedme.client/src/app/warehouse/warehouse-page.component.spec.ts
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.spec.ts
@@ -1,0 +1,237 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { WarehousePageComponent } from './warehouse-page.component';
+import { WarehouseService } from './warehouse.service';
+import { SupplyRow } from './models';
+
+const TEST_ROWS: SupplyRow[] = [
+  {
+    id: 1,
+    docNo: 'PR-100',
+    arrivalDate: '2025-09-26',
+    warehouse: 'Главный склад',
+    responsible: 'Иванов И.',
+    sku: 'MEAT-001',
+    name: 'Курица',
+    category: 'Мясо',
+    qty: 10,
+    unit: 'кг',
+    price: 20,
+    expiry: '2025-10-05',
+    supplier: 'ООО Куры',
+    status: 'ok',
+  },
+  {
+    id: 2,
+    docNo: 'PR-101',
+    arrivalDate: '2025-09-26',
+    warehouse: 'Кухня',
+    responsible: 'Петров П.',
+    sku: 'MEAT-002',
+    name: 'Говядина',
+    category: 'Мясо',
+    qty: 5,
+    unit: 'кг',
+    price: 30,
+    expiry: '2025-09-30',
+    supplier: 'Ферма №5',
+    status: 'warning',
+  },
+  {
+    id: 3,
+    docNo: 'PR-102',
+    arrivalDate: '2025-09-27',
+    warehouse: 'Главный склад',
+    responsible: 'Сидорова А.',
+    sku: 'FISH-001',
+    name: 'Форель охлаждённая',
+    category: 'Рыба',
+    qty: 3,
+    unit: 'кг',
+    price: 90,
+    expiry: '2025-10-02',
+    supplier: 'Морепродукты',
+    status: 'danger',
+  },
+  {
+    id: 4,
+    docNo: 'PR-103',
+    arrivalDate: '2025-09-28',
+    warehouse: 'Бар',
+    responsible: 'Сергеев Д.',
+    sku: 'BAR-001',
+    name: 'Лимон',
+    category: 'Фрукты',
+    qty: 20,
+    unit: 'шт',
+    price: 5,
+    expiry: '2025-10-15',
+    supplier: 'ФруктСнаб',
+    status: 'ok',
+  },
+];
+
+const currencyFormatter = new Intl.NumberFormat('ru-RU', {
+  style: 'currency',
+  currency: 'RUB',
+  maximumFractionDigits: 2,
+});
+
+describe('WarehousePageComponent', () => {
+  let fixture: ComponentFixture<WarehousePageComponent>;
+  let service: WarehouseService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [WarehousePageComponent],
+    }).compileComponents();
+
+    service = TestBed.inject(WarehouseService);
+    service.load(TEST_ROWS);
+
+    fixture = TestBed.createComponent(WarehousePageComponent);
+    fixture.detectChanges();
+  });
+
+  function getTableRows(): NodeListOf<HTMLTableRowElement> {
+    return fixture.nativeElement.querySelectorAll('tbody tr');
+  }
+
+  it('filters rows by search query', () => {
+    const input: HTMLInputElement = fixture.nativeElement.querySelector(
+      '[data-testid="supplies-search"]',
+    );
+    input.value = 'MEAT-001';
+    input.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+
+    const rows = getTableRows();
+    expect(rows.length).toBe(1);
+    expect(rows[0].textContent).toContain('PR-100');
+  });
+
+  it('filters rows by status', () => {
+    const select: HTMLSelectElement = fixture.nativeElement.querySelector(
+      '[data-testid="supplies-status-filter"]',
+    );
+    select.value = 'warning';
+    select.dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+
+    const rows = getTableRows();
+    expect(rows.length).toBe(1);
+    expect(rows[0].textContent).toContain('PR-101');
+  });
+
+  it('filters rows by warehouse', () => {
+    const select: HTMLSelectElement = fixture.nativeElement.querySelector(
+      '[data-testid="supplies-warehouse-filter"]',
+    );
+    select.value = 'Кухня';
+    select.dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+
+    const rows = getTableRows();
+    expect(rows.length).toBe(1);
+    expect(rows[0].textContent).toContain('PR-101');
+  });
+
+  it('filters rows by date range', () => {
+    const from: HTMLInputElement = fixture.nativeElement.querySelector(
+      '[data-testid="supplies-date-from"]',
+    );
+    const to: HTMLInputElement = fixture.nativeElement.querySelector(
+      '[data-testid="supplies-date-to"]',
+    );
+
+    from.value = '2025-09-27';
+    from.dispatchEvent(new Event('change'));
+    to.value = '2025-09-27';
+    to.dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+
+    const rows = getTableRows();
+    expect(rows.length).toBe(1);
+    expect(rows[0].textContent).toContain('PR-102');
+  });
+
+  it('displays calculated row sum using Intl number format', () => {
+    const sumCell: HTMLElement | null = fixture.nativeElement.querySelector('[data-testid="sum-1"]');
+    expect(sumCell).not.toBeNull();
+    expect(sumCell!.textContent?.trim()).toBe(currencyFormatter.format(200));
+  });
+
+  it('shows total sum for filtered rows', () => {
+    const expectedTotal = TEST_ROWS.reduce((acc, row) => acc + row.qty * row.price, 0);
+    const summary: HTMLElement = fixture.nativeElement.querySelector('[data-testid="supplies-summary"]');
+    expect(summary.textContent).toContain(currencyFormatter.format(expectedTotal));
+  });
+
+  it('toggles all rows via header checkbox', () => {
+    const headerCheckbox: HTMLInputElement = fixture.nativeElement.querySelector(
+      '[data-testid="supplies-header-checkbox"]',
+    );
+    headerCheckbox.click();
+    fixture.detectChanges();
+
+    const rowCheckboxes: NodeListOf<HTMLInputElement> = fixture.nativeElement.querySelectorAll(
+      '[data-testid="supplies-row-checkbox"]',
+    );
+    Array.from(rowCheckboxes).forEach((checkbox) => expect(checkbox.checked).toBeTrue());
+
+    headerCheckbox.click();
+    fixture.detectChanges();
+    Array.from(rowCheckboxes).forEach((checkbox) => expect(checkbox.checked).toBeFalse());
+  });
+
+  it('opens drawer on double click', () => {
+    const firstRow = getTableRows()[0];
+    firstRow.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
+    fixture.detectChanges();
+
+    const drawer = fixture.nativeElement.querySelector('.warehouse-page__drawer');
+    expect(drawer).not.toBeNull();
+    expect(drawer.textContent).toContain('PR-100');
+  });
+
+  it('deletes a single row via row menu', () => {
+    const menuButton: HTMLButtonElement = fixture.nativeElement.querySelector('[data-testid="row-menu-1"]');
+    menuButton.click();
+    fixture.detectChanges();
+
+    const deleteAction: HTMLButtonElement = fixture.nativeElement.querySelector('[data-testid="row-menu-delete-1"]');
+    deleteAction.click();
+    fixture.detectChanges();
+
+    const confirmButton: HTMLButtonElement = fixture.nativeElement.querySelector(
+      '.warehouse-page__dialog--confirm .btn.btn-danger',
+    );
+    confirmButton.click();
+    fixture.detectChanges();
+
+    const rows = Array.from(getTableRows()).map((row) => row.textContent ?? '');
+    expect(rows.some((text) => text.includes('PR-100'))).toBeFalse();
+  });
+
+  it('deletes selected rows via bulk delete', () => {
+    const headerCheckbox: HTMLInputElement = fixture.nativeElement.querySelector(
+      '[data-testid="supplies-header-checkbox"]',
+    );
+    headerCheckbox.click();
+    fixture.detectChanges();
+
+    const bulkDelete: HTMLButtonElement = fixture.nativeElement.querySelector('[data-testid="bulk-delete"]');
+    bulkDelete.click();
+    fixture.detectChanges();
+
+    const confirmButton: HTMLButtonElement = fixture.nativeElement.querySelector(
+      '.warehouse-page__dialog--confirm .btn.btn-danger',
+    );
+    confirmButton.click();
+    fixture.detectChanges();
+
+    expect(getTableRows().length).toBe(0);
+    const bulkCount = fixture.nativeElement.querySelector('.warehouse-page__bulk-count');
+    expect(bulkCount).toBeNull();
+  });
+});

--- a/feedme.client/src/app/warehouse/warehouse-page.component.ts
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.ts
@@ -1,70 +1,127 @@
-import { NgFor, NgIf } from '@angular/common';
-import { ChangeDetectionStrategy, Component, computed, signal } from '@angular/core';
+import { NgClass, NgFor, NgIf } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  HostListener,
+  computed,
+  effect,
+  inject,
+  signal,
+  viewChild,
+} from '@angular/core';
+import {
+  AbstractControl,
+  FormBuilder,
+  ReactiveFormsModule,
+  ValidationErrors,
+  Validators,
+} from '@angular/forms';
 
-import { SupplyRow } from './models';
+import { SupplyRow, SupplyStatus } from './models';
 import { WarehouseService } from './warehouse.service';
 import { FieldComponent } from './ui/field.component';
 import { MetricComponent } from './ui/metric.component';
 import { EmptyStateComponent } from './ui/empty-state.component';
+import { RubCurrencyPipe } from './ui/rub-currency.pipe';
+
+type DeleteDialogState = { ids: number[]; title: string } | null;
+
+type RowMenuAction = 'open' | 'edit' | 'delete';
 
 @Component({
   standalone: true,
   selector: 'app-warehouse-page',
   imports: [
+    NgClass,
     NgFor,
     NgIf,
+    ReactiveFormsModule,
     MetricComponent,
     FieldComponent,
     EmptyStateComponent,
+    RubCurrencyPipe,
   ],
   templateUrl: './warehouse-page.component.html',
   styleUrl: './warehouse-page.component.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class WarehousePageComponent {
+  private readonly warehouseService = inject(WarehouseService);
+  private readonly fb = inject(FormBuilder);
+
+  private readonly searchInputRef = viewChild<ElementRef<HTMLInputElement>>('searchInput');
+
   readonly activeTab = signal<'supplies' | 'stock' | 'catalog' | 'inventory'>('supplies');
+
   readonly query = signal('');
-  readonly status = signal<'ok' | 'warning' | 'danger' | ''>('');
+  readonly status = signal<SupplyStatus | ''>('');
   readonly supplier = signal('');
-  readonly selectedRows = signal<number[]>([]);
-  readonly drawerOpen = signal(false);
-  readonly dialogOpen = signal(false);
-  readonly selectedRow = signal<SupplyRow | null>(null);
+  readonly warehouse = signal('');
+  readonly dateFrom = signal<string>('');
+  readonly dateTo = signal<string>('');
+  readonly checkedIds = signal<number[]>([]);
+  readonly drawerRow = signal<SupplyRow | null>(null);
+  readonly openedMenuId = signal<number | null>(null);
+  readonly editDialogRow = signal<SupplyRow | null>(null);
+  readonly deleteDialogState = signal<DeleteDialogState>(null);
 
   readonly rows = this.warehouseService.list();
 
   readonly tabKeys = ['supplies', 'stock', 'catalog', 'inventory'] as const;
 
-  readonly suppliers = computed(() => {
-    const unique = new Set(this.rows().map((row) => row.supplier));
-    return Array.from(unique).sort((a, b) => a.localeCompare(b));
-  });
+  readonly suppliers = computed(() =>
+    Array.from(new Set(this.rows().map((row) => row.supplier))).sort((a, b) =>
+      a.localeCompare(b),
+    ),
+  );
+
+  readonly warehouses = computed(() =>
+    Array.from(new Set(this.rows().map((row) => row.warehouse))).sort((a, b) =>
+      a.localeCompare(b),
+    ),
+  );
 
   readonly filteredRows = computed(() => {
     const search = this.query().trim().toLowerCase();
     const statusFilter = this.status();
     const supplierFilter = this.supplier();
+    const warehouseFilter = this.warehouse();
+    const from = this.dateFrom();
+    const to = this.dateTo();
 
     return this.rows().filter((row) => {
       const matchesSearch = search
-        ? `${row.name}${row.sku}`.toLowerCase().includes(search)
+        ? `${row.docNo}${row.name}${row.sku}`.toLowerCase().includes(search)
         : true;
       const matchesStatus = statusFilter ? row.status === statusFilter : true;
       const matchesSupplier = supplierFilter ? row.supplier === supplierFilter : true;
+      const matchesWarehouse = warehouseFilter ? row.warehouse === warehouseFilter : true;
+      const matchesDateFrom = from ? row.arrivalDate >= from : true;
+      const matchesDateTo = to ? row.arrivalDate <= to : true;
 
-      return matchesSearch && matchesStatus && matchesSupplier;
+      return (
+        matchesSearch &&
+        matchesStatus &&
+        matchesSupplier &&
+        matchesWarehouse &&
+        matchesDateFrom &&
+        matchesDateTo
+      );
     });
   });
+
+  readonly totalSum = computed(() =>
+    this.filteredRows().reduce((sum, row) => sum + this.calculateRowTotal(row), 0),
+  );
 
   readonly allRowsChecked = computed(
     () =>
       this.filteredRows().length > 0 &&
-      this.selectedRows().length === this.filteredRows().length,
+      this.filteredRows().every((row) => this.checkedIds().includes(row.id)),
   );
 
-  readonly hasSelection = computed(() => this.selectedRows().length > 0);
-
-  constructor(private readonly warehouseService: WarehouseService) {}
+  readonly hasSelection = computed(() => this.checkedIds().length > 0);
 
   readonly tabLabels: Record<'supplies' | 'stock' | 'catalog' | 'inventory', string> = {
     supplies: 'Поставки',
@@ -73,57 +130,45 @@ export class WarehousePageComponent {
     inventory: 'Инвентаризация',
   };
 
+  readonly editForm = this.fb.nonNullable.group(
+    {
+      docNo: ['', [Validators.required, Validators.maxLength(32)]],
+      arrivalDate: ['', Validators.required],
+      warehouse: ['', Validators.required],
+      responsible: ['', [Validators.required, Validators.maxLength(64)]],
+      supplier: ['', [Validators.required, Validators.maxLength(64)]],
+      sku: ['', [Validators.required, Validators.maxLength(32)]],
+      name: ['', [Validators.required, Validators.maxLength(128)]],
+      category: ['', [Validators.required, Validators.maxLength(64)]],
+      qty: [0, [Validators.required, Validators.min(0)]],
+      unit: ['', [Validators.required, Validators.maxLength(16)]],
+      price: [0, [Validators.required, Validators.min(0)]],
+      expiry: ['', Validators.required],
+      status: ['ok' as SupplyStatus | '', Validators.required],
+    },
+    { validators: validateDateOrder },
+  );
+
+  constructor() {
+    effect(() => {
+      const availableIds = new Set(this.rows().map((row) => row.id));
+      const filteredIds = this.checkedIds().filter((id) => availableIds.has(id));
+      if (filteredIds.length !== this.checkedIds().length) {
+        this.checkedIds.set(filteredIds);
+      }
+
+      const selected = this.drawerRow();
+      if (selected && !availableIds.has(selected.id)) {
+        this.drawerRow.set(null);
+      }
+    });
+  }
+
   trackByRow = (_: number, row: SupplyRow) => row.id;
 
-  toggleRowSelection(id: number, checked: boolean): void {
-    const selection = new Set(this.selectedRows());
-    if (checked) {
-      selection.add(id);
-    } else {
-      selection.delete(id);
-    }
-    this.selectedRows.set(Array.from(selection).sort((a, b) => a - b));
-  }
-
-  toggleAll(checked: boolean): void {
-    if (checked) {
-      this.selectedRows.set(this.filteredRows().map((row) => row.id));
-      return;
-    }
-    this.selectedRows.set([]);
-  }
-
-  toggleAllFromEvent(event: Event): void {
-    const checkbox = event.target as HTMLInputElement | null;
-    this.toggleAll(checkbox?.checked ?? false);
-  }
-
-  openDrawer(row: SupplyRow): void {
-    this.selectedRow.set(row);
-    this.drawerOpen.set(true);
-  }
-
-  closeDrawer(): void {
-    this.drawerOpen.set(false);
-    this.selectedRow.set(null);
-  }
-
-  openDialog(): void {
-    this.dialogOpen.set(true);
-  }
-
-  closeDialog(): void {
-    this.dialogOpen.set(false);
-  }
-
-  clearFilters(): void {
-    this.query.set('');
-    this.status.set('');
-    this.supplier.set('');
-  }
-
-  selectTab(tab: 'supplies' | 'stock' | 'catalog' | 'inventory'): void {
-    this.activeTab.set(tab);
+  focusSearch(): void {
+    const element = this.searchInputRef()?.nativeElement;
+    element?.focus();
   }
 
   handleSearchChange(event: Event): void {
@@ -146,8 +191,349 @@ export class WarehousePageComponent {
     this.supplier.set(select?.value ?? '');
   }
 
-  handleRowSelection(id: number, event: Event): void {
-    const checkbox = event.target as HTMLInputElement | null;
-    this.toggleRowSelection(id, checkbox?.checked ?? false);
+  handleWarehouseChange(event: Event): void {
+    const select = event.target as HTMLSelectElement | null;
+    this.warehouse.set(select?.value ?? '');
   }
+
+  handleDateFromChange(event: Event): void {
+    const input = event.target as HTMLInputElement | null;
+    this.dateFrom.set(input?.value ?? '');
+  }
+
+  handleDateToChange(event: Event): void {
+    const input = event.target as HTMLInputElement | null;
+    this.dateTo.set(input?.value ?? '');
+  }
+
+  clearFilters(): void {
+    this.query.set('');
+    this.status.set('');
+    this.supplier.set('');
+    this.warehouse.set('');
+    this.dateFrom.set('');
+    this.dateTo.set('');
+    this.focusSearch();
+  }
+
+  toggleRowSelection(id: number, checked: boolean): void {
+    const selection = new Set(this.checkedIds());
+    if (checked) {
+      selection.add(id);
+    } else {
+      selection.delete(id);
+    }
+    this.checkedIds.set(Array.from(selection).sort((a, b) => a - b));
+  }
+
+  toggleAllFromEvent(event: Event): void {
+    const checkbox = event.target as HTMLInputElement | null;
+    const checked = checkbox?.checked ?? false;
+    if (checked) {
+      this.checkedIds.set(this.filteredRows().map((row) => row.id));
+      return;
+    }
+    this.checkedIds.set([]);
+  }
+
+  isRowChecked(id: number): boolean {
+    return this.checkedIds().includes(id);
+  }
+
+  handleRowCheckboxChange(row: SupplyRow, event: Event): void {
+    const checkbox = event.target as HTMLInputElement | null;
+    this.toggleRowSelection(row.id, checkbox?.checked ?? false);
+  }
+
+  handleRowDoubleClick(row: SupplyRow): void {
+    this.openDrawer(row);
+  }
+
+  openDrawer(row: SupplyRow): void {
+    this.drawerRow.set(row);
+  }
+
+  closeDrawer(): void {
+    this.drawerRow.set(null);
+  }
+
+  toggleRowMenu(rowId: number, event: Event): void {
+    event.stopPropagation();
+    this.openedMenuId.set(this.openedMenuId() === rowId ? null : rowId);
+  }
+
+  closeRowMenu(): void {
+    this.openedMenuId.set(null);
+  }
+
+  handleRowMenuAction(row: SupplyRow, action: RowMenuAction, event: Event): void {
+    event.stopPropagation();
+    this.closeRowMenu();
+    if (action === 'open') {
+      this.openDrawer(row);
+      return;
+    }
+    if (action === 'edit') {
+      this.openEditDialog(row);
+      return;
+    }
+    if (action === 'delete') {
+      this.openDeleteDialog([row.id], `${row.docNo} · ${row.name}`);
+    }
+  }
+
+  openEditDialog(row: SupplyRow): void {
+    this.editDialogRow.set(row);
+    this.editForm.reset({
+      docNo: row.docNo,
+      arrivalDate: row.arrivalDate,
+      warehouse: row.warehouse,
+      responsible: row.responsible,
+      supplier: row.supplier,
+      sku: row.sku,
+      name: row.name,
+      category: row.category,
+      qty: row.qty,
+      unit: row.unit,
+      price: row.price,
+      expiry: row.expiry,
+      status: row.status,
+    });
+  }
+
+  closeEditDialog(): void {
+    this.editDialogRow.set(null);
+  }
+
+  saveEdit(): void {
+    const row = this.editDialogRow();
+    if (!row) {
+      return;
+    }
+    if (this.editForm.invalid) {
+      this.editForm.markAllAsTouched();
+      return;
+    }
+    const value = this.editForm.getRawValue();
+    const updated: SupplyRow = {
+      id: row.id,
+      docNo: value.docNo,
+      arrivalDate: value.arrivalDate,
+      warehouse: value.warehouse,
+      responsible: value.responsible,
+      supplier: value.supplier,
+      sku: value.sku,
+      name: value.name,
+      category: value.category,
+      qty: value.qty,
+      unit: value.unit,
+      price: value.price,
+      expiry: value.expiry,
+      status: value.status as SupplyStatus,
+    };
+    this.warehouseService.updateRow(updated);
+    this.editDialogRow.set(null);
+    if (this.drawerRow()?.id === updated.id) {
+      this.drawerRow.set(updated);
+    }
+  }
+
+  openDeleteDialog(ids: number[], title: string): void {
+    this.deleteDialogState.set({ ids, title });
+  }
+
+  openBulkDelete(): void {
+    const ids = this.checkedIds();
+    if (ids.length === 0) {
+      return;
+    }
+    this.openDeleteDialog(ids, `Выбрано: ${ids.length}`);
+  }
+
+  closeDeleteDialog(): void {
+    this.deleteDialogState.set(null);
+  }
+
+  confirmDelete(): void {
+    const dialog = this.deleteDialogState();
+    if (!dialog) {
+      return;
+    }
+    this.warehouseService.removeRows(dialog.ids);
+    this.checkedIds.set([]);
+    const current = this.drawerRow();
+    if (current && dialog.ids.includes(current.id)) {
+      this.drawerRow.set(null);
+    }
+    this.deleteDialogState.set(null);
+  }
+
+  selectTab(tab: 'supplies' | 'stock' | 'catalog' | 'inventory'): void {
+    this.activeTab.set(tab);
+  }
+
+  handleMassWriteOff(ids: number[] = this.checkedIds()): void {
+    if (ids.length === 0) {
+      return;
+    }
+    const snapshot = this.rows();
+    ids.forEach((id) => {
+      const row = snapshot.find((item) => item.id === id);
+      if (row) {
+        this.warehouseService.updateRow({ ...row, status: 'danger' });
+      }
+    });
+    const drawer = this.drawerRow();
+    if (drawer && ids.includes(drawer.id)) {
+      const updated = this.rows().find((item) => item.id === drawer.id);
+      if (updated) {
+        this.drawerRow.set(updated);
+      }
+    }
+  }
+
+  handleMassMove(ids: number[] = this.checkedIds()): void {
+    if (ids.length === 0) {
+      return;
+    }
+    const snapshot = this.rows();
+    const targetWarehouse =
+      this.warehouse() || snapshot[0]?.warehouse || 'Главный склад';
+    ids.forEach((id) => {
+      const row = snapshot.find((item) => item.id === id);
+      if (row) {
+        this.warehouseService.updateRow({ ...row, warehouse: targetWarehouse });
+      }
+    });
+    const drawer = this.drawerRow();
+    if (drawer && ids.includes(drawer.id)) {
+      const updated = this.rows().find((item) => item.id === drawer.id);
+      if (updated) {
+        this.drawerRow.set(updated);
+      }
+    }
+  }
+
+  handleMassPrint(ids: number[] = this.checkedIds()): void {
+    if (ids.length === 0) {
+      return;
+    }
+    const rows = this.rows().filter((row) => ids.includes(row.id));
+    const content = rows
+      .map(
+        (row) =>
+          `${row.docNo}\t${row.sku}\t${row.name}\t${row.qty} ${row.unit}\t${row.warehouse}`,
+      )
+      .join('\n');
+    const blob = new Blob([content], { type: 'text/plain;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'labels.txt';
+    link.click();
+    URL.revokeObjectURL(url);
+  }
+
+  exportFiltered(): void {
+    const header = [
+      '№ док.',
+      'Дата прихода',
+      'Склад',
+      'Ответственный',
+      'SKU',
+      'Название',
+      'Категория',
+      'Кол-во',
+      'Ед.',
+      'Цена',
+      'Сумма',
+      'Срок годности',
+      'Поставщик',
+      'Статус',
+    ];
+    const rows = this.filteredRows().map((row) => [
+      row.docNo,
+      row.arrivalDate,
+      row.warehouse,
+      row.responsible,
+      row.sku,
+      row.name,
+      row.category,
+      row.qty.toString(),
+      row.unit,
+      row.price.toString(),
+      this.calculateRowTotal(row).toString(),
+      row.expiry,
+      row.supplier,
+      row.status,
+    ]);
+    const csv = [header, ...rows]
+      .map((columns) =>
+        columns
+          .map((value) => {
+            const safe = value.replaceAll('"', '""');
+            return `"${safe}"`;
+          })
+          .join(','),
+      )
+      .join('\n');
+
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'supplies.csv';
+    link.click();
+    URL.revokeObjectURL(url);
+  }
+
+  calculateRowTotal(row: SupplyRow): number {
+    return row.qty * row.price;
+  }
+
+  badgeClass(status: SupplyStatus): string {
+    if (status === 'danger') {
+      return 'badge badge-danger';
+    }
+    if (status === 'warning') {
+      return 'badge badge-soft';
+    }
+    return 'badge';
+  }
+
+  statusLabel(status: SupplyStatus): string {
+    if (status === 'danger') {
+      return 'Просрочено';
+    }
+    if (status === 'warning') {
+      return 'Скоро срок';
+    }
+    return 'Ок';
+  }
+
+  get deleteDialog(): DeleteDialogState {
+    return this.deleteDialogState();
+  }
+
+  get editDialogVisible(): boolean {
+    return this.editDialogRow() !== null;
+  }
+
+  @HostListener('window:keydown', ['$event'])
+  handleWindowKeydown(event: KeyboardEvent): void {
+    if (event.key === '/' && !event.altKey && !event.ctrlKey && !event.metaKey) {
+      event.preventDefault();
+      this.focusSearch();
+    }
+  }
+
+}
+
+function validateDateOrder(control: AbstractControl): ValidationErrors | null {
+  const arrival = control.get('arrivalDate')?.value as string | undefined;
+  const expiry = control.get('expiry')?.value as string | undefined;
+  if (!arrival || !expiry) {
+    return null;
+  }
+  return arrival <= expiry ? null : { dateRange: true };
 }

--- a/feedme.client/src/app/warehouse/warehouse.service.ts
+++ b/feedme.client/src/app/warehouse/warehouse.service.ts
@@ -7,6 +7,10 @@ export class WarehouseService {
   private readonly rowsSignal = signal<SupplyRow[]>([
     {
       id: 1,
+      docNo: 'PR-000851',
+      arrivalDate: '2025-09-26',
+      warehouse: 'Главный склад',
+      responsible: 'Иванов И.',
       sku: 'MEAT-001',
       name: 'Курица охлажд.',
       category: 'Мясные заготовки',
@@ -19,10 +23,14 @@ export class WarehouseService {
     },
     {
       id: 2,
+      docNo: 'PR-000852',
+      arrivalDate: '2025-09-26',
+      warehouse: 'Кухня',
+      responsible: 'Петров П.',
       sku: 'MEAT-002',
       name: 'Говядина',
       category: 'Мясные заготовки',
-      qty: 11,
+      qty: 45,
       unit: 'кг',
       price: 450,
       expiry: '2025-09-28',
@@ -31,6 +39,10 @@ export class WarehouseService {
     },
     {
       id: 3,
+      docNo: 'PR-000853',
+      arrivalDate: '2025-09-27',
+      warehouse: 'Главный склад',
+      responsible: 'Сидорова А.',
       sku: 'VEG-011',
       name: 'Лук репчатый',
       category: 'Овощи',
@@ -43,6 +55,10 @@ export class WarehouseService {
     },
     {
       id: 4,
+      docNo: 'PR-000854',
+      arrivalDate: '2025-09-27',
+      warehouse: 'Бар',
+      responsible: 'Сергеев Д.',
       sku: 'DAIRY-004',
       name: 'Сливки 33%',
       category: 'Молочные',
@@ -56,4 +72,22 @@ export class WarehouseService {
   ]);
 
   readonly list = () => this.rowsSignal.asReadonly();
+
+  load(rows: SupplyRow[]): void {
+    this.rowsSignal.set(rows.map((row) => ({ ...row })));
+  }
+
+  updateRow(updated: SupplyRow): void {
+    this.rowsSignal.update((rows) =>
+      rows.map((row) => (row.id === updated.id ? { ...updated } : row)),
+    );
+  }
+
+  removeRows(ids: readonly number[]): void {
+    if (ids.length === 0) {
+      return;
+    }
+    const removeSet = new Set(ids);
+    this.rowsSignal.update((rows) => rows.filter((row) => !removeSet.has(row.id)));
+  }
 }


### PR DESCRIPTION
## Summary
- rebuild the supplies tab with an expanded filter panel, warehouse/date filters, sticky table header, inline row menu, and currency-formatted totals
- add editable drawer with action buttons, reusable RUB currency pipe, and CSV export support driven by signal-based state
- extend the warehouse service with update/delete helpers and cover the new UX flow with Karma component tests for filtering, totals, selection, and deletion

## Testing
- npm test *(fails: ChromeHeadless cannot start because libatk-1.0.so.0 is missing in the runner)*

------
https://chatgpt.com/codex/tasks/task_e_68d8802192d88323b81482572ddfd977