### PR TITLE
style: align supplies buttons with brand palette

### DIFF
--- a/feedme.client/src/app/warehouse/supplies/supplies.component.html
+++ b/feedme.client/src/app/warehouse/supplies/supplies.component.html
@@ -32,18 +32,18 @@
       <div class="chip chip--danger">Просрочено</div>
     </div>
 
-    <button type="button" class="btn btn-outline">Сброс</button>
-    <button type="button" class="btn btn-secondary">Экспорт</button>
-    <button type="button" class="btn btn-primary ml-auto">+ Новая поставка</button>
+    <button type="button" class="btn btn--outline">Сброс</button>
+    <button type="button" class="btn btn--secondary">Экспорт</button>
+    <button type="button" class="btn btn--primary ml-auto">+ Новая поставка</button>
   </form>
 </div>
 
 <div class="bulkbar"> <!-- TODO: show on selection -->
   <span class="bulkbar__hint">Выбрано: 3</span>
   <div class="bulkbar__actions">
-    <button class="btn btn-outline btn-sm" type="button">Списать</button>
-    <button class="btn btn-outline btn-sm" type="button">Переместить</button>
-    <button class="btn btn-outline btn-sm" type="button">Печать</button>
+    <button class="btn btn--outline btn-sm" type="button">Списать</button>
+    <button class="btn btn--outline btn-sm" type="button">Переместить</button>
+    <button class="btn btn--outline btn-sm" type="button">Печать</button>
     <button class="btn btn-danger btn-sm" type="button">Удалить</button>
   </div>
 </div>

--- a/feedme.client/src/app/warehouse/supplies/supplies.component.scss
+++ b/feedme.client/src/app/warehouse/supplies/supplies.component.scss
@@ -1,5 +1,12 @@
 :host {
   display: block;
+  --supplies-primary: #fa4b00;
+  --supplies-primary-hover: #d94300;
+  --supplies-secondary: #ffe8db;
+  --supplies-secondary-hover: #ffd4bc;
+  --supplies-outline-hover: rgba(250, 75, 0, 0.08);
+  --supplies-outline-border: #fa4b00;
+  --supplies-outline-text: #8a2e00;
 }
 
 .supplies__filters-card {
@@ -68,4 +75,71 @@
   margin-left: auto;
   display: flex;
   gap: 0.5rem;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.625rem 1rem;
+  border-radius: 0;
+  border: 1px solid transparent;
+  background: transparent;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  line-height: 1.2;
+  color: #1f2937;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn.btn-sm {
+  padding: 0.5rem 0.75rem;
+  font-size: 0.8125rem;
+}
+
+.btn--primary {
+  background: var(--supplies-primary);
+  color: #ffffff;
+}
+
+.btn--primary:hover:not(:disabled) {
+  background: var(--supplies-primary-hover);
+}
+
+.btn--secondary {
+  background: var(--supplies-secondary);
+  color: var(--supplies-outline-text);
+}
+
+.btn--secondary:hover:not(:disabled) {
+  background: var(--supplies-secondary-hover);
+}
+
+.btn--outline {
+  background: transparent;
+  color: var(--supplies-outline-text);
+  border-color: var(--supplies-outline-border);
+}
+
+.btn--outline:hover:not(:disabled) {
+  background: var(--supplies-outline-hover);
+}
+
+.btn.btn-danger {
+  background: #dc2626;
+  color: #ffffff;
+  border-color: #dc2626;
+}
+
+.btn.btn-danger:hover:not(:disabled) {
+  background: #b91c1c;
+  border-color: #b91c1c;
 }


### PR DESCRIPTION
## Summary
- add brand-specific modifier classes to the supplies action buttons
- scope orange palette styling for primary, secondary, and outline buttons on the supplies page

## Testing
- npm run lint *(fails: npm could not determine executable to run in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d96065bdd08323a0379851525ee44e