### PR TITLE
Add UI chips for selected supply filters

### DIFF
--- a/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.css
+++ b/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.css
@@ -132,6 +132,53 @@
   color: #b91c1c;
 }
 
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.chips .chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.5rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  border: 1px solid var(--border, #e2e8f0);
+  color: #374151;
+  background: #ffffff;
+  line-height: 1.1;
+  font-weight: 500;
+  cursor: default;
+}
+
+.chips .chip--filled {
+  background: #eef2ff;
+  border-color: #c7d2fe;
+  color: #4338ca;
+}
+
+.chips .chip--danger {
+  background: #fee2e2;
+  border-color: #fecaca;
+  color: #b91c1c;
+}
+
+.chips .chip--ghost {
+  background: transparent;
+  color: #6b7280;
+}
+
+.chips button.chip {
+  border: 1px solid var(--border, #e2e8f0);
+  background: transparent;
+  cursor: pointer;
+}
+
+.chips button.chip:hover {
+  background: rgba(15, 23, 42, 0.04);
+}
+
 .btn {
   display: inline-flex;
   align-items: center;

--- a/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.html
+++ b/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.html
@@ -45,6 +45,15 @@
   </div>
 </div>
 
+<div class="chips" aria-label="Выбранные фильтры">
+  <div class="chip chip--filled">Главный склад</div>
+  <div class="chip chip--filled">Кухня</div>
+  <div class="chip">Ок</div>
+  <div class="chip">Скоро срок</div>
+  <div class="chip chip--danger">Просрочено</div>
+  <button class="chip chip--ghost" type="button">Очистить</button>
+</div>
+
 <div class="table-container">
   <table class="supplies-table">
     <thead class="supplies-table__head sticky top-0 bg-background/90 backdrop-blur border-b shadow-[inset_0_-1px_0_0_var(--border)]">


### PR DESCRIPTION
## Summary
- add a static chip panel below the supply filters to showcase selected warehouses and statuses
- introduce scoped chip styles for filled, danger, and ghost states to match the visual design

## Testing
- npm run lint *(fails: npm error could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_68d93489d2cc832380b2e78dc9685d1e