### PR TITLE
Fix template event handlers for warehouse filters

### DIFF
--- a/feedme.client/src/app/warehouse/warehouse-page.component.html
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.html
@@ -64,15 +64,16 @@
               type="search"
               placeholder="№ документа, название или SKU (/)"
               [value]="query()"
-              (input)="updateQuery(($event.target as HTMLInputElement).value)"
+              (input)="updateQuery(searchInput.value)"
             />
           </label>
           <label class="warehouse-page__filter">
             <span class="warehouse-page__filter-label">Статус</span>
             <select
+              #statusSelect
               class="select"
               [value]="status()"
-              (change)="updateStatus(($event.target as HTMLSelectElement).value)"
+              (change)="updateStatus(statusSelect.value)"
             >
               <option value="">Все</option>
               <option value="ok">Ок</option>
@@ -83,9 +84,10 @@
           <label class="warehouse-page__filter">
             <span class="warehouse-page__filter-label">Поставщик</span>
             <select
+              #supplierSelect
               class="select"
               [value]="supplier()"
-              (change)="updateSupplier(($event.target as HTMLSelectElement).value)"
+              (change)="updateSupplier(supplierSelect.value)"
             >
               <option value="">Все поставщики</option>
               <option *ngFor="let option of suppliers()" [value]="option">{{ option }}</option>
@@ -94,9 +96,10 @@
           <label class="warehouse-page__filter">
             <span class="warehouse-page__filter-label">Склад</span>
             <select
+              #warehouseSelect
               class="select"
               [value]="warehouseFilter()"
-              (change)="updateWarehouse(($event.target as HTMLSelectElement).value)"
+              (change)="updateWarehouse(warehouseSelect.value)"
             >
               <option value="">Все склады</option>
               <option *ngFor="let option of warehouses()" [value]="option">{{ option }}</option>
@@ -105,19 +108,21 @@
           <label class="warehouse-page__filter warehouse-page__filter--date">
             <span class="warehouse-page__filter-label">Дата прихода от</span>
             <input
+              #dateFromInput
               class="input"
               type="date"
               [value]="dateFrom()"
-              (change)="updateDateFrom(($event.target as HTMLInputElement).value)"
+              (change)="updateDateFrom(dateFromInput.value)"
             />
           </label>
           <label class="warehouse-page__filter warehouse-page__filter--date">
             <span class="warehouse-page__filter-label">Дата прихода до</span>
             <input
+              #dateToInput
               class="input"
               type="date"
               [value]="dateTo()"
-              (change)="updateDateTo(($event.target as HTMLInputElement).value)"
+              (change)="updateDateTo(dateToInput.value)"
             />
           </label>
           <div class="warehouse-page__filters-actions">


### PR DESCRIPTION
## Summary
- replace the warehouse filter input bindings that used TypeScript casts with template reference variables
- ensure select and date controls read their values via template refs so Angular can parse the expressions correctly

## Testing
- node ./node_modules/@angular/cli/bin/ng lint *(fails: `ansiRegex is not a function` from the Angular CLI runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68d886c5b2fc8323a4766d02c1ba8d4a