### PR TITLE
feat: add warehouse row density toggle skeleton

### DIFF
--- a/feedme.client/src/app/warehouse/warehouse-page.component.css
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.css
@@ -84,6 +84,8 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
   padding: 16px 32px;
   background-color: rgba(255, 255, 255, 0.92);
   border-bottom: 1px solid #e2e8f0;
@@ -102,7 +104,91 @@
 
 .warehouse-page__actions {
   display: flex;
+  align-items: center;
   gap: 12px;
+  flex-wrap: wrap;
+}
+
+.warehouse-page__actions-buttons {
+  display: inline-flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 12px;
+  margin-left: auto;
+}
+
+.density-switch {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px;
+  border-radius: 12px;
+  border: 1px solid #e2e8f0;
+  background: color-mix(in srgb, #f1f5f9 65%, transparent);
+}
+
+.density-switch__btn {
+  width: 40px;
+  height: 40px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  background: transparent;
+  color: #475569;
+  cursor: pointer;
+  transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease,
+    color 0.2s ease;
+}
+
+.density-switch__btn:hover {
+  background: rgba(148, 163, 184, 0.16);
+  color: #1f2937;
+}
+
+.density-switch__btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.35);
+}
+
+.density-switch__btn--active {
+  border-color: rgba(59, 130, 246, 0.4);
+  background: #ffffff;
+  color: #2563eb;
+  box-shadow: inset 0 0 0 1px rgba(59, 130, 246, 0.25);
+}
+
+.density-switch__icon {
+  --line-thickness: 2px;
+  --line-gap: 3px;
+  width: 18px;
+  height: 18px;
+  border-radius: 6px;
+  background-image: repeating-linear-gradient(
+    to bottom,
+    currentColor 0,
+    currentColor var(--line-thickness),
+    transparent var(--line-thickness),
+    transparent calc(var(--line-thickness) + var(--line-gap))
+  );
+}
+
+.density-switch__icon--comfortable {
+  --line-thickness: 2px;
+  --line-gap: 6px;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .warehouse-page__body {
@@ -359,6 +445,14 @@
   border-collapse: separate;
   border-spacing: 0;
   font-size: 0.875rem;
+}
+
+.warehouse-page__table.tbl-comfy .warehouse-page__cell {
+  padding: 16px 20px;
+}
+
+.warehouse-page__table.tbl-comfy .warehouse-page__row.h-11 {
+  height: 60px;
 }
 
 .warehouse-page__table thead {

--- a/feedme.client/src/app/warehouse/warehouse-page.component.html
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.html
@@ -27,8 +27,29 @@
         Главный склад / <span class="warehouse-page__breadcrumb-current">Поставки</span>
       </div>
       <div class="warehouse-page__actions">
-        <button type="button" class="btn btn-outline" (click)="openCreateDialog()">+ Новая поставка</button>
-        <button type="button" class="btn btn-ghost">Ещё</button>
+        <div class="density-switch" role="group" aria-label="Плотность строк">
+          <button
+            type="button"
+            class="density-switch__btn density-switch__btn--active"
+            aria-pressed="true"
+          >
+            <span aria-hidden="true" class="density-switch__icon density-switch__icon--compact"></span>
+            <span class="sr-only">Compact</span>
+          </button>
+          <button type="button" class="density-switch__btn" aria-pressed="false">
+            <span
+              aria-hidden="true"
+              class="density-switch__icon density-switch__icon--comfortable"
+            ></span>
+            <span class="sr-only">Comfortable</span>
+          </button>
+        </div>
+        <div class="warehouse-page__actions-buttons">
+          <button type="button" class="btn btn-outline" (click)="openCreateDialog()">
+            + Новая поставка
+          </button>
+          <button type="button" class="btn btn-ghost">Ещё</button>
+        </div>
       </div>
     </header>
 
@@ -174,7 +195,7 @@
         <section class="warehouse-page__table-card">
           <header class="warehouse-page__table-header">Последние поставки</header>
           <div class="warehouse-page__table-wrapper">
-            <table class="warehouse-page__table">
+            <table class="warehouse-page__table tbl-compact">
               <thead
                 class="sticky top-0 bg-background/90 backdrop-blur border-b shadow-[inset_0_-1px_0_0_var(--border)]"
               >


### PR DESCRIPTION
## Summary
- add a compact/comfortable density toggle placeholder to the warehouse header
- style the density switcher and table density modifiers so the current view stays compact by default

## Testing
- npm run lint *(fails: project has no configured lint target)*
- npm run test *(fails: ChromeHeadless is missing libatk-1.0.so.0 in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d993b2c2108323a949300e010485c4