### PR TITLE
Add bulk action panel markup for supplies

### DIFF
--- a/feedme.client/src/app/warehouse/supplies/supplies.component.html
+++ b/feedme.client/src/app/warehouse/supplies/supplies.component.html
@@ -1,0 +1,9 @@
+<div class="bulkbar"> <!-- TODO: show on selection -->
+  <span class="bulkbar__hint">Выбрано: 3</span>
+  <div class="bulkbar__actions">
+    <button class="btn btn-outline btn-sm" type="button">Списать</button>
+    <button class="btn btn-outline btn-sm" type="button">Переместить</button>
+    <button class="btn btn-outline btn-sm" type="button">Печать</button>
+    <button class="btn btn-danger btn-sm" type="button">Удалить</button>
+  </div>
+</div>

--- a/feedme.client/src/app/warehouse/supplies/supplies.component.scss
+++ b/feedme.client/src/app/warehouse/supplies/supplies.component.scss
@@ -1,0 +1,20 @@
+.bulkbar {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  background: color-mix(in srgb, #f6f7f9 40%, transparent);
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  padding: 0.5rem 0.75rem;
+}
+
+.bulkbar__hint {
+  color: #6b7280;
+  font-size: 0.875rem;
+}
+
+.bulkbar__actions {
+  margin-left: auto;
+  display: flex;
+  gap: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- add the bulk action toolbar markup to the supplies component template
- style the toolbar with shared button spacing and muted palette

## Testing
- npm run lint *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_68d93482605c8323a85ac2771e222250