### PR TITLE
style: add global focus ring variable and styling

### DIFF
--- a/feedme.client/src/styles.css
+++ b/feedme.client/src/styles.css
@@ -2,8 +2,15 @@
 :root {
   --accent-color: #fa4b00;
   --accent-hover-color: #d94300;
+  --brand-600: #fa4b00;
+  --ring: var(--brand-600);
   --cancel-color: #ccc;
   --cancel-hover-color: #b3b3b3;
+}
+
+*:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--ring);
 }
 
 html, body {


### PR DESCRIPTION
## Summary
- introduce a reusable `--ring` design token tied to the brand orange in the global stylesheet
- draw a consistent orange focus-visible ring across interactive elements for accessibility

## Testing
- npm run lint *(fails: project has no lint target configured yet)*
- npm test -- --watch=false --browsers=ChromeHeadlessNoSandbox *(fails: ChromeHeadless cannot start because libatk-1.0.so.0 is missing in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d960806ae88323971d31b81a0d4dba