### PR TITLE
Update supplies table header layout

### DIFF
--- a/feedme.client/src/app/warehouse/warehouse-page.component.css
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.css
@@ -361,12 +361,14 @@
   font-size: 0.875rem;
 }
 
-.warehouse-page__table thead tr {
+.warehouse-page__table thead {
   position: sticky;
   top: 0;
-  background-color: #ffffff;
-  box-shadow: inset 0 -1px 0 #e2e8f0;
-  z-index: 1;
+  z-index: 5;
+}
+
+.warehouse-page__table thead tr {
+  background: transparent;
 }
 
 .warehouse-page__cell {
@@ -378,7 +380,7 @@
 }
 
 .warehouse-page__cell--checkbox {
-  width: 48px;
+  width: 40px;
 }
 
 .warehouse-page__cell--numeric {
@@ -397,6 +399,7 @@
 
 .warehouse-page__cell--status {
   white-space: nowrap;
+  min-width: 112px;
 }
 
 .warehouse-page__empty-row {

--- a/feedme.client/src/app/warehouse/warehouse-page.component.html
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.html
@@ -175,9 +175,14 @@
           <header class="warehouse-page__table-header">Последние поставки</header>
           <div class="warehouse-page__table-wrapper">
             <table class="warehouse-page__table">
-              <thead>
+              <thead
+                class="sticky top-0 bg-background/90 backdrop-blur border-b shadow-[inset_0_-1px_0_0_var(--border)]"
+              >
                 <tr>
-                  <th class="warehouse-page__cell warehouse-page__cell--checkbox">
+                  <th
+                    scope="col"
+                    class="warehouse-page__cell warehouse-page__cell--checkbox text-sm font-medium w-[40px]"
+                  >
                     <input
                       type="checkbox"
                       [checked]="allFilteredChecked()"
@@ -185,20 +190,45 @@
                       aria-label="Выбрать все"
                     />
                   </th>
-                  <th class="warehouse-page__cell font-mono text-xs">№ док.</th>
-                  <th class="warehouse-page__cell warehouse-page__cell--center text-center">Дата прихода</th>
-                  <th class="warehouse-page__cell">Склад</th>
-                  <th class="warehouse-page__cell">Ответственный</th>
-                  <th class="warehouse-page__cell font-mono text-xs">SKU</th>
-                  <th class="warehouse-page__cell">Название</th>
-                  <th class="warehouse-page__cell">Категория</th>
-                  <th class="warehouse-page__cell warehouse-page__cell--numeric text-right">Кол-во</th>
-                  <th class="warehouse-page__cell warehouse-page__cell--numeric text-right">Цена</th>
-                  <th class="warehouse-page__cell warehouse-page__cell--numeric text-right">Сумма</th>
-                  <th class="warehouse-page__cell warehouse-page__cell--center text-center">Срок годности</th>
-                  <th class="warehouse-page__cell">Поставщик</th>
-                  <th class="warehouse-page__cell warehouse-page__cell--status">Статус</th>
-                  <th class="warehouse-page__cell warehouse-page__cell--icon" aria-hidden="true"></th>
+                  <th scope="col" class="warehouse-page__cell text-sm font-medium font-mono text-xs">
+                    № док.
+                  </th>
+                  <th
+                    scope="col"
+                    class="warehouse-page__cell warehouse-page__cell--center text-sm font-medium text-center"
+                  >
+                    Дата прихода
+                  </th>
+                  <th scope="col" class="warehouse-page__cell text-sm font-medium">Склад</th>
+                  <th scope="col" class="warehouse-page__cell text-sm font-medium">Ответственный</th>
+                  <th scope="col" class="warehouse-page__cell text-sm font-medium font-mono text-xs">
+                    SKU
+                  </th>
+                  <th scope="col" class="warehouse-page__cell text-sm font-medium">Название</th>
+                  <th
+                    scope="col"
+                    class="warehouse-page__cell warehouse-page__cell--numeric text-sm font-medium text-right"
+                  >
+                    Кол-во
+                  </th>
+                  <th
+                    scope="col"
+                    class="warehouse-page__cell warehouse-page__cell--center text-sm font-medium text-center"
+                  >
+                    Срок годности
+                  </th>
+                  <th scope="col" class="warehouse-page__cell text-sm font-medium">Поставщик</th>
+                  <th
+                    scope="col"
+                    class="warehouse-page__cell warehouse-page__cell--status text-sm font-medium"
+                  >
+                    Статус
+                  </th>
+                  <th
+                    scope="col"
+                    class="warehouse-page__cell warehouse-page__cell--icon text-sm font-medium w-[44px]"
+                    aria-hidden="true"
+                  ></th>
                 </tr>
               </thead>
               <tbody>
@@ -207,7 +237,7 @@
                   class="warehouse-page__row hover:bg-muted/40 odd:bg-muted/10 h-11 align-middle"
                   (dblclick)="openDrawer(row)"
                 >
-                  <td class="warehouse-page__cell warehouse-page__cell--checkbox">
+                  <td class="warehouse-page__cell warehouse-page__cell--checkbox w-[40px]">
                     <input
                       type="checkbox"
                       [checked]="checkedIds().includes(row.id)"
@@ -230,23 +260,16 @@
                       {{ row.name }}
                     </button>
                   </td>
-                  <td class="warehouse-page__cell">{{ row.category }}</td>
                   <td class="warehouse-page__cell warehouse-page__cell--numeric text-right">
                     {{ row.qty | number: '1.0-3' }} {{ row.unit }}
-                  </td>
-                  <td class="warehouse-page__cell warehouse-page__cell--numeric text-right">
-                    {{ formatCurrency(row.price) }}
-                  </td>
-                  <td class="warehouse-page__cell warehouse-page__cell--numeric text-right">
-                    {{ formatCurrency(rowTotal(row)) }}
                   </td>
                   <td class="warehouse-page__cell warehouse-page__cell--center text-center">{{ row.expiry | date: 'dd.MM.yyyy' }}</td>
                   <td class="warehouse-page__cell warehouse-page__cell--supplier" [attr.title]="row.supplier">
                     <span class="truncate">{{ row.supplier }}</span>
                   </td>
-                  <td class="warehouse-page__cell warehouse-page__cell--status">
+                  <td class="warehouse-page__cell warehouse-page__cell--status min-w-[112px]">
                     <span
-                      class="badge min-w-[88px] justify-center"
+                      class="badge min-w-[112px] justify-center"
                       [ngClass]="{
                         'badge-soft': row.status === 'warning',
                         'badge-danger': row.status === 'danger'
@@ -280,7 +303,7 @@
                   </td>
                 </tr>
                 <tr *ngIf="filteredRows().length === 0">
-                  <td class="warehouse-page__cell warehouse-page__empty-row" colspan="15">
+                  <td class="warehouse-page__cell warehouse-page__empty-row" colspan="12">
                     Нет поставок по текущим фильтрам
                   </td>
                 </tr>


### PR DESCRIPTION
## Summary
- align the supplies table header with the new column order, sticky styling, and utility classes
- adjust body cells to match the updated columns, including width constraints for the checkbox and status badge

## Testing
- npm run lint *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_68d95a9a5c00832397edbbb230dff4c7