### PR TITLE
feat: restyle supply filter chips

### DIFF
--- a/feedme.client/src/app/warehouse/supplies/supplies.component.scss
+++ b/feedme.client/src/app/warehouse/supplies/supplies.component.scss
@@ -30,7 +30,7 @@
 
 .chip {
   padding: 0.25rem 0.5rem;
-  border-radius: 9999px;
+  border-radius: var(--radius);
   font-size: 0.75rem;
   border: 1px solid var(--border);
   background: #fff;
@@ -38,15 +38,21 @@
 }
 
 .chip--filled {
-  background: #eef2ff;
-  border-color: #c7d2fe;
-  color: #4338ca;
+  background: color-mix(in srgb, var(--brand-600) 10%, #fff);
+  border: 1px solid var(--brand-600);
+  color: var(--brand-600);
 }
 
 .chip--danger {
   background: #fee2e2;
   border-color: #fecaca;
   color: #b91c1c;
+}
+
+.chip--ghost {
+  border: 1px dashed var(--brand-600);
+  color: var(--brand-600);
+  background: transparent;
 }
 
 .bulkbar {


### PR DESCRIPTION
## Summary
- align supply filter chip radius with the design token and update the filled treatment to use the brand palette
- add a dashed ghost chip variant to support outlined orange filters

## Testing
- npm run lint *(fails: lint target not configured for the Angular project)*

------
https://chatgpt.com/codex/tasks/task_e_68d9607086608323901fc4b618a8bc27