### PR TITLE
style: align supply table rows

### DIFF
--- a/feedme.client/src/app/warehouse/warehouse-page.component.css
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.css
@@ -308,11 +308,6 @@
   color: #94a3b8;
 }
 
-.warehouse-page__cell--mono {
-  font-family: 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
-  font-size: 0.75rem;
-}
-
 .warehouse-page__cell--name {
   max-width: 240px;
 }
@@ -398,8 +393,11 @@
 .min-w-\[88px\] {
   display: inline-flex;
   min-width: 88px;
-  justify-content: center;
   align-items: center;
+}
+
+.justify-center {
+  justify-content: center;
 }
 
 .warehouse-page__row-menu {

--- a/feedme.client/src/app/warehouse/warehouse-page.component.html
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.html
@@ -209,11 +209,11 @@
                       [attr.aria-label]="'Строка ' + row.docNo"
                     />
                   </td>
-                  <td class="warehouse-page__cell warehouse-page__cell--mono font-mono text-xs">{{ row.docNo }}</td>
+                  <td class="warehouse-page__cell font-mono text-xs">{{ row.docNo }}</td>
                   <td class="warehouse-page__cell warehouse-page__cell--center text-center">{{ row.arrivalDate | date: 'dd.MM.yyyy' }}</td>
                   <td class="warehouse-page__cell">{{ row.warehouse }}</td>
                   <td class="warehouse-page__cell">{{ row.responsible }}</td>
-                  <td class="warehouse-page__cell warehouse-page__cell--mono font-mono text-xs">{{ row.sku }}</td>
+                  <td class="warehouse-page__cell font-mono text-xs">{{ row.sku }}</td>
                   <td class="warehouse-page__cell warehouse-page__cell--name">
                     <button
                       type="button"
@@ -235,12 +235,12 @@
                     {{ formatCurrency(rowTotal(row)) }}
                   </td>
                   <td class="warehouse-page__cell warehouse-page__cell--center text-center">{{ row.expiry | date: 'dd.MM.yyyy' }}</td>
-                  <td class="warehouse-page__cell warehouse-page__cell--supplier">
-                    <span class="truncate" [attr.title]="row.supplier">{{ row.supplier }}</span>
+                  <td class="warehouse-page__cell warehouse-page__cell--supplier" [attr.title]="row.supplier">
+                    <span class="truncate">{{ row.supplier }}</span>
                   </td>
                   <td class="warehouse-page__cell warehouse-page__cell--status">
                     <span
-                      class="badge min-w-[88px] text-center"
+                      class="badge min-w-[88px] justify-center"
                       [ngClass]="{
                         'badge-soft': row.status === 'warning',
                         'badge-danger': row.status === 'danger'


### PR DESCRIPTION
## Summary
- align the supply table row layout with the mock by applying monospace styling to document and SKU cells and centering numeric/date columns
- truncate long supplier values with a tooltip and center the status badge with the required utility classes

## Testing
- npm run lint *(fails: no Angular lint target is configured yet)*

------
https://chatgpt.com/codex/tasks/task_e_68d8953cb860832388ba9cfe8cf09b05