### PR TITLE
style: restyle supply table rows and actions

### DIFF
--- a/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.css
+++ b/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.css
@@ -180,25 +180,26 @@
   background-color: #4f46e5;
 }
 
-.btn-ghost {
+.icon-btn {
+  width: 32px;
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0.5rem;
   border: none;
   background: transparent;
-  color: #475569;
-}
-
-.btn-ghost:hover:not(:disabled),
-.btn-ghost:focus-visible {
-  background-color: rgba(226, 232, 240, 0.6);
-  color: #0f172a;
-  outline: none;
-}
-
-.btn-icon {
-  width: 36px;
-  height: 36px;
-  font-size: 24px;
+  font-size: 20px;
   line-height: 1;
   padding: 0;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.icon-btn:hover,
+.icon-btn:focus-visible {
+  background: rgba(0, 0, 0, 0.06);
+  outline: none;
 }
 
 .btn-sm {
@@ -338,66 +339,6 @@
 .checkbox:focus-visible {
   outline: 2px solid #6366f1;
   outline-offset: 2px;
-}
-
-.menu {
-  position: relative;
-  display: inline-flex;
-}
-
-.menu__panel {
-  position: absolute;
-  right: 0;
-  top: calc(100% + 8px);
-  display: none;
-  flex-direction: column;
-  min-width: 160px;
-  padding: 8px 0;
-  border-radius: 10px;
-  border: 1px solid #e2e8f0;
-  background-color: #ffffff;
-  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.15);
-  z-index: 10;
-}
-
-.menu:focus-within .menu__panel,
-.menu:hover .menu__panel {
-  display: flex;
-}
-
-.menu__item {
-  width: 100%;
-  text-align: left;
-  padding: 10px 16px;
-  background: transparent;
-  border: none;
-  font-size: 0.875rem;
-  color: #0f172a;
-  cursor: pointer;
-  transition: background-color 0.2s ease, color 0.2s ease;
-}
-
-.menu__item:hover,
-.menu__item:focus-visible {
-  background-color: #f1f5f9;
-  color: #111827;
-  outline: none;
-}
-
-.menu__item--destructive {
-  color: #b91c1c;
-}
-
-.menu__item--destructive:hover,
-.menu__item--destructive:focus-visible {
-  background-color: rgba(248, 113, 113, 0.12);
-  color: #991b1b;
-}
-
-.menu__separator {
-  height: 1px;
-  margin: 4px 0;
-  background-color: #e2e8f0;
 }
 
 .no-data {

--- a/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.html
+++ b/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.html
@@ -117,30 +117,10 @@
             {{ item.status || item.state || 'Ок' }}
           </span>
         </td>
-        <td class="w-[44px]">
-          <div class="menu">
-            <button
-              type="button"
-              class="btn btn-ghost btn-icon"
-              aria-haspopup="true"
-              aria-expanded="false"
-              aria-label="Открыть меню"
-            >
-              ⋯
-            </button>
-            <div class="menu__panel" role="menu">
-              <button type="button" class="menu__item" role="menuitem" (click)="onSettingsClick.emit(item)">
-                Открыть
-              </button>
-              <button type="button" class="menu__item" role="menuitem">
-                Редактировать
-              </button>
-              <div class="menu__separator" role="separator"></div>
-              <button type="button" class="menu__item menu__item--destructive" role="menuitem">
-                Удалить
-              </button>
-            </div>
-          </div>
+        <td class="w-[44px] text-right">
+          <button type="button" class="icon-btn" aria-label="Меню" (click)="onSettingsClick.emit(item)">
+            ⋯
+          </button>
         </td>
       </tr>
       <tr *ngIf="paginatedData.length === 0">


### PR DESCRIPTION
## Summary
- update the supplies table row markup to use zebra striping, centered dates, and monospace numeric fields
- replace the status column badge styling and trailing action cell with the compact ellipsis icon button
- clean up obsolete dropdown menu styles and add the shared icon button styling

## Testing
- npm run lint *(fails: npm could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_68d95adeb7e483238e0a3f1fac54515d