### PR TITLE
Add tooltips for warehouse table column headers

### DIFF
--- a/feedme.client/src/app/components/StockTableComponent/stock-table.component.html
+++ b/feedme.client/src/app/components/StockTableComponent/stock-table.component.html
@@ -26,6 +26,7 @@
             type="button"
             class="sort-button"
             (click)="changeSort(column.field)"
+            [attr.title]="getColumnTooltip(column.label)"
           >
             <span class="truncate" [title]="column.label">{{ column.label }}</span>
             <span class="sort-indicator" *ngIf="sortKey === column.field">

--- a/feedme.client/src/app/components/StockTableComponent/stock-table.component.ts
+++ b/feedme.client/src/app/components/StockTableComponent/stock-table.component.ts
@@ -56,6 +56,12 @@ export class StockTableComponent implements OnChanges {
     { label: 'Остаток', field: 'stock' },
   ];
 
+  private readonly columnTooltips: Record<string, string> = {
+    '№ док.': 'Номер приходного документа',
+    'Кол-во': 'Количество в базовой ед. изм.',
+    'Срок годности': 'Дата, после которой товар списывается',
+  };
+
   sortKey: keyof StockTableItem | null = null;
   sortDirection: SortDirection = 'asc';
 
@@ -115,6 +121,10 @@ export class StockTableComponent implements OnChanges {
 
   formatValue(item: StockTableItem, column: StockColumn): unknown {
     return this.getColumnValue(item, column) ?? '';
+  }
+
+  getColumnTooltip(label: string): string | null {
+    return this.columnTooltips[label] ?? null;
   }
 
   get paginatedData(): StockTableItem[] {

--- a/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.html
+++ b/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.html
@@ -53,14 +53,14 @@
         <th class="w-[40px]" scope="col">
           <input type="checkbox" class="checkbox" aria-label="Выбрать все поставки" />
         </th>
-        <th scope="col" class="text-sm font-medium">№ док.</th>
+        <th scope="col" class="text-sm font-medium" title="Номер приходного документа">№ док.</th>
         <th scope="col" class="text-sm font-medium">Дата прихода</th>
         <th scope="col" class="text-sm font-medium">Склад</th>
         <th scope="col" class="text-sm font-medium">Ответственный</th>
         <th scope="col" class="text-sm font-medium">SKU</th>
         <th scope="col" class="text-sm font-medium">Название</th>
-        <th scope="col" class="text-sm font-medium text-right">Кол-во</th>
-        <th scope="col" class="text-sm font-medium text-center">Срок годности</th>
+        <th scope="col" class="text-sm font-medium text-right" title="Количество в базовой ед. изм.">Кол-во</th>
+        <th scope="col" class="text-sm font-medium text-center" title="Дата, после которой товар списывается">Срок годности</th>
         <th scope="col" class="text-sm font-medium">Поставщик</th>
         <th scope="col" class="text-sm font-medium">Статус</th>
         <th scope="col" class="w-[44px]"></th>

--- a/feedme.client/src/app/warehouse/warehouse-page.component.html
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.html
@@ -190,7 +190,11 @@
                       aria-label="Выбрать все"
                     />
                   </th>
-                  <th scope="col" class="warehouse-page__cell text-sm font-medium font-mono text-xs">
+                  <th
+                    scope="col"
+                    class="warehouse-page__cell text-sm font-medium font-mono text-xs"
+                    title="Номер приходного документа"
+                  >
                     № док.
                   </th>
                   <th
@@ -208,12 +212,14 @@
                   <th
                     scope="col"
                     class="warehouse-page__cell warehouse-page__cell--numeric text-sm font-medium text-right"
+                    title="Количество в базовой ед. изм."
                   >
                     Кол-во
                   </th>
                   <th
                     scope="col"
                     class="warehouse-page__cell warehouse-page__cell--center text-sm font-medium text-center"
+                    title="Дата, после которой товар списывается"
                   >
                     Срок годности
                   </th>


### PR DESCRIPTION
## Summary
- add descriptive tooltips to supply and warehouse table headers for document number, quantity, and expiration date columns
- expose tooltip mapping in the stock table to surface consistent hints on sortable column headers

## Testing
- npm run lint *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_68d993a9295c8323a48b0a1c39c76d22