### PR TITLE
Rework supplies filter panel layout

### DIFF
--- a/feedme.client/src/app/warehouse/warehouse-page.component.css
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.css
@@ -156,36 +156,44 @@
 .warehouse-page__filters {
   display: flex;
   flex-wrap: wrap;
-  gap: 16px;
-  padding: 20px;
+  align-items: center;
+  gap: 12px;
+  padding: 16px;
   border: 1px solid #e2e8f0;
   border-radius: 12px;
   background-color: #ffffff;
-  align-items: flex-end;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.04);
 }
 
-.warehouse-page__filter {
+.warehouse-page__filters-control {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  min-width: 200px;
 }
 
-.warehouse-page__filter--date {
-  min-width: 180px;
+.warehouse-page__filters-control--search {
+  flex: 1 1 320px;
+  min-width: 240px;
 }
 
-.warehouse-page__filter-label {
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: #94a3b8;
+.warehouse-page__filters-control--search .input {
+  width: 100%;
 }
 
-.warehouse-page__filters-actions {
+.warehouse-page__filters-control--date {
+  flex: 0 0 auto;
+}
+
+.warehouse-page__filters-control--date .input {
+  width: 160px;
+}
+
+.warehouse-page__filters .btn {
+  height: 44px;
+  white-space: nowrap;
+}
+
+.ml-auto {
   margin-left: auto;
-  display: flex;
-  gap: 12px;
 }
 
 .warehouse-page__bulk {

--- a/feedme.client/src/app/warehouse/warehouse-page.component.html
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.html
@@ -56,79 +56,40 @@
 
       <section *ngIf="activeTab() === 'supplies'" class="warehouse-page__tab-panel">
         <form class="warehouse-page__filters" (submit)="$event.preventDefault()">
-          <label class="warehouse-page__filter">
-            <span class="warehouse-page__filter-label">Поиск</span>
+          <div class="warehouse-page__filters-control warehouse-page__filters-control--search">
             <input
               #searchInput
               class="input"
               type="search"
-              placeholder="№ документа, название или SKU (/)"
+              placeholder="Поиск по номеру, SKU или названию"
+              aria-label="Поиск по поставкам"
               [value]="query()"
               (input)="updateQuery(searchInput.value)"
             />
-          </label>
-          <label class="warehouse-page__filter">
-            <span class="warehouse-page__filter-label">Статус</span>
-            <select
-              #statusSelect
-              class="select"
-              [value]="status()"
-              (change)="updateStatus(statusSelect.value)"
-            >
-              <option value="">Все</option>
-              <option value="ok">Ок</option>
-              <option value="warning">Скоро срок</option>
-              <option value="danger">Просрочено</option>
-            </select>
-          </label>
-          <label class="warehouse-page__filter">
-            <span class="warehouse-page__filter-label">Поставщик</span>
-            <select
-              #supplierSelect
-              class="select"
-              [value]="supplier()"
-              (change)="updateSupplier(supplierSelect.value)"
-            >
-              <option value="">Все поставщики</option>
-              <option *ngFor="let option of suppliers()" [value]="option">{{ option }}</option>
-            </select>
-          </label>
-          <label class="warehouse-page__filter">
-            <span class="warehouse-page__filter-label">Склад</span>
-            <select
-              #warehouseSelect
-              class="select"
-              [value]="warehouseFilter()"
-              (change)="updateWarehouse(warehouseSelect.value)"
-            >
-              <option value="">Все склады</option>
-              <option *ngFor="let option of warehouses()" [value]="option">{{ option }}</option>
-            </select>
-          </label>
-          <label class="warehouse-page__filter warehouse-page__filter--date">
-            <span class="warehouse-page__filter-label">Дата прихода от</span>
+          </div>
+          <div class="warehouse-page__filters-control warehouse-page__filters-control--date">
             <input
               #dateFromInput
               class="input"
               type="date"
+              aria-label="Дата прихода от"
               [value]="dateFrom()"
               (change)="updateDateFrom(dateFromInput.value)"
             />
-          </label>
-          <label class="warehouse-page__filter warehouse-page__filter--date">
-            <span class="warehouse-page__filter-label">Дата прихода до</span>
+          </div>
+          <div class="warehouse-page__filters-control warehouse-page__filters-control--date">
             <input
               #dateToInput
               class="input"
               type="date"
+              aria-label="Дата прихода до"
               [value]="dateTo()"
               (change)="updateDateTo(dateToInput.value)"
             />
-          </label>
-          <div class="warehouse-page__filters-actions">
-            <button type="button" class="btn btn-outline" (click)="clearFilters()">Сброс</button>
-            <button type="button" class="btn btn-secondary">Экспорт</button>
           </div>
+          <button type="button" class="btn btn-outline" (click)="clearFilters()">Сброс</button>
+          <button type="button" class="btn btn-secondary">Экспорт</button>
+          <button type="button" class="btn ml-auto" (click)="openCreateDialog()">+ Новая поставка</button>
         </form>
 
         <section class="warehouse-page__bulk" *ngIf="hasSelection(); else bulkHint" aria-live="polite">


### PR DESCRIPTION
## Summary
- refactor the supplies tab filter bar into a compact card with search, date range, and action buttons that follow the mockup order
- update component styles for consistent spacing, control widths, and add an ml-auto helper so the primary action sticks to the right

## Testing
- npm run lint *(fails: workspace has no lint target configured)*

------
https://chatgpt.com/codex/tasks/task_e_68d88ce7d7a4832388dd7ba64e459b2e