### PR TITLE
style: restyle supply table footer

### DIFF
--- a/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.css
+++ b/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.css
@@ -157,56 +157,63 @@ table.supply-table {
 .table-footer {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 1rem;
   margin-top: 1rem;
-  padding: 0.75rem 1rem;
-  background-color: rgba(148, 163, 184, 0.15);
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+  padding: 0.75rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.45);
+  background-color: rgba(148, 163, 184, 0.18);
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.12);
   border-radius: 0.75rem;
 }
 
-.table-footer__info {
-  font-size: 0.875rem;
-  color: #6b7280;
-}
-
-.table-footer__actions {
-  display: inline-flex;
-  gap: 0.5rem;
-  margin-left: auto;
-}
-
-.table-footer__button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.35rem 0.9rem;
-  font-size: 0.875rem;
-  font-weight: 500;
-  color: #1f2937;
-  background-color: #ffffff;
-  border: 1px solid #d0d5dd;
-  border-radius: 0.5rem;
-  cursor: pointer;
-  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
-}
-
-.table-footer__button:hover:not(:disabled),
-.table-footer__button:focus-visible:not(:disabled) {
-  background-color: #f8fafc;
-  border-color: #c4c9d4;
-  color: #0f172a;
-  outline: none;
-}
-
-.table-footer__button:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
+.table-footer__summary {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
 }
 
 .table-footer__page {
-  margin-left: 0.75rem;
-  font-size: 0.875rem;
-  color: #4b5563;
-
+  font-size: 0.8125rem;
 }
+
+.flex {
+  display: flex;
+}
+
+.items-center {
+  align-items: center;
+}
+
+.p-3 {
+  padding: 0.75rem;
+}
+
+.border-t {
+  border-top: 1px solid rgba(148, 163, 184, 0.45);
+}
+
+.text-sm {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+}
+
+.text-muted-foreground {
+  color: #64748b;
+}
+
+.bg-muted\/40 {
+  background-color: rgba(148, 163, 184, 0.18);
+}
+
+.shadow-sm {
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.12);
+}
+
+.ml-auto {
+  margin-left: auto;
+}
+
+.gap-2 {
+  gap: 0.5rem;
+}
+

--- a/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.html
+++ b/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.html
@@ -116,22 +116,24 @@
 
 <!-- Пагинация -->
 
-<div class="table-footer">
-  <span class="table-footer__info">Показано {{ paginatedData.length }} поставок</span>
-  <div class="table-footer__actions">
+<div class="table-footer flex items-center p-3 border-t text-sm bg-muted/40 shadow-sm">
+  <div class="table-footer__summary">
+    <span class="text-sm text-muted-foreground">Показано {{ paginatedData.length }} поставок</span>
+    <span class="table-footer__page text-muted-foreground">Страница {{ currentPage }} из {{ totalPages }}</span>
+  </div>
+  <div class="ml-auto flex gap-2">
     <button type="button"
-            class="table-footer__button"
+            class="btn btn-outline btn-sm"
             (click)="prevPage()"
             [disabled]="currentPage === 1">
       Назад
     </button>
     <button type="button"
-            class="table-footer__button"
+            class="btn btn-outline btn-sm"
             (click)="nextPage()"
             [disabled]="currentPage === totalPages">
       Далее
     </button>
   </div>
-  <span class="table-footer__page">Страница {{ currentPage }} из {{ totalPages }}</span>
 </div>
 


### PR DESCRIPTION
## Summary
- restyle the supplies table footer to use a muted flex container with summary text on the left and outline action buttons on the right
- add scoped utility classes to support the new footer spacing, alignment, and muted foreground styling

## Testing
- npm run lint *(fails: npm could not determine executable to run in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d894264ac483238361596a30eec33f