### PR TITLE
Add import buttons to supply filter toolbars

### DIFF
--- a/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.css
+++ b/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.css
@@ -162,6 +162,18 @@
   background-color: #f1f5f9;
 }
 
+.btn-brand-outline {
+  background-color: transparent;
+  color: var(--brand-600);
+  border: 1px solid var(--brand-600);
+  box-shadow: none;
+}
+
+.btn-brand-outline:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--brand-600) 12%, #ffffff);
+  border-color: color-mix(in srgb, var(--brand-600) 90%, #000000 10%);
+}
+
 .btn-secondary {
   background-color: #e2e8f0;
   color: #0f172a;

--- a/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.html
+++ b/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.html
@@ -41,6 +41,7 @@
     </div>
 
     <button type="button" class="btn btn-outline">Сброс</button>
+    <button type="button" class="btn btn-brand-outline">Импорт</button>
     <button type="button" class="btn btn-secondary">Экспорт</button>
     <button type="button" class="btn btn-primary ml-auto" (click)="addSupply()">+ Новая поставка</button>
   </div>

--- a/feedme.client/src/app/warehouse/supplies/supplies.component.html
+++ b/feedme.client/src/app/warehouse/supplies/supplies.component.html
@@ -33,6 +33,7 @@
     </div>
 
     <button type="button" class="btn btn--outline">Сброс</button>
+    <button type="button" class="btn btn-brand-outline">Импорт</button>
     <button type="button" class="btn btn--secondary">Экспорт</button>
     <button type="button" class="btn btn--primary ml-auto">+ Новая поставка</button>
   </form>

--- a/feedme.client/src/app/warehouse/supplies/supplies.component.scss
+++ b/feedme.client/src/app/warehouse/supplies/supplies.component.scss
@@ -137,6 +137,18 @@
   background: var(--supplies-secondary-hover);
 }
 
+.btn-brand-outline {
+  background: transparent;
+  color: var(--supplies-primary);
+  border-color: var(--supplies-primary);
+}
+
+.btn-brand-outline:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--supplies-primary) 12%, #ffffff);
+  color: var(--supplies-outline-text);
+  border-color: var(--supplies-primary-hover);
+}
+
 .btn--outline {
   background: transparent;
   color: var(--supplies-outline-text);

--- a/feedme.client/src/app/warehouse/warehouse-page.component.css
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.css
@@ -299,6 +299,18 @@
   white-space: nowrap;
 }
 
+.warehouse-page__filters .btn-brand-outline {
+  background: transparent;
+  color: var(--brand-600);
+  border: 1px solid var(--brand-600);
+  box-shadow: none;
+}
+
+.warehouse-page__filters .btn-brand-outline:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--brand-600) 12%, #ffffff);
+  border-color: color-mix(in srgb, var(--brand-600) 90%, #000000 10%);
+}
+
 .ml-auto {
   margin-left: auto;
 }

--- a/feedme.client/src/app/warehouse/warehouse-page.component.html
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.html
@@ -153,6 +153,7 @@
               </label>
             </div>
             <button type="button" class="btn btn-outline" (click)="clearFilters()">Сброс</button>
+            <button type="button" class="btn btn-brand-outline">Импорт</button>
             <button type="button" class="btn btn-secondary">Экспорт</button>
             <button type="button" class="btn ml-auto" (click)="openCreateDialog()">+ Новая поставка</button>
           </form>


### PR DESCRIPTION
## Summary
- add an Import action between Reset and Export in the supplies filter toolbars
- introduce a brand-outline button style so the new action matches the design system

## Testing
- npm run lint *(fails: Angular workspace has no configured `lint` target)*

------
https://chatgpt.com/codex/tasks/task_e_68d993984878832392d094894f908801