### PR TITLE
feat: add sticky warehouse breadcrumb bar

### DIFF
--- a/feedme.client/src/app/warehouse/warehouse-page.component.css
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.css
@@ -80,29 +80,122 @@
 .warehouse-page__top-bar {
   position: sticky;
   top: 0;
-  z-index: 10;
+  z-index: 15;
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
   padding: 16px 32px;
-  background-color: rgba(255, 255, 255, 0.92);
+  background-color: rgba(248, 250, 252, 0.95);
   border-bottom: 1px solid #e2e8f0;
-  backdrop-filter: blur(8px);
+  backdrop-filter: blur(12px);
 }
 
 .warehouse-page__breadcrumbs {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
   font-size: 0.875rem;
-  color: #6b7280;
+  font-weight: 500;
+  color: #64748b;
 }
 
-.warehouse-page__breadcrumb-current {
+.warehouse-page__breadcrumb {
+  color: inherit;
+}
+
+.warehouse-page__breadcrumb--current {
   color: #111827;
   font-weight: 600;
 }
 
-.warehouse-page__actions {
-  display: flex;
+.warehouse-page__breadcrumb-separator {
+  color: #cbd5f5;
+}
+
+.warehouse-page__warehouse-switch {
+  display: inline-flex;
+  align-items: center;
   gap: 12px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #475569;
+}
+
+.warehouse-page__warehouse-label {
+  display: inline-flex;
+  align-items: center;
+}
+
+.warehouse-page__select-wrapper {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.warehouse-page__select-wrapper::after {
+  content: '';
+  position: absolute;
+  inset-inline-end: 12px;
+  top: 50%;
+  width: 12px;
+  height: 12px;
+  transform: translateY(-50%);
+  pointer-events: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='none' viewBox='0 0 12 12'%3E%3Cpath fill='%2367748b' d='M2.47 4.47a.75.75 0 0 1 1.06 0L6 6.94l2.47-2.47a.75.75 0 1 1 1.06 1.06L6.53 8.53a1.5 1.5 0 0 1-2.12 0L2.47 5.53a.75.75 0 0 1 0-1.06Z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-size: 12px 12px;
+}
+
+.warehouse-page__warehouse-select {
+  appearance: none;
+  min-width: 200px;
+  padding: 10px 40px 10px 14px;
+  border: 1px solid #cbd5f0;
+  border-radius: 0;
+  background-color: #ffffff;
+  color: #0f172a;
+  font-size: 0.875rem;
+  font-weight: 600;
+  line-height: 1.25;
+  transition: border-color 0.2s ease, color 0.2s ease;
+}
+
+.warehouse-page__warehouse-select:hover {
+  border-color: #94a3b8;
+}
+
+.warehouse-page__warehouse-select:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
+  border-color: #2563eb;
+  box-shadow: none;
+}
+
+.warehouse-page__warehouse-select::-ms-expand {
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .warehouse-page__top-bar {
+    padding: 16px 20px;
+  }
+
+  .warehouse-page__warehouse-switch {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .warehouse-page__select-wrapper {
+    flex: 1 1 auto;
+  }
+
+  .warehouse-page__warehouse-select {
+    width: 100%;
+  }
 }
 
 .warehouse-page__body {

--- a/feedme.client/src/app/warehouse/warehouse-page.component.html
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.html
@@ -22,14 +22,27 @@
   </aside>
 
   <main class="warehouse-page__content">
-    <header class="warehouse-page__top-bar">
-      <div class="warehouse-page__breadcrumbs">
-        Главный склад / <span class="warehouse-page__breadcrumb-current">Поставки</span>
-      </div>
-      <div class="warehouse-page__actions">
-        <button type="button" class="btn btn-outline" (click)="openCreateDialog()">+ Новая поставка</button>
-        <button type="button" class="btn btn-ghost">Ещё</button>
-      </div>
+    <header class="warehouse-page__top-bar" aria-label="Контекст склада">
+      <nav class="warehouse-page__breadcrumbs" aria-label="Хлебные крошки">
+        <span class="warehouse-page__breadcrumb">Главный склад</span>
+        <span class="warehouse-page__breadcrumb-separator" aria-hidden="true">/</span>
+        <span class="warehouse-page__breadcrumb warehouse-page__breadcrumb--current">Поставки</span>
+      </nav>
+
+      <label class="warehouse-page__warehouse-switch" for="warehouse-selector">
+        <span class="warehouse-page__warehouse-label">Склад</span>
+        <span class="warehouse-page__select-wrapper">
+          <select
+            id="warehouse-selector"
+            class="warehouse-page__warehouse-select"
+            aria-label="Выбор склада"
+          >
+            <option value="main">Главный склад</option>
+            <option value="kitchen">Кухня</option>
+            <option value="bar">Бар</option>
+          </select>
+        </span>
+      </label>
     </header>
 
     <section class="warehouse-page__body">


### PR DESCRIPTION
## Summary
- replace the warehouse page header with sticky breadcrumbs and a stubbed warehouse selector to keep context visible above the tabs
- refresh the top-bar styles so breadcrumbs stay flat and the selector is square, focusable, and responsive

## Testing
- npm run lint *(fails: project has no lint target configured)*

------
https://chatgpt.com/codex/tasks/task_e_68d993983ca483239d3103a061126ffb