### PR TITLE
Remove glow effects from warehouse tables

### DIFF
--- a/feedme.client/src/app/components/CatalogTableComponent/catalog-table.component.css
+++ b/feedme.client/src/app/components/CatalogTableComponent/catalog-table.component.css
@@ -56,12 +56,26 @@ app-catalog-view-switcher {
   color: #0f172a;
   border-bottom: 1px solid #e2e8f0;
   background-color: transparent;
+  box-shadow: none;
+  filter: none;
+  background-image: none;
 }
 
 .catalog-table thead th {
   text-align: left;
   font-weight: 500;
   white-space: nowrap;
+  background-color: #ffffff;
+  box-shadow: none;
+  filter: none;
+  background-image: none;
+}
+
+.catalog-table thead {
+  background-color: #ffffff;
+  box-shadow: none;
+  filter: none;
+  background-image: none;
 }
 
 .catalog-table thead th.sorted {

--- a/feedme.client/src/app/components/StockTableComponent/stock-table.component.css
+++ b/feedme.client/src/app/components/StockTableComponent/stock-table.component.css
@@ -29,6 +29,9 @@
   color: #0f172a;
   border-bottom: 1px solid #e2e8f0;
   background-color: transparent;
+  box-shadow: none;
+  filter: none;
+  background-image: none;
 }
 
 .stock-table thead th {
@@ -41,10 +44,19 @@
   position: sticky;
   top: 0;
   z-index: 2;
-  background-color: rgba(255, 255, 255, 0.92);
-  backdrop-filter: blur(8px);
+  background-color: #ffffff;
   border-bottom: 1px solid rgba(148, 163, 184, 0.35);
-  box-shadow: inset 0 -1px 0 0 rgba(148, 163, 184, 0.45);
+  box-shadow: none !important;
+  filter: none !important;
+  backdrop-filter: none !important;
+  background-image: none !important;
+}
+
+.stock-table__head th {
+  background-color: #ffffff;
+  box-shadow: none !important;
+  filter: none !important;
+  background-image: none !important;
 }
 
 .stock-table thead th.sorted {

--- a/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.css
+++ b/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.css
@@ -303,6 +303,9 @@
   color: #0f172a;
   border-bottom: 1px solid #e2e8f0;
   background-color: transparent;
+  box-shadow: none;
+  filter: none;
+  background-image: none;
 }
 
 .supplies-table th {
@@ -349,10 +352,19 @@
   position: sticky;
   top: 0;
   z-index: 2;
-  background-color: rgba(255, 255, 255, 0.92);
-  backdrop-filter: blur(8px);
+  background-color: #ffffff;
   border-bottom: 1px solid rgba(148, 163, 184, 0.35);
-  box-shadow: inset 0 -1px 0 0 rgba(148, 163, 184, 0.45);
+  box-shadow: none !important;
+  filter: none !important;
+  backdrop-filter: none !important;
+  background-image: none !important;
+}
+
+.supplies-table__head th {
+  background-color: #ffffff;
+  box-shadow: none !important;
+  filter: none !important;
+  background-image: none !important;
 }
 
 .hover\:bg-muted\/40:hover {


### PR DESCRIPTION
## Summary
- remove box shadows and filters from the supplies table header and cells so the surface stays flat
- align the stock table header styling with the flat look while preserving sticky behavior
- ensure catalog table headers and cells use plain backgrounds without extra glow

## Testing
- npm run lint *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_68d9c70dbc3083239c5f0c4d83016aa7