### PR TITLE
style: align stock table with supply styling

### DIFF
--- a/feedme.client/src/app/components/StockTableComponent/stock-table.component.css
+++ b/feedme.client/src/app/components/StockTableComponent/stock-table.component.css
@@ -37,6 +37,16 @@
   white-space: nowrap;
 }
 
+.stock-table__head {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background-color: rgba(255, 255, 255, 0.92);
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: inset 0 -1px 0 0 rgba(148, 163, 184, 0.45);
+}
+
 .stock-table thead th.sorted {
   color: #6366f1;
 }
@@ -116,11 +126,15 @@
   vertical-align: middle;
 }
 
-.actions-cell {
-  width: 80px;
+.w-\[44px\] {
+  width: 44px;
 }
 
-.btn-action {
+.stock-table__actions-cell {
+  width: 44px;
+}
+
+.stock-table__action-button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -129,13 +143,14 @@
   border: none;
   border-radius: 8px;
   background-color: transparent;
-  font-size: 18px;
+  font-size: 22px;
+  line-height: 1;
   cursor: pointer;
   transition: background-color 0.2s ease, color 0.2s ease;
 }
 
-.btn-action:hover,
-.btn-action:focus-visible {
+.stock-table__action-button:hover,
+.stock-table__action-button:focus-visible {
   background-color: rgba(226, 232, 240, 0.7);
   color: #111827;
   outline: none;

--- a/feedme.client/src/app/components/StockTableComponent/stock-table.component.html
+++ b/feedme.client/src/app/components/StockTableComponent/stock-table.component.html
@@ -8,14 +8,16 @@
 
 <div class="table-container">
   <table class="stock-table">
-    <thead>
+    <thead class="stock-table__head sticky top-0 bg-background/90 backdrop-blur border-b shadow-[inset_0_-1px_0_0_var(--border)]">
       <tr class="h-11 align-middle">
         <th
           *ngFor="let column of columns"
+          scope="col"
           class="text-sm font-medium"
           [ngClass]="{
-            'text-right': column.field === 'unitPrice' || column.field === 'totalCost' || column.field === 'stock',
-            'text-center': column.field === 'expiryDate'
+            'text-right': column.field === 'unitPrice' || column.field === 'totalCost' || column.field === 'stock' || column.label === 'Кол-во',
+            'text-center': column.field === 'expiryDate' || column.label === 'Дата',
+            'font-mono text-xs': column.label === 'SKU'
           }"
           [attr.aria-sort]="getAriaSort(column.field)"
           [class.sorted]="sortKey === column.field"
@@ -31,44 +33,41 @@
             </span>
           </button>
         </th>
-        <th class="text-sm font-medium text-center">Действие</th>
+        <th scope="col" class="text-sm font-medium w-[44px]"></th>
       </tr>
     </thead>
     <tbody>
-      <tr *ngFor="let item of paginatedData" class="h-11 align-middle hover:bg-muted/40 odd:bg-muted/10">
+      <tr *ngFor="let item of paginatedData" class="stock-table__row h-11 align-middle hover:bg-muted/40 odd:bg-muted/10">
         <td
           *ngFor="let column of columns"
           [ngClass]="{
-            'text-right': column.field === 'unitPrice' || column.field === 'totalCost' || column.field === 'stock',
-            'text-center': column.field === 'expiryDate'
+            'text-right': column.field === 'unitPrice' || column.field === 'totalCost' || column.field === 'stock' || column.label === 'Кол-во',
+            'text-center': column.field === 'expiryDate' || column.label === 'Дата',
+            'font-mono text-xs': column.label === 'SKU'
           }"
         >
-          <ng-container [ngSwitch]="column.field">
-            <span
-              *ngSwitchCase="'name'"
-              class="truncate"
-              [title]="formatValue(item, column) ?? ''"
-            >
-              {{ formatValue(item, column) }}
-            </span>
-            <span
-              *ngSwitchCase="'category'"
-              class="truncate"
-              [title]="formatValue(item, column) ?? ''"
-            >
-              {{ formatValue(item, column) }}
-            </span>
-            <span *ngSwitchDefault>
+          <ng-container *ngIf="column.label === 'Название' || column.label === 'Поставщик'; else plainCell">
+            <span class="truncate" [title]="formatValue(item, column) ?? ''">
               {{ formatValue(item, column) }}
             </span>
           </ng-container>
+          <ng-template #plainCell>
+            <span>{{ formatValue(item, column) }}</span>
+          </ng-template>
         </td>
-        <td class="actions-cell text-center">
-          <button (click)="onSettingsClick.emit(item)" class="btn-action" aria-label="Открыть настройки">⚙️</button>
+        <td class="stock-table__actions-cell text-center">
+          <button
+            type="button"
+            class="stock-table__action-button"
+            (click)="onSettingsClick.emit(item)"
+            aria-label="Открыть меню действий"
+          >
+            ⋯
+          </button>
         </td>
       </tr>
       <tr *ngIf="paginatedData.length === 0">
-        <td colspan="7" class="no-data">Нет данных</td>
+        <td [attr.colspan]="columns.length + 1" class="no-data">Нет данных</td>
       </tr>
     </tbody>
   </table>


### PR DESCRIPTION
## Summary
- restyled the stock table header to match the sticky, elevated supplies table appearance
- updated row and cell markup so quantity, date, and SKU columns inherit the same alignment rules as the supplies view and replaced the action icon with an ellipsis button
- refreshed component-specific styles to support the sticky header and the new compact action button width

## Testing
- npm run lint *(fails: project has no configured lint target and prompts to add ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_68d95af2a234832386ac8d1614150093