### PR TITLE
feat: support draft and transit supply statuses

### DIFF
--- a/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.css
+++ b/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.css
@@ -132,6 +132,16 @@
   color: #b91c1c;
 }
 
+.chip--muted {
+  background-color: rgba(148, 163, 184, 0.16);
+  color: #475569;
+}
+
+.chip--info {
+  background-color: rgba(59, 130, 246, 0.16);
+  color: #1d4ed8;
+}
+
 .btn {
   display: inline-flex;
   align-items: center;

--- a/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.html
+++ b/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.html
@@ -37,6 +37,8 @@
         <span class="chip">Ок</span>
         <span class="chip chip--secondary">Скоро срок</span>
         <span class="chip chip--destructive">Просрочено</span>
+        <span class="chip chip--muted">Черновик</span>
+        <span class="chip chip--info">В пути</span>
       </div>
     </div>
 
@@ -112,7 +114,7 @@
               class="badge min-w-[88px] justify-center"
               [ngClass]="status | statusBadgeClass"
             >
-              {{ status }}
+              {{ status | statusBadgeLabel }}
             </span>
           </ng-container>
         </td>

--- a/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.ts
+++ b/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.ts
@@ -4,6 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { TableControlsComponent } from '../table-controls/table-controls.component';
 import { EmptyStateComponent } from '../../warehouse/ui/empty-state.component';
 import { StatusBadgeClassPipe } from '../../pipes/status-badge-class.pipe';
+import { StatusBadgeLabelPipe } from '../../pipes/status-badge-label.pipe';
 
 type SortDirection = 'asc' | 'desc';
 type SortType = 'string' | 'number' | 'date';
@@ -22,7 +23,14 @@ interface FilterOptions {
 @Component({
   selector: 'app-supply-table',
   standalone: true,
-  imports: [CommonModule, FormsModule, TableControlsComponent, EmptyStateComponent, StatusBadgeClassPipe],
+  imports: [
+    CommonModule,
+    FormsModule,
+    TableControlsComponent,
+    EmptyStateComponent,
+    StatusBadgeClassPipe,
+    StatusBadgeLabelPipe,
+  ],
   templateUrl: './supply-table.component.html',
   styleUrls: ['./supply-table.component.css']
 })

--- a/feedme.client/src/app/pipes/status-badge-class.pipe.ts
+++ b/feedme.client/src/app/pipes/status-badge-class.pipe.ts
@@ -6,6 +6,8 @@ const STATUS_CLASS_MAP = new Map<string, string>([
   ['норма', 'badge--ok'],
   ['normal', 'badge--ok'],
   ['в наличии', 'badge--ok'],
+  ['черновик', 'badge--draft'],
+  ['draft', 'badge--draft'],
   ['скоро срок', 'badge--warn'],
   ['warning', 'badge--warn'],
   ['warn', 'badge--warn'],
@@ -15,6 +17,11 @@ const STATUS_CLASS_MAP = new Map<string, string>([
   ['danger', 'badge--danger'],
   ['expired', 'badge--danger'],
   ['overdue', 'badge--danger'],
+  ['в пути', 'badge--transit'],
+  ['в дороге', 'badge--transit'],
+  ['transit', 'badge--transit'],
+  ['on the way', 'badge--transit'],
+  ['in transit', 'badge--transit'],
 ]);
 
 const DEFAULT_BADGE_CLASS = 'badge--ok';

--- a/feedme.client/src/app/pipes/status-badge-label.pipe.ts
+++ b/feedme.client/src/app/pipes/status-badge-label.pipe.ts
@@ -1,0 +1,40 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+const STATUS_LABEL_MAP = new Map<string, string>([
+  ['ок', 'Ок'],
+  ['ok', 'Ок'],
+  ['норма', 'Ок'],
+  ['normal', 'Ок'],
+  ['в наличии', 'Ок'],
+  ['скоро срок', 'Скоро срок'],
+  ['warning', 'Скоро срок'],
+  ['warn', 'Скоро срок'],
+  ['due soon', 'Скоро срок'],
+  ['soon', 'Скоро срок'],
+  ['просрочено', 'Просрочено'],
+  ['danger', 'Просрочено'],
+  ['expired', 'Просрочено'],
+  ['overdue', 'Просрочено'],
+  ['черновик', 'Черновик'],
+  ['draft', 'Черновик'],
+  ['drafts', 'Черновик'],
+  ['черновики', 'Черновик'],
+  ['в пути', 'В пути'],
+  ['в дороге', 'В пути'],
+  ['transit', 'В пути'],
+  ['on the way', 'В пути'],
+  ['in transit', 'В пути'],
+]);
+
+const DEFAULT_LABEL = 'Ок';
+
+@Pipe({
+  name: 'statusBadgeLabel',
+  standalone: true,
+})
+export class StatusBadgeLabelPipe implements PipeTransform {
+  transform(status?: string | null): string {
+    const normalized = (status ?? '').trim().toLowerCase();
+    return STATUS_LABEL_MAP.get(normalized) ?? DEFAULT_LABEL;
+  }
+}

--- a/feedme.client/src/app/warehouse/models.ts
+++ b/feedme.client/src/app/warehouse/models.ts
@@ -1,4 +1,16 @@
-export type SupplyStatus = 'ok' | 'warning' | 'danger';
+export type SupplyStatus = 'ok' | 'warning' | 'danger' | 'draft' | 'transit';
+
+export const SUPPLY_STATUSES: ReadonlyArray<SupplyStatus> = [
+  'ok',
+  'warning',
+  'danger',
+  'draft',
+  'transit',
+];
+
+export function isSupplyStatus(value: string): value is SupplyStatus {
+  return SUPPLY_STATUSES.includes(value as SupplyStatus);
+}
 
 export interface SupplyRow {
   readonly id: number;

--- a/feedme.client/src/app/warehouse/supplies/supplies.component.html
+++ b/feedme.client/src/app/warehouse/supplies/supplies.component.html
@@ -30,6 +30,8 @@
       <div class="chip chip--filled">Главный склад</div>
       <div class="chip">Ок</div>
       <div class="chip chip--danger">Просрочено</div>
+      <div class="chip chip--draft">Черновик</div>
+      <div class="chip chip--transit">В пути</div>
     </div>
 
     <button type="button" class="btn btn--outline">Сброс</button>

--- a/feedme.client/src/app/warehouse/supplies/supplies.component.scss
+++ b/feedme.client/src/app/warehouse/supplies/supplies.component.scss
@@ -64,6 +64,18 @@
   color: #b91c1c;
 }
 
+.chip--draft {
+  background: #f3f4f6;
+  border-color: #e5e7eb;
+  color: #4b5563;
+}
+
+.chip--transit {
+  background: #e0f2fe;
+  border-color: #bfdbfe;
+  color: #1d4ed8;
+}
+
 .chip--ghost {
   border: 1px dashed var(--brand-600);
   color: var(--brand-600);

--- a/feedme.client/src/app/warehouse/warehouse-page.component.html
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.html
@@ -86,9 +86,9 @@
                   aria-label="Фильтр по статусу"
                 >
                   <option value="">Все статусы</option>
-                  <option value="ok">Ок</option>
-                  <option value="warning">Скоро срок</option>
-                  <option value="danger">Просрочено</option>
+                  <option *ngFor="let statusOption of statuses" [value]="statusOption">
+                    {{ statusOption | statusBadgeLabel }}
+                  </option>
                 </select>
               </label>
             </div>
@@ -272,7 +272,7 @@
                       class="badge min-w-[112px] justify-center"
                       [ngClass]="row.status | statusBadgeClass"
                     >
-                      {{ row.status === 'ok' ? 'Ок' : row.status === 'warning' ? 'Скоро срок' : 'Просрочено' }}
+                      {{ row.status | statusBadgeLabel }}
                     </span>
                   </td>
                   <td class="warehouse-page__cell warehouse-page__cell--icon">
@@ -341,7 +341,7 @@
           <div class="warehouse-page__drawer-meta">SKU {{ row.sku }}</div>
         </div>
         <span class="badge" [ngClass]="row.status | statusBadgeClass">
-          {{ row.status === 'ok' ? 'Ок' : row.status === 'warning' ? 'Скоро срок' : 'Просрочено' }}
+          {{ row.status | statusBadgeLabel }}
         </span>
       </header>
       <div class="warehouse-page__drawer-grid">
@@ -427,9 +427,9 @@
           <label class="warehouse-page__dialog-field">
             <span class="warehouse-page__dialog-label">Статус</span>
             <select class="select" formControlName="status">
-              <option value="ok">Ок</option>
-              <option value="warning">Скоро срок</option>
-              <option value="danger">Просрочено</option>
+              <option *ngFor="let statusOption of statuses" [value]="statusOption">
+                {{ statusOption | statusBadgeLabel }}
+              </option>
             </select>
           </label>
         </div>

--- a/feedme.client/src/app/warehouse/warehouse-page.component.spec.ts
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.spec.ts
@@ -53,7 +53,7 @@ class InMemoryWarehouseService {
       price: 28,
       expiry: '2025-10-15',
       supplier: 'ОвощБаза',
-      status: 'ok',
+      status: 'draft',
     },
     {
       id: 4,
@@ -70,6 +70,22 @@ class InMemoryWarehouseService {
       expiry: '2025-10-01',
       supplier: 'МолКомбинат',
       status: 'danger',
+    },
+    {
+      id: 5,
+      docNo: 'PO-000855',
+      arrivalDate: '2025-09-29',
+      warehouse: 'Главный склад',
+      responsible: 'Кириллов К.',
+      sku: 'BEV-021',
+      name: 'Сок яблочный',
+      category: 'Напитки',
+      qty: 48,
+      unit: 'л',
+      price: 75,
+      expiry: '2025-10-20',
+      supplier: 'Fresh Drinks',
+      status: 'transit',
     },
   ];
 
@@ -149,6 +165,27 @@ describe('WarehousePageComponent', () => {
     const rows = getTableRows(fixture.nativeElement);
     expect(rows.length).toBe(1);
     expect(rows[0].textContent).toContain('Скоро срок');
+  });
+
+  it('supports draft and transit statuses', () => {
+    const selects = fixture.nativeElement.querySelectorAll('select') as NodeListOf<HTMLSelectElement>;
+    const statusSelect = selects[0];
+
+    statusSelect.value = 'draft';
+    statusSelect.dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+
+    let rows = getTableRows(fixture.nativeElement);
+    expect(rows.length).toBe(1);
+    expect(rows[0].textContent).toContain('Черновик');
+
+    statusSelect.value = 'transit';
+    statusSelect.dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+
+    rows = getTableRows(fixture.nativeElement);
+    expect(rows.length).toBe(1);
+    expect(rows[0].textContent).toContain('В пути');
   });
 
   it('filters rows by warehouse', () => {

--- a/feedme.client/src/app/warehouse/warehouse-page.component.ts
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.ts
@@ -16,12 +16,13 @@ import {
   Validators,
 } from '@angular/forms';
 
-import { SupplyRow, SupplyStatus } from './models';
+import { SUPPLY_STATUSES, SupplyRow, SupplyStatus, isSupplyStatus } from './models';
 import { WarehouseService } from './warehouse.service';
 import { EmptyStateComponent } from './ui/empty-state.component';
 import { FieldComponent } from './ui/field.component';
 import { MetricComponent } from './ui/metric.component';
 import { StatusBadgeClassPipe } from '../pipes/status-badge-class.pipe';
+import { StatusBadgeLabelPipe } from '../pipes/status-badge-label.pipe';
 
 const RUB_FORMATTER = new Intl.NumberFormat('ru-RU', {
   style: 'currency',
@@ -41,6 +42,7 @@ const RUB_FORMATTER = new Intl.NumberFormat('ru-RU', {
     FieldComponent,
     EmptyStateComponent,
     StatusBadgeClassPipe,
+    StatusBadgeLabelPipe,
   ],
   templateUrl: './warehouse-page.component.html',
   styleUrl: './warehouse-page.component.css',
@@ -55,6 +57,7 @@ export class WarehousePageComponent {
   readonly activeTab = signal<'supplies' | 'stock' | 'catalog' | 'inventory'>('supplies');
   readonly query = signal('');
   readonly status = signal<SupplyStatus | ''>('');
+  readonly statuses = SUPPLY_STATUSES;
   readonly supplier = signal('');
   readonly warehouseFilter = signal('');
   readonly dateFrom = signal('');
@@ -204,7 +207,7 @@ export class WarehousePageComponent {
   }
 
   updateStatus(value: string): void {
-    if (value === 'ok' || value === 'warning' || value === 'danger') {
+    if (isSupplyStatus(value)) {
       this.status.set(value);
       return;
     }

--- a/feedme.client/src/app/warehouse/warehouse.service.ts
+++ b/feedme.client/src/app/warehouse/warehouse.service.ts
@@ -51,7 +51,7 @@ export class WarehouseService {
       price: 28,
       expiry: '2025-10-15',
       supplier: 'ОвощБаза',
-      status: 'ok',
+      status: 'draft',
     },
     {
       id: 4,
@@ -68,6 +68,22 @@ export class WarehouseService {
       expiry: '2025-10-01',
       supplier: 'МолКомбинат',
       status: 'danger',
+    },
+    {
+      id: 5,
+      docNo: 'PO-000855',
+      arrivalDate: '2025-09-29',
+      warehouse: 'Главный склад',
+      responsible: 'Кириллов К.',
+      sku: 'BEV-021',
+      name: 'Сок яблочный',
+      category: 'Напитки',
+      qty: 48,
+      unit: 'л',
+      price: 75,
+      expiry: '2025-10-20',
+      supplier: 'Fresh Drinks',
+      status: 'transit',
     },
   ]);
 

--- a/feedme.client/src/styles.css
+++ b/feedme.client/src/styles.css
@@ -222,7 +222,7 @@ button:hover:not(:disabled) {
 
   gap: 0.25rem;
   padding: 0.125rem 0.5rem;
-  border-radius: var(--radius, 0.5rem);
+  border-radius: 0.375rem;
   border: 1px solid transparent;
   font-size: 0.8125rem;
 
@@ -248,4 +248,16 @@ button:hover:not(:disabled) {
   background-color: #fee2e2;
   color: #b91c1c;
   border-color: #fecaca;
+}
+
+.badge--draft {
+  background-color: #f3f4f6;
+  color: #4b5563;
+  border-color: #d1d5db;
+}
+
+.badge--transit {
+  background-color: #e0f2fe;
+  color: #1d4ed8;
+  border-color: #bfdbfe;
 }


### PR DESCRIPTION
## Summary
- add reusable status badge label pipe and extend badge styles for draft and transit
- allow warehouse UI to filter, edit, and display the new statuses with updated sample data and tests
- surface the new statuses in supply table filters and chips for consistency

## Testing
- `npm run lint` *(fails: no Angular lint target is configured yet)*
- `npm test -- --watch=false --browsers=ChromeHeadlessNoSandbox --progress=false` *(fails: ChromeHeadless cannot start because libatk-1.0.so.0 is missing in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d993af72b48323a47e803eade70f11