### PR TITLE
Add supply filter selects to warehouse page

### DIFF
--- a/feedme.client/src/app/warehouse/warehouse-page.component.css
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.css
@@ -170,6 +170,20 @@
   flex-direction: column;
 }
 
+.warehouse-page__filters-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.warehouse-page__filters-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: #64748b;
+  letter-spacing: 0.04em;
+}
+
 .warehouse-page__filters-control--search {
   flex: 1 1 320px;
   min-width: 240px;
@@ -185,6 +199,11 @@
 
 .warehouse-page__filters-control--date .input {
   width: 160px;
+}
+
+.warehouse-page__filters-control--select {
+  flex: 0 1 200px;
+  min-width: 180px;
 }
 
 .warehouse-page__filters .btn {

--- a/feedme.client/src/app/warehouse/warehouse-page.component.html
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.html
@@ -57,35 +57,95 @@
       <section *ngIf="activeTab() === 'supplies'" class="warehouse-page__tab-panel">
         <form class="warehouse-page__filters" (submit)="$event.preventDefault()">
           <div class="warehouse-page__filters-control warehouse-page__filters-control--search">
-            <input
-              #searchInput
-              class="input"
-              type="search"
-              placeholder="Поиск по номеру, SKU или названию"
-              aria-label="Поиск по поставкам"
-              [value]="query()"
-              (input)="updateQuery(searchInput.value)"
-            />
+            <label class="warehouse-page__filters-field">
+              <span class="warehouse-page__filters-label">Поиск</span>
+              <input
+                #searchInput
+                class="input"
+                type="search"
+                placeholder="Поиск по номеру, SKU или названию"
+                aria-label="Поиск по поставкам"
+                [value]="query()"
+                (input)="updateQuery(searchInput.value)"
+              />
+            </label>
+          </div>
+          <div class="warehouse-page__filters-control warehouse-page__filters-control--select">
+            <label class="warehouse-page__filters-field">
+              <span class="warehouse-page__filters-label">Статус</span>
+              <select
+                #statusSelect
+                class="select"
+                [value]="status()"
+                (change)="updateStatus(statusSelect.value)"
+                aria-label="Фильтр по статусу"
+              >
+                <option value="">Все статусы</option>
+                <option value="ok">Ок</option>
+                <option value="warning">Скоро срок</option>
+                <option value="danger">Просрочено</option>
+              </select>
+            </label>
+          </div>
+          <div class="warehouse-page__filters-control warehouse-page__filters-control--select">
+            <label class="warehouse-page__filters-field">
+              <span class="warehouse-page__filters-label">Поставщик</span>
+              <select
+                #supplierSelect
+                class="select"
+                [value]="supplier()"
+                (change)="updateSupplier(supplierSelect.value)"
+                aria-label="Фильтр по поставщику"
+              >
+                <option value="">Все поставщики</option>
+                <option *ngFor="let supplierName of suppliers()" [value]="supplierName">
+                  {{ supplierName }}
+                </option>
+              </select>
+            </label>
+          </div>
+          <div class="warehouse-page__filters-control warehouse-page__filters-control--select">
+            <label class="warehouse-page__filters-field">
+              <span class="warehouse-page__filters-label">Склад</span>
+              <select
+                #warehouseSelect
+                class="select"
+                [value]="warehouseFilter()"
+                (change)="updateWarehouse(warehouseSelect.value)"
+                aria-label="Фильтр по складу"
+              >
+                <option value="">Все склады</option>
+                <option *ngFor="let warehouseName of warehouses()" [value]="warehouseName">
+                  {{ warehouseName }}
+                </option>
+              </select>
+            </label>
           </div>
           <div class="warehouse-page__filters-control warehouse-page__filters-control--date">
-            <input
-              #dateFromInput
-              class="input"
-              type="date"
-              aria-label="Дата прихода от"
-              [value]="dateFrom()"
-              (change)="updateDateFrom(dateFromInput.value)"
-            />
+            <label class="warehouse-page__filters-field">
+              <span class="warehouse-page__filters-label">Приход от</span>
+              <input
+                #dateFromInput
+                class="input"
+                type="date"
+                aria-label="Дата прихода от"
+                [value]="dateFrom()"
+                (change)="updateDateFrom(dateFromInput.value)"
+              />
+            </label>
           </div>
           <div class="warehouse-page__filters-control warehouse-page__filters-control--date">
-            <input
-              #dateToInput
-              class="input"
-              type="date"
-              aria-label="Дата прихода до"
-              [value]="dateTo()"
-              (change)="updateDateTo(dateToInput.value)"
-            />
+            <label class="warehouse-page__filters-field">
+              <span class="warehouse-page__filters-label">Приход до</span>
+              <input
+                #dateToInput
+                class="input"
+                type="date"
+                aria-label="Дата прихода до"
+                [value]="dateTo()"
+                (change)="updateDateTo(dateToInput.value)"
+              />
+            </label>
           </div>
           <button type="button" class="btn btn-outline" (click)="clearFilters()">Сброс</button>
           <button type="button" class="btn btn-secondary">Экспорт</button>


### PR DESCRIPTION
## Summary
- add labeled status, supplier, and warehouse selects to the supplies filter panel
- tweak filter layout styling for consistent labels and control widths

## Testing
- npm test *(fails: ChromeHeadless missing libatk-1.0.so.0 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d892bd1570832398f6e8d74d478fb6