### PR TITLE
Normalize warehouse UI border radii

### DIFF
--- a/feedme.client/src/app/warehouse/supplies/supplies.component.scss
+++ b/feedme.client/src/app/warehouse/supplies/supplies.component.scss
@@ -2,6 +2,14 @@
   display: block;
 }
 
+.card,
+.input,
+.select,
+.table,
+.dialog {
+  border-radius: var(--radius);
+}
+
 .supplies__filters-card {
   margin-bottom: 1rem;
 }
@@ -30,7 +38,7 @@
 
 .chip {
   padding: 0.25rem 0.5rem;
-  border-radius: 9999px;
+  border-radius: var(--radius);
   font-size: 0.75rem;
   border: 1px solid var(--border);
   background: #fff;
@@ -55,7 +63,7 @@
   gap: 0.75rem;
   background: color-mix(in srgb, #f6f7f9 40%, transparent);
   border: 1px solid var(--border);
-  border-radius: 0.5rem;
+  border-radius: var(--radius);
   padding: 0.5rem 0.75rem;
 }
 

--- a/feedme.client/src/app/warehouse/ui/empty-state.component.scss
+++ b/feedme.client/src/app/warehouse/ui/empty-state.component.scss
@@ -1,6 +1,6 @@
 .empty {
   border: 1px dashed var(--border, #e5e7eb);
-  border-radius: .75rem;
+  border-radius: var(--radius);
   padding: 2rem;
   text-align: center;
   background: color-mix(in srgb, #f6f7f9 30%, transparent);


### PR DESCRIPTION
## Summary
- align warehouse supplies styles with the shared radius token instead of hard-coded rounded corners
- add a shared radius override for card, input, select, table, and dialog shells within the supplies view
- update the empty state styles to respect the global radius variable

## Testing
- `npm run lint` *(fails: npm could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_68d9607aea008323ae46310fc94e0698