### PR TITLE
feat: restyle supply quick action icons

### DIFF
--- a/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.css
+++ b/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.css
@@ -211,56 +211,48 @@
   background-color: #4f46e5;
 }
 
-.icon-btn {
-  width: 32px;
-  height: 32px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 0.5rem;
-  border: none;
-  background: transparent;
-  font-size: 20px;
-  line-height: 1;
-  padding: 0;
-  cursor: pointer;
-  transition: background-color 0.2s ease;
-}
-
-.icon-btn:hover,
-.icon-btn:focus-visible {
-  background: rgba(0, 0, 0, 0.06);
-  outline: none;
-}
-
 .row-actions {
-  display: inline-flex;
+  display: flex;
   align-items: center;
   justify-content: flex-end;
-  gap: 4px;
-  width: 100%;
-  flex-wrap: nowrap;
+  gap: 0.25rem;
+  min-width: 176px;
+  white-space: nowrap;
 }
 
-.row-action {
+.icon-btn {
   width: 28px;
   height: 28px;
-  border: 0;
-  background: transparent;
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+  filter: none;
   border-radius: 0;
-  font-size: 18px;
-  line-height: 1;
+  color: #6b7280;
+  padding: 0;
   cursor: pointer;
-  transition: background-color 0.2s ease;
+  transition: background-color 0.2s ease, color 0.2s ease;
 }
 
-.row-action:hover,
-.row-action:focus-visible {
+.icon-btn .icon {
+  width: 16px;
+  height: 16px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 1.5;
+}
+
+.icon-btn:hover {
   background: rgba(17, 24, 39, 0.06);
-  outline: none;
+  color: #111827;
+}
+
+.icon-btn:focus-visible {
+  outline: 0;
+  box-shadow: 0 0 0 2px var(--brand, #ff6a00);
 }
 
 .sr-only {

--- a/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.html
+++ b/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.html
@@ -121,36 +121,79 @@
             </span>
           </ng-container>
         </td>
-        <td class="w-[176px] text-right">
-          <div class="row-actions" role="group" aria-label="Быстрые действия">
-            <button
-              type="button"
-              class="row-action"
-              aria-label="Списать поставку"
-              (click)="writeOff.emit(item)"
-            >
-              <span aria-hidden="true">🗑</span>
-            </button>
-            <button
-              type="button"
-              class="row-action"
-              aria-label="Переместить поставку"
-              (click)="move.emit(item)"
-            >
-              <span aria-hidden="true">⇄</span>
-            </button>
-            <button
-              type="button"
-              class="row-action"
-              aria-label="Распечатать поставку"
-              (click)="print.emit(item)"
-            >
-              <span aria-hidden="true">🖨</span>
-            </button>
-            <button type="button" class="icon-btn" aria-label="Меню" (click)="onSettingsClick.emit(item)">
-              ⋯
-            </button>
-          </div>
+        <td class="row-actions">
+          <button
+            type="button"
+            class="icon-btn"
+            aria-label="Списать"
+            (click)="writeOff.emit(item)"
+          >
+            <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+              <path
+                d="M4 6h16"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="1.5"
+              />
+              <path
+                d="M10 11v6m4-6v6M6 6l1 12a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2l1-12M9 6V4a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v2"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="1.5"
+              />
+            </svg>
+          </button>
+          <button
+            type="button"
+            class="icon-btn"
+            aria-label="Переместить"
+            (click)="move.emit(item)"
+          >
+            <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+              <path
+                d="M7.5 8.5 4 12l3.5 3.5M4 12h9m3.5-7.5L20 8l-3.5 3.5M20 8H11"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="1.5"
+              />
+            </svg>
+          </button>
+          <button
+            type="button"
+            class="icon-btn"
+            aria-label="Печать"
+            (click)="print.emit(item)"
+          >
+            <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+              <path
+                d="M7 9V4h10v5M7 17H5a2 2 0 0 1-2-2v-3a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2h-2"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="1.5"
+              />
+              <path
+                d="M8 17h8v5H8z"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="1.5"
+              />
+              <path
+                d="M17 13h.01"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="1.5"
+              />
+            </svg>
+          </button>
+          <button type="button" class="icon-btn" aria-label="Меню" (click)="onSettingsClick.emit(item)">
+            ⋯
+          </button>
         </td>
       </tr>
       <tr *ngIf="paginatedData.length === 0">


### PR DESCRIPTION
## Summary
- replace emoji-based quick action controls with accessible SVG icon buttons in the supply table
- restyle the quick action buttons to use square transparent buttons with clear hover and focus states that match the new design

## Testing
- npm run lint *(fails: workspace has no configured lint target)*

------
https://chatgpt.com/codex/tasks/task_e_68d9c6fae408832397a91a612c6a24cd