### PR TITLE
Remove extra scrolling and rounding from supply table layout

### DIFF
--- a/feedme.client/src/app/app.component.css
+++ b/feedme.client/src/app/app.component.css
@@ -26,7 +26,6 @@
 
 .content-wrapper {
   flex: 1;
-  overflow-y: auto;
   background: #f9f9f9;
   padding: 16px;
 }
@@ -43,5 +42,5 @@
   flex: 1; /* занять всё оставшееся пространство */
   display: flex;
   flex-direction: column; /* чтобы header был над content */
-  overflow: auto; /* если контента больше области */
+  overflow: hidden; /* исключаем прокрутку внутри основного контейнера */
 }

--- a/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.css
+++ b/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.css
@@ -1,14 +1,19 @@
 :host {
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: 0;
 }
 
 .card {
   border: 1px solid #e2e8f0;
-  border-radius: 12px;
+  border-radius: 0;
   background-color: #ffffff;
-  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.04);
+  box-shadow: none;
+}
+
+.supplies-filters {
+  margin: 0;
+  border-bottom: 0;
 }
 
 .card__content {
@@ -208,11 +213,12 @@
 }
 
 .table-container {
-  overflow-x: auto;
-  border-radius: 12px;
+  overflow-x: hidden;
+  border-radius: 0;
   border: 1px solid #e2e8f0;
+  border-top: 0;
   background-color: #ffffff;
-  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.04);
+  box-shadow: none;
 }
 
 .supplies-table {
@@ -327,10 +333,11 @@
 }
 
 .table-footer {
-  border-radius: 12px;
+  border-radius: 0;
   border: 1px solid rgba(148, 163, 184, 0.35);
+  border-top: 0;
   background-color: rgba(226, 232, 240, 0.4);
-  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.08);
+  box-shadow: none;
 }
 
 .text-muted-foreground {


### PR DESCRIPTION
## Summary
- disable scrolling on the main application container to remove duplicate scrollbars
- square off the supply table card, table container, and footer while eliminating spacing between the filters and table

## Testing
- npm run lint *(fails: lint target is not configured in this workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68d9917f13c48323ad0cf52c39ad0f98