### PR TITLE
feat: apply orange brand theme

### DIFF
--- a/feedme.client/src/styles.css
+++ b/feedme.client/src/styles.css
@@ -1,9 +1,10 @@
 /* глобальные стили */
 :root {
-  --accent-color: #fa4b00;
-  --accent-hover-color: #d94300;
-  --cancel-color: #ccc;
-  --cancel-hover-color: #b3b3b3;
+  --brand: #ff6a00;
+  --brand-600: #ff6a00;
+  --brand-700: #e85f00;
+  --ring: var(--brand-600);
+  --radius: 0px;
 }
 
 html, body {
@@ -43,7 +44,7 @@ select {
     height: 40px;
     padding: 8px;
     border: 1px solid #ccc;
-    border-radius: 5px;
+    border-radius: var(--radius);
     box-sizing: border-box;
   }
 
@@ -62,49 +63,60 @@ select {
 .cancel-btn,
 .save-btn {
   padding: 8px 16px;
-  border-radius: 6px;
+  border-radius: var(--radius);
   cursor: pointer;
   border: none;
   font-size: 14px;
 }
 
 .cancel-btn {
-  background-color: var(--cancel-color);
+  background-color: #ccc;
   color: #333;
 }
 
   .cancel-btn:hover {
-    background-color: var(--cancel-hover-color);
+    background-color: #b3b3b3;
   }
 
 .save-btn {
-  background-color: var(--accent-color);
+  background-color: var(--brand-600);
   color: #fff;
 }
 
 .save-btn:hover {
-  background-color: var(--accent-hover-color);
+  background-color: var(--brand-700);
 }
 
-.btn {
+.btn,
+button,
+.shadcn-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 8px;
-  border-radius: 10px;
+  border-radius: var(--radius);
   border: none;
   padding: 10px 18px;
   font-size: 0.95rem;
   font-weight: 600;
   cursor: pointer;
   transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
-  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  background: var(--brand-600);
   color: #ffffff;
-  box-shadow: 0 8px 16px rgba(37, 99, 235, 0.25);
+  box-shadow: 0 8px 16px rgba(255, 106, 0, 0.25);
 }
 
-.btn:hover:not(:disabled) {
-  background: linear-gradient(135deg, #1d4ed8, #1e3a8a);
+.btn--primary,
+.shadcn-btn:not([variant]),
+.shadcn-btn[variant="default"] {
+  background: var(--brand-600);
+  color: #ffffff;
+}
+
+.btn:hover:not(:disabled),
+.shadcn-btn:hover:not(:disabled),
+button:hover:not(:disabled) {
+  background: var(--brand-700);
 }
 
 .btn:disabled {
@@ -116,29 +128,33 @@ select {
 .btn-sm {
   padding: 6px 12px;
   font-size: 0.8125rem;
-  border-radius: 8px;
+  border-radius: var(--radius);
   box-shadow: none;
 }
 
-.btn-outline {
-  background: #ffffff;
-  color: #1d4ed8;
-  border: 1px solid rgba(29, 78, 216, 0.4);
+.btn-outline,
+.shadcn-btn[variant="outline"] {
+  background: transparent;
+  color: var(--brand-600);
+  border: 1px solid var(--brand-600);
   box-shadow: none;
 }
 
-.btn-outline:hover:not(:disabled) {
-  background: rgba(29, 78, 216, 0.08);
+.btn-outline:hover:not(:disabled),
+.shadcn-btn[variant="outline"]:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--brand-600) 10%, #ffffff);
 }
 
-.btn-secondary {
-  background: linear-gradient(135deg, #10b981, #059669);
-  color: #ffffff;
-  box-shadow: 0 8px 16px rgba(16, 185, 129, 0.25);
+.btn-secondary,
+.shadcn-btn[variant="secondary"] {
+  background: color-mix(in srgb, var(--brand-600) 10%, #ffffff);
+  color: var(--brand-600);
+  box-shadow: 0 8px 16px rgba(255, 106, 0, 0.15);
 }
 
-.btn-secondary:hover:not(:disabled) {
-  background: linear-gradient(135deg, #059669, #047857);
+.btn-secondary:hover:not(:disabled),
+.shadcn-btn[variant="secondary"]:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--brand-600) 20%, #ffffff);
 }
 
 .btn-danger {
@@ -164,7 +180,7 @@ select {
 .input,
 .select {
   width: 100%;
-  border-radius: 10px;
+  border-radius: var(--radius);
   border: 1px solid #d1d5db;
   background-color: #ffffff;
   padding: 10px 14px;
@@ -177,8 +193,8 @@ select {
 .input:focus,
 .select:focus {
   outline: none;
-  border-color: #2563eb;
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.25);
+  border-color: var(--ring);
+  box-shadow: 0 0 0 3px rgba(255, 106, 0, 0.25);
 }
 
 .select {
@@ -196,13 +212,21 @@ select {
   align-items: center;
   justify-content: center;
   padding: 4px 10px;
-  border-radius: 999px;
-  background-color: rgba(16, 185, 129, 0.18);
-  color: #047857;
+  border-radius: var(--radius);
+  background-color: color-mix(in srgb, var(--brand-600) 10%, #ffffff);
+  color: var(--brand-600);
   font-size: 0.75rem;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.06em;
+}
+
+.card,
+.table,
+.input,
+.select,
+.badge {
+  border-radius: var(--radius);
 }
 
 .badge-soft {


### PR DESCRIPTION
## Summary
- introduce global orange brand variables and a zero-radius token for the shared theme
- refresh buttons, form controls, and badges to align with the new brand colors and squared styling

## Testing
- `npm run lint` *(fails: npm could not determine executable to run in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9605d16e083238c3ef2c7b2c30cb0