### PR TITLE
Add warehouse metrics signal

### DIFF
--- a/feedme.client/src/app/warehouse/warehouse-page.component.html
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.html
@@ -45,7 +45,9 @@
 
         <article class="square warehouse-page__metric-card" aria-live="polite">
           <p class="warehouse-page__metric-label">Сумма закупок / 7 дн.</p>
-          <p class="warehouse-page__metric-value warehouse-page__metric-value--currency">0 ₽</p>
+          <p class="warehouse-page__metric-value warehouse-page__metric-value--currency">
+            {{ formatCurrency(snapshot.purchaseAmountLastWeek) }}
+          </p>
         </article>
 
         <article class="square warehouse-page__metric-card" aria-live="polite">

--- a/feedme.client/src/app/warehouse/warehouse-page.component.ts
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.ts
@@ -76,6 +76,7 @@ export class WarehousePageComponent {
   readonly editDialogTab = signal<EditDialogTab>('details');
 
   readonly rows = this.warehouseService.list();
+  readonly metrics = this.warehouseService.metrics();
 
 
   readonly editDialogTabs: ReadonlyArray<{ key: EditDialogTab; label: string }> = [

--- a/feedme.client/src/app/warehouse/warehouse.service.ts
+++ b/feedme.client/src/app/warehouse/warehouse.service.ts
@@ -1,6 +1,13 @@
-import { Injectable, signal } from '@angular/core';
+import { computed, Injectable, signal } from '@angular/core';
 
 import { SupplyRow } from './models';
+
+export type WarehouseMetrics = {
+  suppliesLastWeek: number;
+  purchaseAmountLastWeek: number;
+  positions: number;
+  expired: number;
+};
 
 @Injectable({ providedIn: 'root' })
 export class WarehouseService {
@@ -73,6 +80,44 @@ export class WarehouseService {
 
   readonly list = () => this.rowsSignal.asReadonly();
 
+  private readonly metricsSignal = computed<WarehouseMetrics>(() => {
+    const rows = this.rowsSignal();
+    const skuSet = new Set<string>();
+
+    const today = new Date();
+    const startOfToday = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+    const sevenDaysAgo = new Date(startOfToday);
+    sevenDaysAgo.setDate(startOfToday.getDate() - 6);
+
+    let suppliesLastWeek = 0;
+    let purchaseAmountLastWeek = 0;
+    let expired = 0;
+
+    for (const row of rows) {
+      skuSet.add(row.sku);
+
+      const arrivalDate = this.parseDate(row.arrivalDate);
+      if (!Number.isNaN(arrivalDate.getTime()) && arrivalDate >= sevenDaysAgo) {
+        suppliesLastWeek += 1;
+        purchaseAmountLastWeek += row.qty * row.price;
+      }
+
+      const expiryDate = this.parseDate(row.expiry);
+      if (!Number.isNaN(expiryDate.getTime()) && expiryDate < startOfToday) {
+        expired += 1;
+      }
+    }
+
+    return {
+      suppliesLastWeek,
+      purchaseAmountLastWeek,
+      positions: skuSet.size,
+      expired,
+    } satisfies WarehouseMetrics;
+  });
+
+  readonly metrics = () => this.metricsSignal;
+
   addRow(row: Omit<SupplyRow, 'id'>): void {
     this.rowsSignal.update((rows) => {
       const nextId = rows.reduce((max, current) => Math.max(max, current.id), 0) + 1;
@@ -89,5 +134,14 @@ export class WarehouseService {
   removeRowsById(ids: readonly number[]): void {
     const idSet = new Set(ids);
     this.rowsSignal.update((rows) => rows.filter((row) => !idSet.has(row.id)));
+  }
+
+  private parseDate(value: string): Date {
+    if (!value) {
+      return new Date(NaN);
+    }
+
+    const [year, month, day] = value.split('-').map(Number);
+    return new Date(year, month - 1, day);
   }
 }


### PR DESCRIPTION
## Summary
- add a computed metrics signal in `WarehouseService` that aggregates weekly supplies, purchase totals, positions, and expired counts
- expose the metrics snapshot on the warehouse page component and render the purchase total with the existing currency formatter

## Testing
- npm run lint *(fails: workspace does not define a `lint` target; Angular CLI suggests adding angular-eslint)*
- npm test *(fails: ChromeHeadless cannot start because libatk-1.0.so.0 is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d9c3cf23d48323bcd6bbd2659ee5b9