### PR TITLE
feat: enhance warehouse stock tab

### DIFF
--- a/feedme.client/src/app/warehouse/models.ts
+++ b/feedme.client/src/app/warehouse/models.ts
@@ -12,3 +12,21 @@ export interface SupplyRow {
   readonly supplier: string;
   readonly status: StockStatus;
 }
+
+export interface StockRow {
+  readonly id: number;
+  readonly sku: string;
+  readonly name: string;
+  readonly category: string;
+  readonly warehouse: string;
+  readonly quantity: number;
+  readonly unit: string;
+  readonly expiryDate: string;
+  readonly primarySupplier: string;
+  readonly comments: string;
+}
+
+export interface ResolvedStockRow extends StockRow {
+  readonly daysToExpiry: number;
+  readonly expiryStatus: StockStatus;
+}

--- a/feedme.client/src/app/warehouse/warehouse-page.component.css
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.css
@@ -280,8 +280,59 @@
   text-decoration: underline;
 }
 
-.warehouse-page__table tbody tr:hover {
+.warehouse-page__cell--strong {
+  font-weight: 600;
+  color: #111827;
+}
+
+.warehouse-page__table tbody tr:not(.warehouse-page__stock-row):hover {
   background-color: #f8fafc;
+}
+
+.warehouse-page__stock-row {
+  cursor: pointer;
+  transition: background-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.warehouse-page__stock-row:focus,
+.warehouse-page__stock-row:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: -2px;
+}
+
+.warehouse-page__stock-row--ok {
+  background-color: #f0fdf4;
+  box-shadow: inset 4px 0 0 #22c55e;
+}
+
+.warehouse-page__stock-row--warning {
+  background-color: #fffbeb;
+  box-shadow: inset 4px 0 0 #facc15;
+}
+
+.warehouse-page__stock-row--danger {
+  background-color: #fef2f2;
+  box-shadow: inset 4px 0 0 #ef4444;
+}
+
+.warehouse-page__stock-row--ok:hover,
+.warehouse-page__stock-row--warning:hover,
+.warehouse-page__stock-row--danger:hover {
+  filter: brightness(0.97);
+}
+
+.warehouse-page__expiry-date {
+  display: block;
+}
+
+.warehouse-page__expiry-hint {
+  display: inline-block;
+  margin-top: 4px;
+  padding: 2px 6px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  background-color: #e2e8f0;
+  color: #475569;
 }
 
 .warehouse-page__table-footer {
@@ -304,6 +355,14 @@
   justify-content: center;
   align-items: center;
   padding: 48px 0;
+}
+
+.warehouse-page__empty-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  padding: 40px 0;
 }
 
 .warehouse-page__drawer {

--- a/feedme.client/src/app/warehouse/warehouse-page.component.html
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.html
@@ -148,7 +148,7 @@
                   </td>
                   <td class="warehouse-page__cell warehouse-page__cell--mono">{{ row.sku }}</td>
                   <td class="warehouse-page__cell warehouse-page__cell--link">
-                    <button type="button" (click)="openDrawer(row)">{{ row.name }}</button>
+                    <button type="button" (click)="openSupplyDrawer(row)">{{ row.name }}</button>
                   </td>
                   <td class="warehouse-page__cell">{{ row.category }}</td>
                   <td class="warehouse-page__cell warehouse-page__cell--numeric">{{ row.qty }} {{ row.unit }}</td>
@@ -175,9 +175,114 @@
         </section>
       </section>
 
-      <section *ngIf="activeTab() === 'stock'" class="warehouse-page__empty">
-        <app-empty title="Остатки" subtitle="Выберите склад и примените фильтры"></app-empty>
+      <section *ngIf="activeTab() === 'stock'" class="warehouse-page__tab-panel">
+        <form class="warehouse-page__filters" (submit)="$event.preventDefault()">
+          <label class="warehouse-page__filter">
+            <span class="warehouse-page__filter-label">Поиск</span>
+            <input
+              class="input"
+              type="search"
+              placeholder="SKU, название или категория"
+              [value]="stockQuery()"
+              (input)="handleStockSearchChange($event)"
+            />
+          </label>
+          <label class="warehouse-page__filter">
+            <span class="warehouse-page__filter-label">Склад</span>
+            <select
+              class="select"
+              [value]="stockWarehouse()"
+              (change)="handleStockWarehouseChange($event)"
+            >
+              <option value="">Все склады</option>
+              <option *ngFor="let location of stockWarehouses" [value]="location">{{ location }}</option>
+            </select>
+          </label>
+          <label class="warehouse-page__filter">
+            <span class="warehouse-page__filter-label">Срок годности</span>
+            <select
+              class="select"
+              [value]="stockExpiryFilter()"
+              (change)="handleStockExpiryChange($event)"
+            >
+              <option *ngFor="let option of stockExpiryOptions" [value]="option.value">{{ option.label }}</option>
+            </select>
+          </label>
+          <div class="warehouse-page__filters-actions">
+            <button type="button" class="btn btn-outline" (click)="clearStockFilters()">Сброс</button>
+            <button type="button" class="btn btn-secondary" (click)="exportStock()">Экспорт</button>
+          </div>
+        </form>
+
+        <section class="warehouse-page__table-card">
+          <header class="warehouse-page__table-header">Остатки по складам</header>
+          <ng-container *ngIf="hasStockRows(); else stockEmpty">
+            <div class="warehouse-page__table-wrapper">
+              <table class="warehouse-page__table">
+                <thead>
+                  <tr>
+                    <th class="warehouse-page__cell">SKU</th>
+                    <th class="warehouse-page__cell">Название</th>
+                    <th class="warehouse-page__cell">Категория</th>
+                    <th class="warehouse-page__cell">Склад</th>
+                    <th class="warehouse-page__cell warehouse-page__cell--numeric">Кол-во</th>
+                    <th class="warehouse-page__cell">Срок годности</th>
+                    <th class="warehouse-page__cell">Поставщик (осн.)</th>
+                    <th class="warehouse-page__cell">Статус срока годности</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr
+                    *ngFor="let row of filteredStockRows(); trackBy: trackByStockRow"
+                    class="warehouse-page__stock-row"
+                    [class.warehouse-page__stock-row--ok]="row.expiryStatus === 'ok'"
+                    [class.warehouse-page__stock-row--warning]="row.expiryStatus === 'warning'"
+                    [class.warehouse-page__stock-row--danger]="row.expiryStatus === 'danger'"
+                    (dblclick)="openStockDrawer(row)"
+                    (keydown)="handleStockRowKeydown(row, $event)"
+                    tabindex="0"
+                  >
+                    <td class="warehouse-page__cell warehouse-page__cell--mono">{{ row.sku }}</td>
+                    <td class="warehouse-page__cell warehouse-page__cell--strong">{{ row.name }}</td>
+                    <td class="warehouse-page__cell">{{ row.category }}</td>
+                    <td class="warehouse-page__cell">{{ row.warehouse }}</td>
+                    <td class="warehouse-page__cell warehouse-page__cell--numeric">{{ row.quantity | number:'1.0-2' }} {{ row.unit }}</td>
+                    <td class="warehouse-page__cell">
+                      <span class="warehouse-page__expiry-date">{{ row.expiryDate }}</span>
+                      <span class="warehouse-page__expiry-hint">
+                        <ng-container *ngIf="row.daysToExpiry >= 0; else expiredHint">
+                          Осталось {{ row.daysToExpiry }} д.
+                        </ng-container>
+                        <ng-template #expiredHint>Просрочено на {{ (row.daysToExpiry * -1) }} д.</ng-template>
+                      </span>
+                    </td>
+                    <td class="warehouse-page__cell">{{ row.primarySupplier }}</td>
+                    <td class="warehouse-page__cell">
+                      <span *ngIf="row.expiryStatus === 'ok'" class="badge">В норме</span>
+                      <span *ngIf="row.expiryStatus === 'warning'" class="badge badge-soft">Скоро срок</span>
+                      <span *ngIf="row.expiryStatus === 'danger'" class="badge badge-danger">Просрочено</span>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </ng-container>
+          <footer class="warehouse-page__table-footer">
+            <span>Показано {{ filteredStockRows().length }} строк. Общий остаток: {{ stockQuantityTotal() | number:'1.0-2' }} ед.</span>
+            <div class="warehouse-page__pagination">
+              <button type="button" class="btn btn-outline btn-sm">Назад</button>
+              <button type="button" class="btn btn-outline btn-sm">Далее</button>
+            </div>
+          </footer>
+        </section>
       </section>
+
+      <ng-template #stockEmpty>
+        <div class="warehouse-page__empty-card">
+          <app-empty title="Нет данных" subtitle="Попробуйте изменить фильтры или добавьте новый остаток"></app-empty>
+          <button type="button" class="btn" (click)="handleAddStock()">Добавить остаток</button>
+        </div>
+      </ng-template>
       <section *ngIf="activeTab() === 'catalog'" class="warehouse-page__empty">
         <app-empty title="Каталог" subtitle="Импортируйте CSV или создайте первую позицию"></app-empty>
       </section>
@@ -187,35 +292,70 @@
     </section>
   </main>
 
-  <aside class="warehouse-page__drawer" *ngIf="drawerOpen()">
-    <section class="warehouse-page__drawer-content" *ngIf="selectedRow() as row">
-      <header class="warehouse-page__drawer-header">
-        <div>
-          <div class="warehouse-page__drawer-sku">SKU {{ row.sku }}</div>
-          <div class="warehouse-page__drawer-title">{{ row.name }}</div>
-        </div>
-        <span *ngIf="row.status === 'warning'" class="badge badge-soft">Скоро срок</span>
-        <span *ngIf="row.status === 'danger'" class="badge badge-danger">Просрочено</span>
-      </header>
-      <div class="warehouse-page__drawer-grid">
-        <app-field label="Категория" [value]="row.category"></app-field>
-        <app-field label="Поставщик" [value]="row.supplier"></app-field>
-        <app-field label="Количество" [value]="row.qty + ' ' + row.unit"></app-field>
-        <app-field label="Цена закупки" [value]="row.price + ' ₽'"></app-field>
-        <app-field label="Срок годности" [value]="row.expiry"></app-field>
-      </div>
-      <footer class="warehouse-page__drawer-actions">
-        <button type="button" class="btn btn-outline btn-sm">Списать</button>
-        <button type="button" class="btn btn-outline btn-sm">Переместить</button>
-        <button type="button" class="btn btn-sm">Печать ярлыков</button>
-        <button type="button" class="btn btn-ghost btn-sm" (click)="closeDrawer()">Закрыть</button>
-      </footer>
+  <aside class="warehouse-page__drawer" *ngIf="drawerEntry() as entry">
+    <section class="warehouse-page__drawer-content">
+      <ng-container [ngSwitch]="entry.kind">
+        <ng-container *ngSwitchCase="'supply'" [ngTemplateOutlet]="supplyDrawer" [ngTemplateOutletContext]="{ $implicit: entry.record }"></ng-container>
+        <ng-container *ngSwitchCase="'stock'" [ngTemplateOutlet]="stockDrawer" [ngTemplateOutletContext]="{ $implicit: entry.record }"></ng-container>
+      </ng-container>
     </section>
   </aside>
 
+  <ng-template #supplyDrawer let-row>
+    <header class="warehouse-page__drawer-header">
+      <div>
+        <div class="warehouse-page__drawer-sku">SKU {{ row.sku }}</div>
+        <div class="warehouse-page__drawer-title">{{ row.name }}</div>
+      </div>
+      <span *ngIf="row.status === 'warning'" class="badge badge-soft">Скоро срок</span>
+      <span *ngIf="row.status === 'danger'" class="badge badge-danger">Просрочено</span>
+    </header>
+    <div class="warehouse-page__drawer-grid">
+      <app-field label="Категория" [value]="row.category"></app-field>
+      <app-field label="Поставщик" [value]="row.supplier"></app-field>
+      <app-field label="Количество" [value]="row.qty + ' ' + row.unit"></app-field>
+      <app-field label="Цена закупки" [value]="row.price + ' ₽'"></app-field>
+      <app-field label="Срок годности" [value]="row.expiry"></app-field>
+    </div>
+    <footer class="warehouse-page__drawer-actions">
+      <button type="button" class="btn btn-outline btn-sm">Списать</button>
+      <button type="button" class="btn btn-outline btn-sm">Переместить</button>
+      <button type="button" class="btn btn-sm">Печать ярлыков</button>
+      <button type="button" class="btn btn-ghost btn-sm" (click)="closeDrawer()">Закрыть</button>
+    </footer>
+  </ng-template>
+
+  <ng-template #stockDrawer let-row>
+    <header class="warehouse-page__drawer-header">
+      <div>
+        <div class="warehouse-page__drawer-sku">SKU {{ row.sku }}</div>
+        <div class="warehouse-page__drawer-title">{{ row.name }}</div>
+      </div>
+      <span *ngIf="row.expiryStatus === 'ok'" class="badge">В норме</span>
+      <span *ngIf="row.expiryStatus === 'warning'" class="badge badge-soft">Скоро срок</span>
+      <span *ngIf="row.expiryStatus === 'danger'" class="badge badge-danger">Просрочено</span>
+    </header>
+    <div class="warehouse-page__drawer-grid">
+      <app-field label="Категория" [value]="row.category"></app-field>
+      <app-field label="Склад" [value]="row.warehouse"></app-field>
+      <app-field label="Количество" [value]="row.quantity + ' ' + row.unit"></app-field>
+      <app-field label="Срок годности" [value]="row.expiryDate + ' (' + row.daysToExpiry + ' д.)'"></app-field>
+      <app-field label="Поставщик (осн.)" [value]="row.primarySupplier"></app-field>
+      <app-field label="Комментарии" [value]="row.comments"></app-field>
+    </div>
+    <footer class="warehouse-page__drawer-actions">
+      <button type="button" class="btn btn-outline btn-sm">Списать</button>
+      <button type="button" class="btn btn-outline btn-sm">Переместить</button>
+      <button type="button" class="btn btn-sm">Редактировать</button>
+      <button type="button" class="btn btn-ghost btn-sm" (click)="closeDrawer()">Закрыть</button>
+    </footer>
+  </ng-template>
+
   <div class="warehouse-page__dialog-backdrop" *ngIf="dialogOpen()">
-    <section class="warehouse-page__dialog" role="dialog" aria-modal="true" aria-labelledby="new-supply-title">
-      <header class="warehouse-page__dialog-header" id="new-supply-title">Новая поставка</header>
+    <section class="warehouse-page__dialog" role="dialog" aria-modal="true" aria-labelledby="warehouse-dialog-title">
+      <header class="warehouse-page__dialog-header" id="warehouse-dialog-title">
+        {{ dialogContext() === 'supply' ? 'Новая поставка' : 'Новый остаток' }}
+      </header>
       <div class="warehouse-page__dialog-grid">
         <label class="warehouse-page__dialog-field">
           <span class="warehouse-page__dialog-label">Поставщик</span>

--- a/feedme.client/src/app/warehouse/warehouse-page.component.ts
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.ts
@@ -1,11 +1,15 @@
-import { NgFor, NgIf } from '@angular/common';
+import { NgFor, NgIf, NgSwitch, NgSwitchCase, NgTemplateOutlet } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, signal } from '@angular/core';
 
-import { SupplyRow } from './models';
+import { ResolvedStockRow, StockStatus, SupplyRow } from './models';
 import { WarehouseService } from './warehouse.service';
 import { FieldComponent } from './ui/field.component';
 import { MetricComponent } from './ui/metric.component';
 import { EmptyStateComponent } from './ui/empty-state.component';
+
+type DrawerEntry =
+  | { readonly kind: 'supply'; readonly record: SupplyRow }
+  | { readonly kind: 'stock'; readonly record: ResolvedStockRow };
 
 @Component({
   standalone: true,
@@ -16,6 +20,9 @@ import { EmptyStateComponent } from './ui/empty-state.component';
     MetricComponent,
     FieldComponent,
     EmptyStateComponent,
+    NgSwitch,
+    NgSwitchCase,
+    NgTemplateOutlet,
   ],
   templateUrl: './warehouse-page.component.html',
   styleUrl: './warehouse-page.component.css',
@@ -27,11 +34,24 @@ export class WarehousePageComponent {
   readonly status = signal<'ok' | 'warning' | 'danger' | ''>('');
   readonly supplier = signal('');
   readonly selectedRows = signal<number[]>([]);
-  readonly drawerOpen = signal(false);
   readonly dialogOpen = signal(false);
-  readonly selectedRow = signal<SupplyRow | null>(null);
+  readonly drawerEntry = signal<DrawerEntry | null>(null);
+  readonly dialogContext = signal<'supply' | 'stock'>('supply');
+
+  readonly stockQuery = signal('');
+  readonly stockWarehouse = signal('');
+  readonly stockExpiryFilter = signal<'7' | '14' | ''>('');
+
+  readonly stockWarehouses = ['Главный склад', 'Кухня', 'Бар', 'Холодильник'] as const;
+
+  readonly stockExpiryOptions: ReadonlyArray<{ readonly value: '' | '7' | '14'; readonly label: string }> = [
+    { value: '', label: 'Все сроки' },
+    { value: '7', label: '≤ 7 дней' },
+    { value: '14', label: '≤ 14 дней' },
+  ];
 
   readonly rows = this.warehouseService.list();
+  readonly stockRows = this.warehouseService.listStock();
 
   readonly tabKeys = ['supplies', 'stock', 'catalog', 'inventory'] as const;
 
@@ -39,6 +59,17 @@ export class WarehousePageComponent {
     const unique = new Set(this.rows().map((row) => row.supplier));
     return Array.from(unique).sort((a, b) => a.localeCompare(b));
   });
+
+  readonly resolvedStockRows = computed<ResolvedStockRow[]>(() =>
+    this.stockRows().map((row) => {
+      const daysToExpiry = this.calculateDaysToExpiry(row.expiryDate);
+      return {
+        ...row,
+        daysToExpiry,
+        expiryStatus: this.resolveExpiryStatus(daysToExpiry),
+      } satisfies ResolvedStockRow;
+    }),
+  );
 
   readonly filteredRows = computed(() => {
     const search = this.query().trim().toLowerCase();
@@ -56,6 +87,34 @@ export class WarehousePageComponent {
     });
   });
 
+  readonly filteredStockRows = computed(() => {
+    const search = this.stockQuery().trim().toLowerCase();
+    const warehouseFilter = this.stockWarehouse();
+    const expiryFilter = this.stockExpiryFilter();
+
+    const filtered = this.resolvedStockRows().filter((row) => {
+      const matchesSearch = search
+        ? `${row.sku} ${row.name} ${row.category}`.toLowerCase().includes(search)
+        : true;
+      const matchesWarehouse = warehouseFilter ? row.warehouse === warehouseFilter : true;
+      const matchesExpiry =
+        expiryFilter === '7'
+          ? row.daysToExpiry <= 7
+          : expiryFilter === '14'
+            ? row.daysToExpiry <= 14
+            : true;
+
+      return matchesSearch && matchesWarehouse && matchesExpiry;
+    });
+
+    return [...filtered].sort((a, b) => {
+      if (a.daysToExpiry !== b.daysToExpiry) {
+        return a.daysToExpiry - b.daysToExpiry;
+      }
+      return a.sku.localeCompare(b.sku);
+    });
+  });
+
   readonly allRowsChecked = computed(
     () =>
       this.filteredRows().length > 0 &&
@@ -63,6 +122,10 @@ export class WarehousePageComponent {
   );
 
   readonly hasSelection = computed(() => this.selectedRows().length > 0);
+  readonly hasStockRows = computed(() => this.filteredStockRows().length > 0);
+  readonly stockQuantityTotal = computed(() =>
+    this.filteredStockRows().reduce((total, row) => total + row.quantity, 0),
+  );
 
   constructor(private readonly warehouseService: WarehouseService) {}
 
@@ -74,6 +137,7 @@ export class WarehousePageComponent {
   };
 
   trackByRow = (_: number, row: SupplyRow) => row.id;
+  trackByStockRow = (_: number, row: ResolvedStockRow) => row.id;
 
   toggleRowSelection(id: number, checked: boolean): void {
     const selection = new Set(this.selectedRows());
@@ -98,17 +162,20 @@ export class WarehousePageComponent {
     this.toggleAll(checkbox?.checked ?? false);
   }
 
-  openDrawer(row: SupplyRow): void {
-    this.selectedRow.set(row);
-    this.drawerOpen.set(true);
+  openSupplyDrawer(row: SupplyRow): void {
+    this.drawerEntry.set({ kind: 'supply', record: row });
+  }
+
+  openStockDrawer(row: ResolvedStockRow): void {
+    this.drawerEntry.set({ kind: 'stock', record: row });
   }
 
   closeDrawer(): void {
-    this.drawerOpen.set(false);
-    this.selectedRow.set(null);
+    this.drawerEntry.set(null);
   }
 
   openDialog(): void {
+    this.dialogContext.set('supply');
     this.dialogOpen.set(true);
   }
 
@@ -120,6 +187,12 @@ export class WarehousePageComponent {
     this.query.set('');
     this.status.set('');
     this.supplier.set('');
+  }
+
+  clearStockFilters(): void {
+    this.stockQuery.set('');
+    this.stockWarehouse.set('');
+    this.stockExpiryFilter.set('');
   }
 
   selectTab(tab: 'supplies' | 'stock' | 'catalog' | 'inventory'): void {
@@ -149,5 +222,113 @@ export class WarehousePageComponent {
   handleRowSelection(id: number, event: Event): void {
     const checkbox = event.target as HTMLInputElement | null;
     this.toggleRowSelection(id, checkbox?.checked ?? false);
+  }
+
+  handleStockSearchChange(event: Event): void {
+    const input = event.target as HTMLInputElement | null;
+    this.stockQuery.set(input?.value ?? '');
+  }
+
+  handleStockWarehouseChange(event: Event): void {
+    const select = event.target as HTMLSelectElement | null;
+    this.stockWarehouse.set(select?.value ?? '');
+  }
+
+  handleStockExpiryChange(event: Event): void {
+    const select = event.target as HTMLSelectElement | null;
+    const value = select?.value ?? '';
+    if (value === '7' || value === '14') {
+      this.stockExpiryFilter.set(value);
+      return;
+    }
+    this.stockExpiryFilter.set('');
+  }
+
+  handleStockRowKeydown(row: ResolvedStockRow, event: KeyboardEvent): void {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      this.openStockDrawer(row);
+    }
+  }
+
+  exportStock(): void {
+    const headers = [
+      'SKU',
+      'Название',
+      'Категория',
+      'Склад',
+      'Количество',
+      'Срок годности',
+      'Поставщик (осн.)',
+      'Статус срока годности',
+      'Дней до окончания',
+    ];
+
+    const rows = this.filteredStockRows();
+    const csvLines = rows.map((row) =>
+      [
+        row.sku,
+        row.name,
+        row.category,
+        row.warehouse,
+        `${row.quantity} ${row.unit}`,
+        row.expiryDate,
+        row.primarySupplier,
+        this.getStatusLabel(row.expiryStatus),
+        String(row.daysToExpiry),
+      ]
+        .map((value) => `"${value.replace(/"/g, '""')}"`)
+        .join(';'),
+    );
+
+    const csvContent = [headers.join(';'), ...csvLines].join('\n');
+    const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.download = `stock-${new Date().toISOString().slice(0, 10)}.csv`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(link.href);
+  }
+
+  handleAddStock(): void {
+    this.dialogContext.set('stock');
+    this.dialogOpen.set(true);
+  }
+
+  private calculateDaysToExpiry(expiryDate: string): number {
+    const [year, month, day] = expiryDate.split('-').map(Number);
+    const target = new Date(year, (month ?? 1) - 1, day ?? 1);
+    target.setHours(0, 0, 0, 0);
+
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    const diff = target.getTime() - today.getTime();
+    return Math.floor(diff / (1000 * 60 * 60 * 24));
+  }
+
+  private resolveExpiryStatus(daysToExpiry: number): StockStatus {
+    if (daysToExpiry < 0) {
+      return 'danger';
+    }
+    if (daysToExpiry <= 14) {
+      return 'warning';
+    }
+    return 'ok';
+  }
+
+  private getStatusLabel(status: StockStatus): string {
+    switch (status) {
+      case 'ok':
+        return 'В норме';
+      case 'warning':
+        return 'Скоро срок';
+      case 'danger':
+        return 'Просрочено';
+      default:
+        return '';
+    }
   }
 }

--- a/feedme.client/src/app/warehouse/warehouse.service.ts
+++ b/feedme.client/src/app/warehouse/warehouse.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, signal } from '@angular/core';
 
-import { SupplyRow } from './models';
+import { StockRow, SupplyRow } from './models';
 
 @Injectable({ providedIn: 'root' })
 export class WarehouseService {
@@ -56,4 +56,93 @@ export class WarehouseService {
   ]);
 
   readonly list = () => this.rowsSignal.asReadonly();
+
+  private readonly stockRowsSignal = signal<StockRow[]>([
+    {
+      id: 101,
+      sku: 'VEG-011',
+      name: 'Лук репчатый',
+      category: 'Овощи',
+      warehouse: 'Главный склад',
+      quantity: 35,
+      unit: 'кг',
+      expiryDate: '2025-10-15',
+      primarySupplier: 'АгроФреш',
+      comments: 'Хранить в темноте при +4°C.',
+    },
+    {
+      id: 102,
+      sku: 'DAIRY-004',
+      name: 'Сливки 33%',
+      category: 'Молочные продукты',
+      warehouse: 'Бар',
+      quantity: 12.1,
+      unit: 'л',
+      expiryDate: '2025-10-01',
+      primarySupplier: 'МолКомбинат',
+      comments: 'Партия для капучино, следить за охлаждением.',
+    },
+    {
+      id: 103,
+      sku: 'MEAT-002',
+      name: 'Говядина мраморная',
+      category: 'Мясо',
+      warehouse: 'Кухня',
+      quantity: 9,
+      unit: 'кг',
+      expiryDate: '2025-09-28',
+      primarySupplier: 'Ферма №5',
+      comments: 'Для стейков, проверить температуру камеры №2.',
+    },
+    {
+      id: 104,
+      sku: 'SEA-021',
+      name: 'Креветка крупная',
+      category: 'Морепродукты',
+      warehouse: 'Холодильник',
+      quantity: 6.5,
+      unit: 'кг',
+      expiryDate: '2025-09-20',
+      primarySupplier: 'Морская волна',
+      comments: 'Поставить на разморозку перед банкетом 18.09.',
+    },
+    {
+      id: 105,
+      sku: 'BAK-008',
+      name: 'Хлеб чиабатта',
+      category: 'Выпечка',
+      warehouse: 'Главный склад',
+      quantity: 24,
+      unit: 'шт',
+      expiryDate: '2025-09-14',
+      primarySupplier: 'БулкоФабрика',
+      comments: 'Использовать в первую очередь на завтраке.',
+    },
+    {
+      id: 106,
+      sku: 'DRY-015',
+      name: 'Макароны Пенне',
+      category: 'Бакалея',
+      warehouse: 'Кухня',
+      quantity: 48,
+      unit: 'кг',
+      expiryDate: '2026-02-11',
+      primarySupplier: 'Итальяно',
+      comments: 'Основной гарнир, остаток проверять еженедельно.',
+    },
+    {
+      id: 107,
+      sku: 'BAR-031',
+      name: 'Сироп ванильный',
+      category: 'Бар',
+      warehouse: 'Бар',
+      quantity: 8,
+      unit: 'л',
+      expiryDate: '2025-12-05',
+      primarySupplier: 'SweetBar',
+      comments: 'Открытые бутылки хранить не более 30 дней.',
+    },
+  ]);
+
+  readonly listStock = () => this.stockRowsSignal.asReadonly();
 }


### PR DESCRIPTION
## Summary
- add stock inventory models and data for warehouse view
- implement stock tab filters, expiry highlighting, totals, and CSV export
- extend drawer to support supply and stock details with status-aware styling

## Testing
- `npm run lint` *(fails: project has no lint target configured)*

------
https://chatgpt.com/codex/tasks/task_e_68d881660e108323a83371b443d54611