### PR TITLE
feat: add dashboard snapshot metrics to warehouse page

### DIFF
--- a/feedme.client/src/app/warehouse/warehouse-page.component.css
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.css
@@ -112,10 +112,68 @@
   gap: 32px;
 }
 
-.warehouse-page__metrics {
+.warehouse-page__snapshot {
   display: grid;
   gap: 16px;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.square {
+  border-radius: 0;
+}
+
+.warehouse-page__metric-card {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 24px;
+  border: 1px solid var(--border, #e5e7eb);
+  background-color: #ffffff;
+  aspect-ratio: 1 / 1;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06);
+}
+
+.warehouse-page__metric-label {
+  font-size: 0.875rem;
+  line-height: 1.4;
+  font-weight: 500;
+  color: var(--muted-foreground, #6b7280);
+}
+
+.warehouse-page__metric-value {
+  font-size: 1.5rem;
+  line-height: 1.25;
+  font-weight: 600;
+  color: var(--brand, #fa4b00);
+}
+
+.warehouse-page__metric-value--currency {
+  font-variant-numeric: tabular-nums;
+}
+
+.warehouse-page__metric-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 48px;
+  padding: 6px 12px;
+  border-radius: 9999px;
+  background-color: #fee2e2;
+  color: #b91c1c;
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.warehouse-page__metric-card--expired .warehouse-page__metric-value {
+  color: #b91c1c;
+}
+
+@media (max-width: 1024px) {
+  .warehouse-page__snapshot {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
 .warehouse-page__tabs {

--- a/feedme.client/src/app/warehouse/warehouse-page.component.html
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.html
@@ -33,12 +33,33 @@
     </header>
 
     <section class="warehouse-page__body">
-      <div class="warehouse-page__metrics">
-        <app-metric title="Позиций на складе" value="1 248" hint="активные SKU"></app-metric>
-        <app-metric title="Просрочено" value="2" hint="требует списания" variant="danger"></app-metric>
-        <app-metric title="Скоро срок" value="7" hint="≤ 14 дней" variant="warn"></app-metric>
-        <app-metric title="Ниже минимума" value="5" hint="> авто-заказ" variant="warn"></app-metric>
-      </div>
+      <section
+        *ngIf="metrics() as snapshot"
+        class="warehouse-page__snapshot"
+        aria-label="Ключевые показатели склада"
+      >
+        <article class="square warehouse-page__metric-card" aria-live="polite">
+          <p class="warehouse-page__metric-label">Поставок за 7 дней</p>
+          <p class="warehouse-page__metric-value">{{ snapshot.suppliesLastWeek }}</p>
+        </article>
+
+        <article class="square warehouse-page__metric-card" aria-live="polite">
+          <p class="warehouse-page__metric-label">Сумма закупок / 7 дн.</p>
+          <p class="warehouse-page__metric-value warehouse-page__metric-value--currency">0 ₽</p>
+        </article>
+
+        <article class="square warehouse-page__metric-card" aria-live="polite">
+          <p class="warehouse-page__metric-label">Позиций на складе</p>
+          <p class="warehouse-page__metric-value">{{ snapshot.positions }}</p>
+        </article>
+
+        <article class="square warehouse-page__metric-card warehouse-page__metric-card--expired" aria-live="polite">
+          <p class="warehouse-page__metric-label">Просрочено</p>
+          <p class="warehouse-page__metric-value">
+            <span class="warehouse-page__metric-badge">{{ snapshot.expired }}</span>
+          </p>
+        </article>
+      </section>
 
       <nav class="warehouse-page__tabs tabs" role="tablist">
         <button

--- a/feedme.client/src/app/warehouse/warehouse-page.component.ts
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.ts
@@ -20,7 +20,6 @@ import { SupplyRow, SupplyStatus } from './models';
 import { WarehouseService } from './warehouse.service';
 import { EmptyStateComponent } from './ui/empty-state.component';
 import { FieldComponent } from './ui/field.component';
-import { MetricComponent } from './ui/metric.component';
 import { StatusBadgeClassPipe } from '../pipes/status-badge-class.pipe';
 
 const RUB_FORMATTER = new Intl.NumberFormat('ru-RU', {
@@ -37,7 +36,6 @@ const RUB_FORMATTER = new Intl.NumberFormat('ru-RU', {
     NgIf,
     NgClass,
     ReactiveFormsModule,
-    MetricComponent,
     FieldComponent,
     EmptyStateComponent,
     StatusBadgeClassPipe,
@@ -69,6 +67,34 @@ export class WarehousePageComponent {
   readonly menuRowId = signal<number | null>(null);
 
   readonly rows = this.warehouseService.list();
+
+  readonly metrics = computed(() => {
+    const rows = this.rows();
+    const now = new Date();
+    const sevenDaysAgo = new Date(now);
+    sevenDaysAgo.setDate(now.getDate() - 7);
+
+    let suppliesLastWeek = 0;
+    let expired = 0;
+
+    for (const row of rows) {
+      const arrivalDate = new Date(row.arrivalDate);
+      if (arrivalDate >= sevenDaysAgo) {
+        suppliesLastWeek += 1;
+      }
+
+      const expiryDate = new Date(row.expiry);
+      if (expiryDate < now) {
+        expired += 1;
+      }
+    }
+
+    return {
+      suppliesLastWeek,
+      positions: rows.length,
+      expired,
+    };
+  });
 
   readonly suppliers = computed(() =>
     Array.from(new Set(this.rows().map((row) => row.supplier))).sort((a, b) =>


### PR DESCRIPTION
## Summary
- replace the warehouse metrics section with square snapshot cards styled for desktop and mobile breakpoints
- compute last-week supply, position, and expired counts in the shell to drive the new cards while keeping the 7-day purchase stub

## Testing
- NG_CLI_DISABLE_TTY=1 ./node_modules/.bin/ng build

------
https://chatgpt.com/codex/tasks/task_e_68d9937e774c83239907a808b8695a20