### PR TITLE
feat: make supply table header sticky

### DIFF
--- a/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.css
+++ b/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.css
@@ -36,6 +36,7 @@ app-table-controls {
 .table-container {
   overflow-x: auto;
   width: 100%;
+  position: relative;
 }
 
 /* 5. сама таблица */
@@ -58,22 +59,30 @@ table.supply-table {
   }
 
 .table-head {
-  background-color: rgba(148, 163, 184, 0.15);
-}
-
-.table-head tr {
-  border-bottom: 1px solid #dfe3eb;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background-color: rgba(255, 255, 255, 0.9);
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: inset 0 -1px 0 0 rgba(15, 23, 42, 0.08);
 }
 
 .header-cell {
   padding: 0;
+  transition: background-color 0.2s ease;
 }
 
-.header-cell--static {
-  padding: 0.75rem 1rem;
-  font-size: 0.875rem;
-  font-weight: 500;
-  color: #4b5563;
+.header-cell--sortable {
+  cursor: pointer;
+}
+
+.header-cell--sortable:hover .sort-button {
+  background-color: rgba(148, 163, 184, 0.3);
+}
+
+.header-cell--sortable:hover {
+  background-color: rgba(148, 163, 184, 0.3);
 }
 
 .sort-button {
@@ -127,6 +136,12 @@ table.supply-table {
   color: #fa4b00;
 }
 
+.header-cell--menu {
+  width: 44px;
+  padding: 0.75rem 0;
+  text-align: center;
+}
+
   /* 7. строки */
   table.supply-table tbody td {
     padding: 1.25rem 1rem;
@@ -149,7 +164,8 @@ table.supply-table {
   /* 9. колонка действий */
   table.supply-table tbody td:last-child {
     text-align: center;
-    width: 80px;
+    width: 44px;
+    padding: 1.25rem 0;
   }
 
 

--- a/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.html
+++ b/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.html
@@ -14,7 +14,7 @@
   <table class="supply-table">
     <thead class="table-head">
       <tr>
-        <th class="header-cell" [attr.aria-sort]="getAriaSort('productName')">
+        <th class="header-cell header-cell--sortable" [attr.aria-sort]="getAriaSort('productName')">
           <button type="button"
                   class="sort-button"
                   (click)="toggleSort('productName')"
@@ -25,7 +25,7 @@
             </span>
           </button>
         </th>
-        <th class="header-cell" [attr.aria-sort]="getAriaSort('category')">
+        <th class="header-cell header-cell--sortable" [attr.aria-sort]="getAriaSort('category')">
           <button type="button"
                   class="sort-button"
                   (click)="toggleSort('category')"
@@ -36,7 +36,7 @@
             </span>
           </button>
         </th>
-        <th class="header-cell" [attr.aria-sort]="getAriaSort('stock')">
+        <th class="header-cell header-cell--sortable" [attr.aria-sort]="getAriaSort('stock')">
           <button type="button"
                   class="sort-button"
                   (click)="toggleSort('stock')"
@@ -47,7 +47,7 @@
             </span>
           </button>
         </th>
-        <th class="header-cell" [attr.aria-sort]="getAriaSort('unitPrice')">
+        <th class="header-cell header-cell--sortable" [attr.aria-sort]="getAriaSort('unitPrice')">
           <button type="button"
                   class="sort-button"
                   (click)="toggleSort('unitPrice')"
@@ -58,7 +58,7 @@
             </span>
           </button>
         </th>
-        <th class="header-cell" [attr.aria-sort]="getAriaSort('expiryDate')">
+        <th class="header-cell header-cell--sortable" [attr.aria-sort]="getAriaSort('expiryDate')">
           <button type="button"
                   class="sort-button"
                   (click)="toggleSort('expiryDate')"
@@ -69,7 +69,7 @@
             </span>
           </button>
         </th>
-        <th class="header-cell" [attr.aria-sort]="getAriaSort('responsible')">
+        <th class="header-cell header-cell--sortable" [attr.aria-sort]="getAriaSort('responsible')">
           <button type="button"
                   class="sort-button"
                   (click)="toggleSort('responsible')"
@@ -80,7 +80,7 @@
             </span>
           </button>
         </th>
-        <th class="header-cell" [attr.aria-sort]="getAriaSort('supplier')">
+        <th class="header-cell header-cell--sortable" [attr.aria-sort]="getAriaSort('supplier')">
           <button type="button"
                   class="sort-button"
                   (click)="toggleSort('supplier')"
@@ -91,7 +91,7 @@
             </span>
           </button>
         </th>
-        <th class="header-cell header-cell--static">Действие</th>
+        <th class="header-cell header-cell--menu" aria-hidden="true"></th>
       </tr>
     </thead>
     <tbody>


### PR DESCRIPTION
## Summary
- make the supplies table header sticky with a blurred background and subtle border shadow
- align sortable header cells with hover feedback and add a dedicated blank menu column header

## Testing
- npm run lint *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_68d895379ce88323a3b6bce84464e4bd