### PR TITLE
feat: add menu column to supplies and stock tables

### DIFF
--- a/feedme.client/src/app/components/StockTableComponent/stock-table.component.css
+++ b/feedme.client/src/app/components/StockTableComponent/stock-table.component.css
@@ -74,9 +74,21 @@ table.stock-table tbody tr:hover {
   background-color: #f5f5f5;
 }
 
-table.stock-table td.actions-cell {
-  text-align: center;
-  width: 80px;
+.cell-menu {
+  width: 44px;
+  text-align: right;
+}
+
+.icon-btn {
+  width: 32px;
+  height: 32px;
+  border-radius: 0.5rem;
+  border: 0;
+  background: transparent;
+}
+
+.icon-btn:hover {
+  background: rgba(0, 0, 0, 0.06);
 }
 
 .pagination-controls {

--- a/feedme.client/src/app/components/StockTableComponent/stock-table.component.html
+++ b/feedme.client/src/app/components/StockTableComponent/stock-table.component.html
@@ -22,14 +22,22 @@
             </span>
           </button>
         </th>
-        <th>Действие</th>
+        <th style="width:44px"></th>
       </tr>
     </thead>
     <tbody>
       <tr *ngFor="let item of paginatedData">
         <td *ngFor="let column of columns">{{ formatValue(item, column) }}</td>
-        <td class="actions-cell">
-          <button (click)="onSettingsClick.emit(item)">⚙️</button>
+        <td class="cell-menu">
+          <button
+            type="button"
+            class="icon-btn"
+            aria-label="Меню"
+            (click)="onSettingsClick.emit(item)"
+          >
+            ⋯
+          </button>
+          <!-- TODO: dropdown UI позже отдельной задачей -->
         </td>
       </tr>
       <tr *ngIf="paginatedData.length === 0">

--- a/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.css
+++ b/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.css
@@ -193,14 +193,6 @@
   outline: none;
 }
 
-.btn-icon {
-  width: 36px;
-  height: 36px;
-  font-size: 24px;
-  line-height: 1;
-  padding: 0;
-}
-
 .btn-sm {
   padding: 8px 12px;
   font-size: 0.8125rem;
@@ -339,64 +331,21 @@
   outline-offset: 2px;
 }
 
-.menu {
-  position: relative;
-  display: inline-flex;
+.cell-menu {
+  width: 44px;
+  text-align: right;
 }
 
-.menu__panel {
-  position: absolute;
-  right: 0;
-  top: calc(100% + 8px);
-  display: none;
-  flex-direction: column;
-  min-width: 160px;
-  padding: 8px 0;
-  border-radius: 10px;
-  border: 1px solid #e2e8f0;
-  background-color: #ffffff;
-  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.15);
-  z-index: 10;
-}
-
-.menu:focus-within .menu__panel,
-.menu:hover .menu__panel {
-  display: flex;
-}
-
-.menu__item {
-  width: 100%;
-  text-align: left;
-  padding: 10px 16px;
+.icon-btn {
+  width: 32px;
+  height: 32px;
+  border-radius: 0.5rem;
+  border: 0;
   background: transparent;
-  border: none;
-  font-size: 0.875rem;
-  color: #0f172a;
-  cursor: pointer;
-  transition: background-color 0.2s ease, color 0.2s ease;
 }
 
-.menu__item:hover,
-.menu__item:focus-visible {
-  background-color: #f1f5f9;
-  color: #111827;
-  outline: none;
-}
-
-.menu__item--destructive {
-  color: #b91c1c;
-}
-
-.menu__item--destructive:hover,
-.menu__item--destructive:focus-visible {
-  background-color: rgba(248, 113, 113, 0.12);
-  color: #991b1b;
-}
-
-.menu__separator {
-  height: 1px;
-  margin: 4px 0;
-  background-color: #e2e8f0;
+.icon-btn:hover {
+  background: rgba(0, 0, 0, 0.06);
 }
 
 .no-data {

--- a/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.html
+++ b/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.html
@@ -62,7 +62,7 @@
         <th scope="col" class="text-sm font-medium text-center">Срок годности</th>
         <th scope="col" class="text-sm font-medium">Поставщик</th>
         <th scope="col" class="text-sm font-medium">Статус</th>
-        <th scope="col" class="w-[44px]"></th>
+        <th scope="col" style="width:44px"></th>
       </tr>
     </thead>
     <tbody>
@@ -116,30 +116,16 @@
             {{ item.status || item.state || 'Ок' }}
           </span>
         </td>
-        <td class="w-[44px]">
-          <div class="menu">
-            <button
-              type="button"
-              class="btn btn-ghost btn-icon"
-              aria-haspopup="true"
-              aria-expanded="false"
-              aria-label="Открыть меню"
-            >
-              ⋯
-            </button>
-            <div class="menu__panel" role="menu">
-              <button type="button" class="menu__item" role="menuitem" (click)="onSettingsClick.emit(item)">
-                Открыть
-              </button>
-              <button type="button" class="menu__item" role="menuitem">
-                Редактировать
-              </button>
-              <div class="menu__separator" role="separator"></div>
-              <button type="button" class="menu__item menu__item--destructive" role="menuitem">
-                Удалить
-              </button>
-            </div>
-          </div>
+        <td class="cell-menu">
+          <button
+            type="button"
+            class="icon-btn"
+            aria-label="Меню"
+            (click)="onSettingsClick.emit(item)"
+          >
+            ⋯
+          </button>
+          <!-- TODO: dropdown UI позже отдельной задачей -->
         </td>
       </tr>
       <tr *ngIf="paginatedData.length === 0">


### PR DESCRIPTION
## Summary
- add a dedicated menu column with plain icon buttons in the supplies and stock tables
- add shared cell and icon button styling to match the new design and remove the unused dropdown markup

## Testing
- npm run lint *(fails: workspace has no configured lint target)*

------
https://chatgpt.com/codex/tasks/task_e_68d9347b43808323add1577eec56c103