### PR TITLE
style: improve supplies table header

### DIFF
--- a/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.css
+++ b/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.css
@@ -58,22 +58,37 @@ table.supply-table {
   }
 
 .table-head {
-  background-color: rgba(148, 163, 184, 0.15);
-}
-
-.table-head tr {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: rgba(248, 250, 252, 0.9);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
   border-bottom: 1px solid #dfe3eb;
+  box-shadow: inset 0 -1px 0 0 rgba(148, 163, 184, 0.4);
 }
 
 .header-cell {
   padding: 0;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
 }
 
-.header-cell--static {
-  padding: 0.75rem 1rem;
-  font-size: 0.875rem;
-  font-weight: 500;
-  color: #4b5563;
+.header-cell:hover,
+.header-cell:focus-within {
+  background-color: rgba(148, 163, 184, 0.24);
+}
+
+.header-cell--menu {
+  width: 44px;
+  min-width: 44px;
+  padding: 0.75rem 0.5rem;
+  cursor: default;
+}
+
+.header-cell--menu:hover,
+.header-cell--menu:focus-within {
+  background-color: transparent;
 }
 
 .sort-button {
@@ -149,7 +164,7 @@ table.supply-table {
   /* 9. колонка действий */
   table.supply-table tbody td:last-child {
     text-align: center;
-    width: 80px;
+    width: 44px;
   }
 
 

--- a/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.html
+++ b/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.html
@@ -91,7 +91,7 @@
             </span>
           </button>
         </th>
-        <th class="header-cell header-cell--static">Действие</th>
+        <th class="header-cell header-cell--menu" aria-label="Действия"></th>
       </tr>
     </thead>
     <tbody>


### PR DESCRIPTION
## Summary
- make the supplies table header sticky with a blurred background and subtle shadow
- add hover feedback to header cells and align the action column to a 44px menu width
- replace the action title with an empty header cell reserved for the menu column

## Testing
- npm run lint *(fails: npm could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_68d8943e90f48323a566742ac57b68b7