### PR TITLE
Remove visible labels above supply filter chips

### DIFF
--- a/feedme.client/src/app/warehouse/supplies/supplies.component.html
+++ b/feedme.client/src/app/warehouse/supplies/supplies.component.html
@@ -26,12 +26,21 @@
       </label>
     </div>
 
-    <div class="chips" aria-label="Выбранные фильтры">
-      <div class="chip chip--filled">Главный склад</div>
-      <div class="chip">Ок</div>
-      <div class="chip chip--danger">Просрочено</div>
-      <div class="chip chip--draft">Черновик</div>
-      <div class="chip chip--transit">В пути</div>
+    <div class="supplies__filters-control supplies__filters-control--chips">
+      <span class="sr-only">Склад</span>
+      <div class="chips" aria-label="Фильтр по складам">
+        <div class="chip chip--filled">Главный склад</div>
+      </div>
+    </div>
+
+    <div class="supplies__filters-control supplies__filters-control--chips">
+      <span class="sr-only">Статус</span>
+      <div class="chips" aria-label="Фильтр по статусам">
+        <div class="chip">Ок</div>
+        <div class="chip chip--danger">Просрочено</div>
+        <div class="chip chip--draft">Черновик</div>
+        <div class="chip chip--transit">В пути</div>
+      </div>
     </div>
 
     <button type="button" class="btn btn--outline">Сброс</button>

--- a/feedme.client/src/app/warehouse/supplies/supplies.component.scss
+++ b/feedme.client/src/app/warehouse/supplies/supplies.component.scss
@@ -25,6 +25,11 @@
   display: flex;
 }
 
+.supplies__filters-control--chips {
+  align-items: center;
+  gap: 0.5rem;
+}
+
 .supplies__filters-field {
   display: flex;
   flex-direction: column;
@@ -35,6 +40,17 @@
   font-size: 0.75rem;
   font-weight: 500;
   color: #6b7280;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
 }
 
 .chips {


### PR DESCRIPTION
## Summary
- hide the warehouse and status chip section labels while preserving screen reader text
- keep chip groups aligned with the other filters using a dedicated flex helper

## Testing
- npm run lint *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_68d9c705e8b88323a04479a78802ada8