### PR TITLE
feat: align supplies filter chips panel

### DIFF
--- a/feedme.client/src/app/warehouse/supplies/supplies.component.html
+++ b/feedme.client/src/app/warehouse/supplies/supplies.component.html
@@ -1,3 +1,43 @@
+<div class="card supplies__filters-card">
+  <form class="card__content p-4 flex flex-wrap items-center gap-3" (submit)="$event.preventDefault()">
+    <div class="supplies__filters-control">
+      <label class="supplies__filters-field">
+        <span class="supplies__filters-label">Поиск</span>
+        <input
+          type="search"
+          class="input w-[320px]"
+          placeholder="Поиск по номеру, SKU или названию"
+          aria-label="Поиск по поставкам"
+        />
+      </label>
+    </div>
+
+    <div class="supplies__filters-control">
+      <label class="supplies__filters-field">
+        <span class="supplies__filters-label">Дата от</span>
+        <input type="date" class="input w-[160px]" aria-label="Дата прихода от" />
+      </label>
+    </div>
+
+    <div class="supplies__filters-control">
+      <label class="supplies__filters-field">
+        <span class="supplies__filters-label">Дата до</span>
+        <input type="date" class="input w-[160px]" aria-label="Дата прихода до" />
+      </label>
+    </div>
+
+    <div class="chips" aria-label="Выбранные фильтры">
+      <div class="chip chip--filled">Главный склад</div>
+      <div class="chip">Ок</div>
+      <div class="chip chip--danger">Просрочено</div>
+    </div>
+
+    <button type="button" class="btn btn-outline">Сброс</button>
+    <button type="button" class="btn btn-secondary">Экспорт</button>
+    <button type="button" class="btn btn-primary ml-auto">+ Новая поставка</button>
+  </form>
+</div>
+
 <div class="bulkbar"> <!-- TODO: show on selection -->
   <span class="bulkbar__hint">Выбрано: 3</span>
   <div class="bulkbar__actions">

--- a/feedme.client/src/app/warehouse/supplies/supplies.component.scss
+++ b/feedme.client/src/app/warehouse/supplies/supplies.component.scss
@@ -1,3 +1,54 @@
+:host {
+  display: block;
+}
+
+.supplies__filters-card {
+  margin-bottom: 1rem;
+}
+
+.supplies__filters-control {
+  display: flex;
+}
+
+.supplies__filters-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.supplies__filters-label {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: #6b7280;
+}
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.chip {
+  padding: 0.25rem 0.5rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  border: 1px solid var(--border);
+  background: #fff;
+  color: #374151;
+}
+
+.chip--filled {
+  background: #eef2ff;
+  border-color: #c7d2fe;
+  color: #4338ca;
+}
+
+.chip--danger {
+  background: #fee2e2;
+  border-color: #fecaca;
+  color: #b91c1c;
+}
+
 .bulkbar {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- add a card-based filter panel to the supplies view with search, date controls, chips, and actions aligned per layout
- introduce component-scoped styles for the filter fields and chips to match the visual design

## Testing
- npm run lint *(fails: workspace has no configured "lint" target)*

------
https://chatgpt.com/codex/tasks/task_e_68d95ae4497883238e9c99923eddfdc4