### PR TITLE
feat: add history tab to warehouse dialog

### DIFF
--- a/feedme.client/src/app/warehouse/warehouse-page.component.css
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.css
@@ -681,6 +681,44 @@
   gap: 24px;
 }
 
+.warehouse-page__dialog-tabs {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  background-color: #f8fafc;
+}
+
+.warehouse-page__dialog-tab {
+  border: none;
+  background: transparent;
+  padding: 8px 16px;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #64748b;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.warehouse-page__dialog-tab:hover {
+  color: #0f172a;
+  background-color: rgba(148, 163, 184, 0.16);
+}
+
+.warehouse-page__dialog-tab:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
+}
+
+.warehouse-page__dialog-tab--active {
+  color: #0f172a;
+  background-color: #ffffff;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.12);
+}
+
 .warehouse-page__dialog-header {
   font-size: 1.25rem;
   font-weight: 600;
@@ -708,6 +746,12 @@
   text-transform: uppercase;
   letter-spacing: 0.05em;
   color: #94a3b8;
+}
+
+.warehouse-page__dialog-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
 }
 
 .warehouse-page__dialog-table {
@@ -744,6 +788,61 @@
   display: flex;
   justify-content: flex-end;
   gap: 12px;
+}
+
+.warehouse-page__history-card {
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  overflow: hidden;
+  background-color: #ffffff;
+  display: flex;
+  flex-direction: column;
+}
+
+.warehouse-page__history-card-header {
+  padding: 16px 20px;
+  font-weight: 600;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.warehouse-page__history-table {
+  overflow-x: auto;
+}
+
+.warehouse-page__history-table thead tr {
+  background-color: #f8fafc;
+}
+
+.warehouse-page__history-row {
+  transition: background-color 0.2s ease;
+}
+
+.warehouse-page__history-row:nth-child(odd) {
+  background-color: rgba(148, 163, 184, 0.12);
+}
+
+.warehouse-page__history-row:hover {
+  background-color: rgba(148, 163, 184, 0.28);
+}
+
+.warehouse-page__history-qty {
+  display: inline-flex;
+  justify-content: flex-end;
+  width: 100%;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+
+.warehouse-page__history-qty--in {
+  color: #15803d;
+}
+
+.warehouse-page__history-qty--out {
+  color: #dc2626;
+}
+
+.warehouse-page__history-qty--transfer {
+  color: #2563eb;
 }
 
 .warehouse-page__dialog-content {

--- a/feedme.client/src/app/warehouse/warehouse-page.component.html
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.html
@@ -372,67 +372,157 @@
         {{ editingRowId() ? 'Редактирование поставки' : 'Новая поставка' }}
       </header>
       <form class="warehouse-page__dialog-form" [formGroup]="editForm" (ngSubmit)="submitEdit()">
-        <div class="warehouse-page__dialog-grid">
-          <label class="warehouse-page__dialog-field">
-            <span class="warehouse-page__dialog-label">№ документа</span>
-            <input class="input" formControlName="docNo" />
-          </label>
-          <label class="warehouse-page__dialog-field">
-            <span class="warehouse-page__dialog-label">Дата прихода</span>
-            <input class="input" type="date" formControlName="arrivalDate" />
-          </label>
-          <label class="warehouse-page__dialog-field">
-            <span class="warehouse-page__dialog-label">Склад</span>
-            <input class="input" formControlName="warehouse" />
-          </label>
-          <label class="warehouse-page__dialog-field">
-            <span class="warehouse-page__dialog-label">Ответственный</span>
-            <input class="input" formControlName="responsible" />
-          </label>
-          <label class="warehouse-page__dialog-field">
-            <span class="warehouse-page__dialog-label">Поставщик</span>
-            <input class="input" formControlName="supplier" />
-          </label>
-          <label class="warehouse-page__dialog-field">
-            <span class="warehouse-page__dialog-label">SKU</span>
-            <input class="input" formControlName="sku" />
-          </label>
-          <label class="warehouse-page__dialog-field">
-            <span class="warehouse-page__dialog-label">Название</span>
-            <input class="input" formControlName="name" />
-          </label>
-          <label class="warehouse-page__dialog-field">
-            <span class="warehouse-page__dialog-label">Категория</span>
-            <input class="input" formControlName="category" />
-          </label>
-          <label class="warehouse-page__dialog-field">
-            <span class="warehouse-page__dialog-label">Кол-во</span>
-            <input class="input" type="number" step="0.001" min="0" formControlName="qty" />
-          </label>
-          <label class="warehouse-page__dialog-field">
-            <span class="warehouse-page__dialog-label">Единица измерения</span>
-            <input class="input" formControlName="unit" />
-          </label>
-          <label class="warehouse-page__dialog-field">
-            <span class="warehouse-page__dialog-label">Цена</span>
-            <input class="input" type="number" step="0.01" min="0" formControlName="price" />
-          </label>
-          <label class="warehouse-page__dialog-field">
-            <span class="warehouse-page__dialog-label">Срок годности</span>
-            <input class="input" type="date" formControlName="expiry" />
-            <span class="warehouse-page__field-error" *ngIf="editForm.controls.expiry.touched && editForm.controls.expiry.hasError('dateOrder')">
-              Срок годности не может быть раньше даты прихода
-            </span>
-          </label>
-          <label class="warehouse-page__dialog-field">
-            <span class="warehouse-page__dialog-label">Статус</span>
-            <select class="select" formControlName="status">
-              <option value="ok">Ок</option>
-              <option value="warning">Скоро срок</option>
-              <option value="danger">Просрочено</option>
-            </select>
-          </label>
-        </div>
+        <nav
+          class="warehouse-page__dialog-tabs"
+          role="tablist"
+          aria-label="Разделы поставки"
+        >
+          <button
+            *ngFor="let tab of editDialogTabs; trackBy: trackByEditDialogTab"
+            type="button"
+            class="warehouse-page__dialog-tab"
+            [class.warehouse-page__dialog-tab--active]="editDialogTab() === tab.key"
+            (click)="selectEditDialogTab(tab.key)"
+            role="tab"
+            [attr.aria-selected]="editDialogTab() === tab.key"
+            [attr.id]="'edit-dialog-tab-' + tab.key"
+            [attr.aria-controls]="'edit-dialog-panel-' + tab.key"
+          >
+            {{ tab.label }}
+          </button>
+        </nav>
+
+        <section
+          *ngIf="editDialogTab() === 'details'"
+          class="warehouse-page__dialog-panel"
+          role="tabpanel"
+          id="edit-dialog-panel-details"
+          aria-labelledby="edit-dialog-tab-details"
+        >
+          <div class="warehouse-page__dialog-grid">
+            <label class="warehouse-page__dialog-field">
+              <span class="warehouse-page__dialog-label">№ документа</span>
+              <input class="input" formControlName="docNo" />
+            </label>
+            <label class="warehouse-page__dialog-field">
+              <span class="warehouse-page__dialog-label">Дата прихода</span>
+              <input class="input" type="date" formControlName="arrivalDate" />
+            </label>
+            <label class="warehouse-page__dialog-field">
+              <span class="warehouse-page__dialog-label">Склад</span>
+              <input class="input" formControlName="warehouse" />
+            </label>
+            <label class="warehouse-page__dialog-field">
+              <span class="warehouse-page__dialog-label">Ответственный</span>
+              <input class="input" formControlName="responsible" />
+            </label>
+            <label class="warehouse-page__dialog-field">
+              <span class="warehouse-page__dialog-label">Поставщик</span>
+              <input class="input" formControlName="supplier" />
+            </label>
+            <label class="warehouse-page__dialog-field">
+              <span class="warehouse-page__dialog-label">SKU</span>
+              <input class="input" formControlName="sku" />
+            </label>
+            <label class="warehouse-page__dialog-field">
+              <span class="warehouse-page__dialog-label">Название</span>
+              <input class="input" formControlName="name" />
+            </label>
+            <label class="warehouse-page__dialog-field">
+              <span class="warehouse-page__dialog-label">Категория</span>
+              <input class="input" formControlName="category" />
+            </label>
+            <label class="warehouse-page__dialog-field">
+              <span class="warehouse-page__dialog-label">Кол-во</span>
+              <input class="input" type="number" step="0.001" min="0" formControlName="qty" />
+            </label>
+            <label class="warehouse-page__dialog-field">
+              <span class="warehouse-page__dialog-label">Единица измерения</span>
+              <input class="input" formControlName="unit" />
+            </label>
+            <label class="warehouse-page__dialog-field">
+              <span class="warehouse-page__dialog-label">Цена</span>
+              <input class="input" type="number" step="0.01" min="0" formControlName="price" />
+            </label>
+            <label class="warehouse-page__dialog-field">
+              <span class="warehouse-page__dialog-label">Срок годности</span>
+              <input class="input" type="date" formControlName="expiry" />
+              <span class="warehouse-page__field-error" *ngIf="editForm.controls.expiry.touched && editForm.controls.expiry.hasError('dateOrder')">
+                Срок годности не может быть раньше даты прихода
+              </span>
+            </label>
+            <label class="warehouse-page__dialog-field">
+              <span class="warehouse-page__dialog-label">Статус</span>
+              <select class="select" formControlName="status">
+                <option value="ok">Ок</option>
+                <option value="warning">Скоро срок</option>
+                <option value="danger">Просрочено</option>
+              </select>
+            </label>
+          </div>
+        </section>
+
+        <section
+          *ngIf="editDialogTab() === 'items'"
+          class="warehouse-page__dialog-panel"
+          role="tabpanel"
+          id="edit-dialog-panel-items"
+          aria-labelledby="edit-dialog-tab-items"
+        >
+          <div class="warehouse-page__dialog-table">
+            <header>Позиции поставки</header>
+            <div class="warehouse-page__dialog-body">
+              <p>Добавьте продукты к документу после сохранения поставки.</p>
+            </div>
+          </div>
+        </section>
+
+        <section
+          *ngIf="editDialogTab() === 'history'"
+          class="warehouse-page__dialog-panel"
+          role="tabpanel"
+          id="edit-dialog-panel-history"
+          aria-labelledby="edit-dialog-tab-history"
+        >
+          <article class="warehouse-page__history-card">
+            <header class="warehouse-page__history-card-header">Движение по поставке</header>
+            <div class="warehouse-page__history-table">
+              <table class="warehouse-page__table">
+                <thead>
+                  <tr>
+                    <th scope="col" class="warehouse-page__cell text-sm font-medium">Дата</th>
+                    <th scope="col" class="warehouse-page__cell text-sm font-medium">Операция</th>
+                    <th scope="col" class="warehouse-page__cell warehouse-page__cell--numeric text-sm font-medium text-right">
+                      Кол-во
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr
+                    *ngFor="let entry of editDialogHistory; trackBy: trackByHistoryEntry"
+                    class="warehouse-page__history-row"
+                  >
+                    <td class="warehouse-page__cell">{{ entry.date }}</td>
+                    <td class="warehouse-page__cell">{{ entry.operation }}</td>
+                    <td class="warehouse-page__cell warehouse-page__cell--numeric text-right">
+                      <span
+                        class="warehouse-page__history-qty"
+                        [ngClass]="{
+                          'warehouse-page__history-qty--in': entry.operation === 'Приход',
+                          'warehouse-page__history-qty--out': entry.operation === 'Списание',
+                          'warehouse-page__history-qty--transfer': entry.operation === 'Перемещение'
+                        }"
+                      >
+                        {{ entry.quantity }}
+                      </span>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </article>
+        </section>
+
         <footer class="warehouse-page__dialog-actions">
           <button type="button" class="btn btn-outline" (click)="closeEditDialog()">Отмена</button>
           <button type="submit" class="btn" [disabled]="editForm.invalid">Сохранить</button>

--- a/feedme.client/src/app/warehouse/warehouse-page.component.ts
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.ts
@@ -29,6 +29,14 @@ const RUB_FORMATTER = new Intl.NumberFormat('ru-RU', {
   maximumFractionDigits: 0,
 });
 
+type EditDialogTab = 'details' | 'items' | 'history';
+
+type SupplyHistoryEntry = {
+  date: string;
+  operation: 'Приход' | 'Списание' | 'Перемещение';
+  quantity: string;
+};
+
 @Component({
   standalone: true,
   selector: 'app-warehouse-page',
@@ -67,8 +75,22 @@ export class WarehousePageComponent {
   readonly editingRowId = signal<number | null>(null);
   readonly deleteTargetIds = signal<number[]>([]);
   readonly menuRowId = signal<number | null>(null);
+  readonly editDialogTab = signal<EditDialogTab>('details');
 
   readonly rows = this.warehouseService.list();
+
+  readonly editDialogTabs: ReadonlyArray<{ key: EditDialogTab; label: string }> = [
+    { key: 'details', label: 'Документ' },
+    { key: 'items', label: 'Позиции' },
+    { key: 'history', label: 'История' },
+  ];
+
+  readonly editDialogHistory: ReadonlyArray<SupplyHistoryEntry> = [
+    { date: '12.03.2025 14:20', operation: 'Приход', quantity: '+24 кг' },
+    { date: '14.03.2025 09:10', operation: 'Перемещение', quantity: '−6 кг' },
+    { date: '15.03.2025 18:45', operation: 'Списание', quantity: '−2 кг' },
+    { date: '18.03.2025 11:05', operation: 'Приход', quantity: '+18 кг' },
+  ];
 
   readonly suppliers = computed(() =>
     Array.from(new Set(this.rows().map((row) => row.supplier))).sort((a, b) =>
@@ -194,6 +216,12 @@ export class WarehousePageComponent {
   }
 
   trackByRow = (_: number, row: SupplyRow) => row.id;
+  trackByEditDialogTab = (_: number, tab: { key: EditDialogTab }) => tab.key;
+  trackByHistoryEntry = (_: number, entry: SupplyHistoryEntry) => `${entry.date}-${entry.operation}-${entry.quantity}`;
+
+  selectEditDialogTab(tab: EditDialogTab): void {
+    this.editDialogTab.set(tab);
+  }
 
   selectTab(tab: 'supplies' | 'stock' | 'catalog' | 'inventory'): void {
     this.activeTab.set(tab);
@@ -301,6 +329,7 @@ export class WarehousePageComponent {
     this.editingRowId.set(null);
     this.editDialogOpen.set(true);
     this.menuRowId.set(null);
+    this.editDialogTab.set('details');
   }
 
   startEdit(row: SupplyRow): void {
@@ -309,6 +338,7 @@ export class WarehousePageComponent {
     this.editingRowId.set(row.id);
     this.editDialogOpen.set(true);
     this.menuRowId.set(null);
+    this.editDialogTab.set('details');
   }
 
   closeEditDialog(): void {
@@ -330,6 +360,7 @@ export class WarehousePageComponent {
       status: 'ok' as SupplyStatus,
     });
     this.clearDateOrderError();
+    this.editDialogTab.set('details');
   }
 
   submitEdit(): void {


### PR DESCRIPTION
## Summary
- add a tab definition and static history entries to the warehouse supply dialog
- render the new history tab with a zebra-styled table inside the dialog alongside existing sections
- style dialog tabs and history table to match the main table interactions

## Testing
- npm run lint *(fails: workspace has no configured lint target)*

------
https://chatgpt.com/codex/tasks/task_e_68d9939f6f888323b6d903c48ad87559