### PR TITLE
feat: add quick action icons to supplies table

### DIFF
--- a/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.css
+++ b/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.css
@@ -58,6 +58,10 @@
   width: 44px;
 }
 
+.w-\[176px\] {
+  width: 176px;
+}
+
 .input {
   display: block;
   width: 100%;
@@ -200,6 +204,48 @@
 .icon-btn:focus-visible {
   background: rgba(0, 0, 0, 0.06);
   outline: none;
+}
+
+.row-actions {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 4px;
+  width: 100%;
+  flex-wrap: nowrap;
+}
+
+.row-action {
+  width: 28px;
+  height: 28px;
+  border: 0;
+  background: transparent;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0;
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.row-action:hover,
+.row-action:focus-visible {
+  background: rgba(17, 24, 39, 0.06);
+  outline: none;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .btn-sm {

--- a/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.html
+++ b/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.html
@@ -63,7 +63,9 @@
         <th scope="col" class="text-sm font-medium text-center">Срок годности</th>
         <th scope="col" class="text-sm font-medium">Поставщик</th>
         <th scope="col" class="text-sm font-medium">Статус</th>
-        <th scope="col" class="w-[44px]"></th>
+        <th scope="col" class="w-[176px] text-right">
+          <span class="sr-only">Быстрые действия</span>
+        </th>
       </tr>
     </thead>
     <tbody>
@@ -116,10 +118,36 @@
             </span>
           </ng-container>
         </td>
-        <td class="w-[44px] text-right">
-          <button type="button" class="icon-btn" aria-label="Меню" (click)="onSettingsClick.emit(item)">
-            ⋯
-          </button>
+        <td class="w-[176px] text-right">
+          <div class="row-actions" role="group" aria-label="Быстрые действия">
+            <button
+              type="button"
+              class="row-action"
+              aria-label="Списать поставку"
+              (click)="writeOff.emit(item)"
+            >
+              <span aria-hidden="true">🗑</span>
+            </button>
+            <button
+              type="button"
+              class="row-action"
+              aria-label="Переместить поставку"
+              (click)="move.emit(item)"
+            >
+              <span aria-hidden="true">⇄</span>
+            </button>
+            <button
+              type="button"
+              class="row-action"
+              aria-label="Распечатать поставку"
+              (click)="print.emit(item)"
+            >
+              <span aria-hidden="true">🖨</span>
+            </button>
+            <button type="button" class="icon-btn" aria-label="Меню" (click)="onSettingsClick.emit(item)">
+              ⋯
+            </button>
+          </div>
         </td>
       </tr>
       <tr *ngIf="paginatedData.length === 0">

--- a/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.spec.ts
+++ b/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.spec.ts
@@ -34,7 +34,7 @@ describe('SupplyTableComponent', () => {
 
     spyOn(component.onSettingsClick, 'emit');
 
-    const settingsButton = fixture.debugElement.query(By.css('tbody button'));
+    const settingsButton = fixture.debugElement.query(By.css('button[aria-label="Меню"]'));
     settingsButton.nativeElement.click();
 
     expect(component.onSettingsClick.emit).toHaveBeenCalledWith(supply);

--- a/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.ts
+++ b/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.ts
@@ -33,6 +33,12 @@ export class SupplyTableComponent implements OnChanges {
   @Output() onAddSupply = new EventEmitter<void>();
   /** Сообщаем, что пользователь хочет открыть настройки конкретной поставки */
   @Output() onSettingsClick = new EventEmitter<any>();
+  /** Сообщаем, что пользователь хочет списать поставку */
+  @Output() writeOff = new EventEmitter<any>();
+  /** Сообщаем, что пользователь хочет переместить поставку */
+  @Output() move = new EventEmitter<any>();
+  /** Сообщаем, что пользователь хочет распечатать документы поставки */
+  @Output() print = new EventEmitter<any>();
 
   // фильтр и пагинация
   searchQuery = '';


### PR DESCRIPTION
## Summary
- add three quick-action buttons (write-off, move, print) before the row menu in the supplies table
- expose dedicated output events for each quick action to keep the table component reusable
- style the action strip with consistent square hover states and accessible labelling

## Testing
- npm test -- --watch=false --browsers=ChromeHeadless *(fails: ChromeHeadless cannot start because libatk-1.0.so.0 is missing in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d9938b69fc8323b5c9fd791ed00b07