### PR TITLE
Add total sum placeholder to supply table footer

### DIFF
--- a/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.css
+++ b/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.css
@@ -333,6 +333,17 @@
   box-shadow: 0 4px 12px rgba(15, 23, 42, 0.08);
 }
 
+.table-footer__summary {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+}
+
+.table-footer__total {
+  color: #0f172a;
+}
+
 .text-muted-foreground {
   color: #64748b;
 }

--- a/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.html
+++ b/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.html
@@ -138,8 +138,11 @@
 ></app-empty>
 
 <div class="table-footer flex items-center p-3 border-t text-sm bg-muted/40 shadow-sm">
-  <div class="table-footer__summary text-muted-foreground">
-    Показано {{ paginatedData.length }} поставок · Страница {{ currentPage }} из {{ totalPages }}
+  <div class="table-footer__summary">
+    <span class="table-footer__summary-text text-muted-foreground">
+      Показано {{ paginatedData.length }} поставок · Страница {{ currentPage }} из {{ totalPages }}
+    </span>
+    <span class="table-footer__total font-medium">Итог по сумме: 0 ₽</span>
   </div>
   <div class="ml-auto flex gap-2">
     <button type="button" class="btn btn-outline btn-sm" (click)="prevPage()" [disabled]="currentPage === 1">


### PR DESCRIPTION
## Summary
- show a placeholder for the total supply amount in the table footer
- adjust the footer layout to keep the pagination controls aligned while adding the new summary text

## Testing
- npm run lint *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_68d993a3fe2c8323985d8517893f7e4c