### PR TITLE
feat: restyle supply status badges

### DIFF
--- a/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.css
+++ b/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.css
@@ -298,28 +298,6 @@
   vertical-align: middle;
 }
 
-.badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 4px 10px;
-  border-radius: 9999px;
-  background-color: rgba(16, 185, 129, 0.18);
-  color: #047857;
-  font-size: 0.8125rem;
-  font-weight: 600;
-}
-
-.badge-secondary {
-  background-color: rgba(245, 158, 11, 0.18);
-  color: #b45309;
-}
-
-.badge-destructive {
-  background-color: rgba(248, 113, 113, 0.18);
-  color: #b91c1c;
-}
-
 .min-w-\[88px\] {
   min-width: 88px;
 }

--- a/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.html
+++ b/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.html
@@ -107,15 +107,14 @@
           </span>
         </td>
         <td>
-          <span
-            class="badge min-w-[88px] justify-center"
-            [ngClass]="{
-              'badge-secondary': item.status?.toLowerCase() === 'скоро срок',
-              'badge-destructive': item.status?.toLowerCase() === 'просрочено'
-            }"
-          >
-            {{ item.status || item.state || 'Ок' }}
-          </span>
+          <ng-container *ngIf="(item.status || item.state || 'Ок') as status">
+            <span
+              class="badge min-w-[88px] justify-center"
+              [ngClass]="status | statusBadgeClass"
+            >
+              {{ status }}
+            </span>
+          </ng-container>
         </td>
         <td class="w-[44px] text-right">
           <button type="button" class="icon-btn" aria-label="Меню" (click)="onSettingsClick.emit(item)">

--- a/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.ts
+++ b/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { TableControlsComponent } from '../table-controls/table-controls.component';
 import { EmptyStateComponent } from '../../warehouse/ui/empty-state.component';
+import { StatusBadgeClassPipe } from '../../pipes/status-badge-class.pipe';
 
 type SortDirection = 'asc' | 'desc';
 type SortType = 'string' | 'number' | 'date';
@@ -21,7 +22,7 @@ interface FilterOptions {
 @Component({
   selector: 'app-supply-table',
   standalone: true,
-  imports: [CommonModule, FormsModule, TableControlsComponent, EmptyStateComponent],
+  imports: [CommonModule, FormsModule, TableControlsComponent, EmptyStateComponent, StatusBadgeClassPipe],
   templateUrl: './supply-table.component.html',
   styleUrls: ['./supply-table.component.css']
 })

--- a/feedme.client/src/app/pipes/status-badge-class.pipe.ts
+++ b/feedme.client/src/app/pipes/status-badge-class.pipe.ts
@@ -1,0 +1,31 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+const STATUS_CLASS_MAP = new Map<string, string>([
+  ['ок', 'badge--ok'],
+  ['ok', 'badge--ok'],
+  ['норма', 'badge--ok'],
+  ['normal', 'badge--ok'],
+  ['в наличии', 'badge--ok'],
+  ['скоро срок', 'badge--warn'],
+  ['warning', 'badge--warn'],
+  ['warn', 'badge--warn'],
+  ['due soon', 'badge--warn'],
+  ['soon', 'badge--warn'],
+  ['просрочено', 'badge--danger'],
+  ['danger', 'badge--danger'],
+  ['expired', 'badge--danger'],
+  ['overdue', 'badge--danger'],
+]);
+
+const DEFAULT_BADGE_CLASS = 'badge--ok';
+
+@Pipe({
+  name: 'statusBadgeClass',
+  standalone: true,
+})
+export class StatusBadgeClassPipe implements PipeTransform {
+  transform(status?: string | null): string {
+    const normalized = (status ?? '').trim().toLowerCase();
+    return STATUS_CLASS_MAP.get(normalized) ?? DEFAULT_BADGE_CLASS;
+  }
+}

--- a/feedme.client/src/app/warehouse/warehouse-page.component.html
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.html
@@ -270,10 +270,7 @@
                   <td class="warehouse-page__cell warehouse-page__cell--status min-w-[112px]">
                     <span
                       class="badge min-w-[112px] justify-center"
-                      [ngClass]="{
-                        'badge-soft': row.status === 'warning',
-                        'badge-danger': row.status === 'danger'
-                      }"
+                      [ngClass]="row.status | statusBadgeClass"
                     >
                       {{ row.status === 'ok' ? 'Ок' : row.status === 'warning' ? 'Скоро срок' : 'Просрочено' }}
                     </span>
@@ -343,13 +340,7 @@
           <div class="warehouse-page__drawer-title">{{ row.name }}</div>
           <div class="warehouse-page__drawer-meta">SKU {{ row.sku }}</div>
         </div>
-        <span
-          class="badge"
-          [ngClass]="{
-            'badge-soft': row.status === 'warning',
-            'badge-danger': row.status === 'danger'
-          }"
-        >
+        <span class="badge" [ngClass]="row.status | statusBadgeClass">
           {{ row.status === 'ok' ? 'Ок' : row.status === 'warning' ? 'Скоро срок' : 'Просрочено' }}
         </span>
       </header>

--- a/feedme.client/src/app/warehouse/warehouse-page.component.ts
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.ts
@@ -21,6 +21,7 @@ import { WarehouseService } from './warehouse.service';
 import { EmptyStateComponent } from './ui/empty-state.component';
 import { FieldComponent } from './ui/field.component';
 import { MetricComponent } from './ui/metric.component';
+import { StatusBadgeClassPipe } from '../pipes/status-badge-class.pipe';
 
 const RUB_FORMATTER = new Intl.NumberFormat('ru-RU', {
   style: 'currency',
@@ -39,6 +40,7 @@ const RUB_FORMATTER = new Intl.NumberFormat('ru-RU', {
     MetricComponent,
     FieldComponent,
     EmptyStateComponent,
+    StatusBadgeClassPipe,
   ],
   templateUrl: './warehouse-page.component.html',
   styleUrl: './warehouse-page.component.css',

--- a/feedme.client/src/styles.css
+++ b/feedme.client/src/styles.css
@@ -195,22 +195,29 @@ select {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 4px 10px;
-  border-radius: 999px;
-  background-color: rgba(16, 185, 129, 0.18);
-  color: #047857;
-  font-size: 0.75rem;
+  gap: 0.25rem;
+  padding: 0.125rem 0.5rem;
+  border-radius: var(--radius, 0.5rem);
+  border: 1px solid transparent;
+  font-size: 0.8125rem;
   font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
+  line-height: 1.25;
 }
 
-.badge-soft {
-  background-color: rgba(234, 179, 8, 0.18);
+.badge--ok {
+  background-color: #e8f7ee;
+  color: #1f9254;
+  border-color: #bde5cd;
+}
+
+.badge--warn {
+  background-color: #fff7ed;
   color: #b45309;
+  border-color: #fde5c7;
 }
 
-.badge-danger {
-  background-color: rgba(239, 68, 68, 0.18);
+.badge--danger {
+  background-color: #fee2e2;
   color: #b91c1c;
+  border-color: #fecaca;
 }


### PR DESCRIPTION
## Summary
- restyle shared badge styles to use squared variants with thin borders for OK, warning, and danger
- add a reusable `statusBadgeClass` pipe and apply it in the supply table and warehouse page templates

## Testing
- npm test *(fails: ChromeHeadless cannot start because libatk-1.0.so.0 is missing in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d96076acdc83238f10f797d8991123