### PR TITLE
style: refine warehouse tables styling

### DIFF
--- a/feedme.client/src/app/warehouse/warehouse-page.component.css
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.css
@@ -286,21 +286,93 @@
   font-size: 0.75rem;
 }
 
-.warehouse-page__cell--link button {
-  color: #2563eb;
-  font-weight: 600;
-  cursor: pointer;
+.warehouse-page__cell--name {
+  max-width: 240px;
+}
+
+.warehouse-page__cell--supplier {
+  max-width: 220px;
+}
+
+.warehouse-page__product-name {
+  display: inline-flex;
+  align-items: center;
+  width: 100%;
+  max-width: inherit;
   background: none;
   border: none;
   padding: 0;
+  color: #1f2937;
+  text-align: left;
+  line-height: 1.25rem;
 }
 
-.warehouse-page__cell--link button:hover {
-  text-decoration: underline;
+.warehouse-page__product-name:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
 }
 
-.warehouse-page__table tbody tr:hover {
-  background-color: #f8fafc;
+.warehouse-page__product-name:hover {
+  text-decoration: none;
+}
+
+.warehouse-page__row {
+  transition: background-color 0.2s ease;
+}
+
+.warehouse-page__row.hover\:bg-muted\/40:hover {
+  background-color: rgba(148, 163, 184, 0.28);
+}
+
+.warehouse-page__row.odd\:bg-muted\/10:nth-child(odd) {
+  background-color: rgba(148, 163, 184, 0.12);
+}
+
+.warehouse-page__row.h-11 {
+  height: 44px;
+}
+
+.warehouse-page__row.align-middle > .warehouse-page__cell {
+  vertical-align: middle;
+}
+
+.font-mono {
+  font-family: 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+}
+
+.text-xs {
+  font-size: 0.75rem;
+}
+
+.text-right {
+  text-align: right;
+}
+
+.text-center {
+  text-align: center;
+}
+
+.font-medium {
+  font-weight: 600;
+}
+
+.cursor-default {
+  cursor: default;
+}
+
+.truncate {
+  display: inline-block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.min-w-\[88px\] {
+  display: inline-flex;
+  min-width: 88px;
+  justify-content: center;
+  align-items: center;
 }
 
 .warehouse-page__row-menu {

--- a/feedme.client/src/app/warehouse/warehouse-page.component.html
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.html
@@ -158,24 +158,28 @@
                       aria-label="Выбрать все"
                     />
                   </th>
-                  <th class="warehouse-page__cell">№ док.</th>
-                  <th class="warehouse-page__cell warehouse-page__cell--center">Дата прихода</th>
+                  <th class="warehouse-page__cell font-mono text-xs">№ док.</th>
+                  <th class="warehouse-page__cell warehouse-page__cell--center text-center">Дата прихода</th>
                   <th class="warehouse-page__cell">Склад</th>
                   <th class="warehouse-page__cell">Ответственный</th>
-                  <th class="warehouse-page__cell">SKU</th>
+                  <th class="warehouse-page__cell font-mono text-xs">SKU</th>
                   <th class="warehouse-page__cell">Название</th>
                   <th class="warehouse-page__cell">Категория</th>
-                  <th class="warehouse-page__cell warehouse-page__cell--numeric">Кол-во</th>
-                  <th class="warehouse-page__cell warehouse-page__cell--numeric">Цена</th>
-                  <th class="warehouse-page__cell warehouse-page__cell--numeric">Сумма</th>
-                  <th class="warehouse-page__cell warehouse-page__cell--center">Срок годности</th>
+                  <th class="warehouse-page__cell warehouse-page__cell--numeric text-right">Кол-во</th>
+                  <th class="warehouse-page__cell warehouse-page__cell--numeric text-right">Цена</th>
+                  <th class="warehouse-page__cell warehouse-page__cell--numeric text-right">Сумма</th>
+                  <th class="warehouse-page__cell warehouse-page__cell--center text-center">Срок годности</th>
                   <th class="warehouse-page__cell">Поставщик</th>
                   <th class="warehouse-page__cell warehouse-page__cell--status">Статус</th>
                   <th class="warehouse-page__cell warehouse-page__cell--icon" aria-hidden="true"></th>
                 </tr>
               </thead>
               <tbody>
-                <tr *ngFor="let row of filteredRows(); trackBy: trackByRow" (dblclick)="openDrawer(row)">
+                <tr
+                  *ngFor="let row of filteredRows(); trackBy: trackByRow"
+                  class="warehouse-page__row hover:bg-muted/40 odd:bg-muted/10 h-11 align-middle"
+                  (dblclick)="openDrawer(row)"
+                >
                   <td class="warehouse-page__cell warehouse-page__cell--checkbox">
                     <input
                       type="checkbox"
@@ -184,29 +188,38 @@
                       [attr.aria-label]="'Строка ' + row.docNo"
                     />
                   </td>
-                  <td class="warehouse-page__cell warehouse-page__cell--mono">{{ row.docNo }}</td>
-                  <td class="warehouse-page__cell warehouse-page__cell--center">{{ row.arrivalDate | date: 'dd.MM.yyyy' }}</td>
+                  <td class="warehouse-page__cell warehouse-page__cell--mono font-mono text-xs">{{ row.docNo }}</td>
+                  <td class="warehouse-page__cell warehouse-page__cell--center text-center">{{ row.arrivalDate | date: 'dd.MM.yyyy' }}</td>
                   <td class="warehouse-page__cell">{{ row.warehouse }}</td>
                   <td class="warehouse-page__cell">{{ row.responsible }}</td>
-                  <td class="warehouse-page__cell warehouse-page__cell--mono">{{ row.sku }}</td>
-                  <td class="warehouse-page__cell warehouse-page__cell--link">
-                    <button type="button" (click)="openDrawer(row)">{{ row.name }}</button>
+                  <td class="warehouse-page__cell warehouse-page__cell--mono font-mono text-xs">{{ row.sku }}</td>
+                  <td class="warehouse-page__cell warehouse-page__cell--name">
+                    <button
+                      type="button"
+                      class="warehouse-page__product-name font-medium truncate cursor-default"
+                      (click)="openDrawer(row)"
+                      [attr.title]="row.name"
+                    >
+                      {{ row.name }}
+                    </button>
                   </td>
                   <td class="warehouse-page__cell">{{ row.category }}</td>
-                  <td class="warehouse-page__cell warehouse-page__cell--numeric">
+                  <td class="warehouse-page__cell warehouse-page__cell--numeric text-right">
                     {{ row.qty | number: '1.0-3' }} {{ row.unit }}
                   </td>
-                  <td class="warehouse-page__cell warehouse-page__cell--numeric">
+                  <td class="warehouse-page__cell warehouse-page__cell--numeric text-right">
                     {{ formatCurrency(row.price) }}
                   </td>
-                  <td class="warehouse-page__cell warehouse-page__cell--numeric">
+                  <td class="warehouse-page__cell warehouse-page__cell--numeric text-right">
                     {{ formatCurrency(rowTotal(row)) }}
                   </td>
-                  <td class="warehouse-page__cell warehouse-page__cell--center">{{ row.expiry | date: 'dd.MM.yyyy' }}</td>
-                  <td class="warehouse-page__cell">{{ row.supplier }}</td>
+                  <td class="warehouse-page__cell warehouse-page__cell--center text-center">{{ row.expiry | date: 'dd.MM.yyyy' }}</td>
+                  <td class="warehouse-page__cell warehouse-page__cell--supplier">
+                    <span class="truncate" [attr.title]="row.supplier">{{ row.supplier }}</span>
+                  </td>
                   <td class="warehouse-page__cell warehouse-page__cell--status">
                     <span
-                      class="badge"
+                      class="badge min-w-[88px] text-center"
                       [ngClass]="{
                         'badge-soft': row.status === 'warning',
                         'badge-danger': row.status === 'danger'


### PR DESCRIPTION
## Summary
- align the supplies header and body columns with monospace identifiers, centered dates, and right-aligned numeric values
- add zebra striping, compact row height, and enhanced hover styling for supply rows together with truncated product and supplier fields
- size the status badge consistently with a minimum width and ensure tooltips expose full values

## Testing
- npm run test *(fails: ChromeHeadless cannot start because libatk-1.0.so.0 is missing in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d88d8bc4d4832396ca4447e867849a