### PR TITLE
feat: add expiry status badges to stock table

### DIFF
--- a/feedme.client/src/app/components/StockTableComponent/stock-table.component.css
+++ b/feedme.client/src/app/components/StockTableComponent/stock-table.component.css
@@ -156,6 +156,42 @@
   outline: none;
 }
 
+.stock-table__row {
+  transition: background-color 0.2s ease;
+}
+
+.stock-table__row--expired,
+.stock-table__row--expired:nth-child(odd) {
+  background-color: #fff7f7;
+}
+
+.stock-table__row--expired:hover {
+  background-color: #ffe8e8;
+}
+
+.stock-table__expiry {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: 100%;
+}
+
+.stock-table__expiry-date {
+  font-variant-numeric: tabular-nums;
+  color: #0f172a;
+}
+
+.badge-square {
+  min-width: 32px;
+  height: 32px;
+  padding: 0 12px;
+  border-radius: 8px;
+  font-size: 0.75rem;
+  line-height: 1;
+  font-weight: 600;
+}
+
 .no-data {
   padding: 24px;
   text-align: center;

--- a/feedme.client/src/app/components/StockTableComponent/stock-table.component.html
+++ b/feedme.client/src/app/components/StockTableComponent/stock-table.component.html
@@ -37,35 +37,63 @@
       </tr>
     </thead>
     <tbody>
-      <tr *ngFor="let item of paginatedData" class="stock-table__row h-11 align-middle hover:bg-muted/40 odd:bg-muted/10">
-        <td
-          *ngFor="let column of columns"
-          [ngClass]="{
-            'text-right': column.field === 'unitPrice' || column.field === 'totalCost' || column.field === 'stock' || column.label === 'Кол-во',
-            'text-center': column.field === 'expiryDate' || column.label === 'Дата',
-            'font-mono text-xs': column.label === 'SKU'
-          }"
-        >
-          <ng-container *ngIf="column.label === 'Название' || column.label === 'Поставщик'; else plainCell">
-            <span class="truncate" [title]="formatValue(item, column) ?? ''">
-              {{ formatValue(item, column) }}
-            </span>
-          </ng-container>
-          <ng-template #plainCell>
-            <span>{{ formatValue(item, column) }}</span>
-          </ng-template>
-        </td>
-        <td class="stock-table__actions-cell text-center">
-          <button
-            type="button"
-            class="stock-table__action-button"
-            (click)="onSettingsClick.emit(item)"
-            aria-label="Открыть меню действий"
+      <ng-container *ngFor="let item of paginatedData">
+        <ng-container *ngIf="getExpiryInfo(item) as expiry">
+          <tr
+            class="stock-table__row h-11 align-middle hover:bg-muted/40 odd:bg-muted/10"
+            [ngClass]="{ 'stock-table__row--expired': expiry.status?.state === 'danger' }"
           >
-            ⋯
-          </button>
-        </td>
-      </tr>
+            <td
+              *ngFor="let column of columns"
+              [ngClass]="{
+                'text-right': column.field === 'unitPrice' || column.field === 'totalCost' || column.field === 'stock' || column.label === 'Кол-во',
+                'text-center': column.field === 'expiryDate' || column.label === 'Дата',
+                'font-mono text-xs': column.label === 'SKU'
+              }"
+            >
+              <ng-container *ngIf="column.field === 'expiryDate'; else defaultCell">
+                <div class="stock-table__expiry">
+                  <span class="stock-table__expiry-date">
+                    <ng-container *ngIf="expiry.date; else rawExpiry">
+                      {{ expiry.date | date: 'dd.MM.yyyy' }}
+                    </ng-container>
+                    <ng-template #rawExpiry>
+                      {{ formatValue(item, column) || '—' }}
+                    </ng-template>
+                  </span>
+                  <span
+                    *ngIf="expiry.status as status"
+                    class="badge badge-square"
+                    [ngClass]="status.badgeClass"
+                  >
+                    {{ status.label }}
+                  </span>
+                </div>
+              </ng-container>
+              <ng-template #defaultCell>
+                <ng-container *ngIf="column.label === 'Название' || column.label === 'Поставщик'; else plainCell">
+                  <span class="truncate" [title]="formatValue(item, column) ?? ''">
+                    {{ formatValue(item, column) }}
+                  </span>
+                </ng-container>
+                <ng-template #plainCell>
+                  <span>{{ formatValue(item, column) }}</span>
+                </ng-template>
+              </ng-template>
+            </td>
+            <td class="stock-table__actions-cell text-center">
+              <button
+                type="button"
+                class="stock-table__action-button"
+                (click)="onSettingsClick.emit(item)"
+                aria-label="Открыть меню действий"
+              >
+                ⋯
+              </button>
+            </td>
+          </tr>
+        </ng-container>
+      </ng-container>
       <tr *ngIf="paginatedData.length === 0">
         <td [attr.colspan]="columns.length + 1" class="no-data">Нет данных</td>
       </tr>


### PR DESCRIPTION
## Summary
- render shelf-life badges next to expiry dates with OK/≤14 days/expired states
- tint expired rows and style square badges for the stock table
- centralize expiry status calculation with caching for reuse in the template

## Testing
- npm run lint *(fails: project has no configured "lint" target)*
- npm run test *(fails: ChromeHeadless missing libatk-1.0.so.0 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d99380b17c83238a6225947bb41112