### PR TITLE
Hide supply empty state when data exists

### DIFF
--- a/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.html
+++ b/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.html
@@ -160,8 +160,8 @@
   </table>
 </div>
 
-<!-- TODO: toggle by data -->
 <app-empty
+  *ngIf="!hasAnySupply"
   class="mt-6 block"
   title="Нет поставок"
   subtitle="Создайте первую поставку, чтобы увидеть её в списке."

--- a/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.spec.ts
+++ b/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.spec.ts
@@ -17,6 +17,35 @@ describe('SupplyTableComponent', () => {
     component = fixture.componentInstance;
   });
 
+  it('shows empty state when no supplies are provided', () => {
+    component.data = [];
+    component.ngOnChanges({ data: new SimpleChange([], component.data, true) } as SimpleChanges);
+    fixture.detectChanges();
+
+    const emptyState = fixture.debugElement.query(By.css('app-empty'));
+    expect(emptyState).not.toBeNull();
+  });
+
+  it('hides empty state when at least one supply exists', () => {
+    component.data = [
+      {
+        productName: 'Молоко',
+        category: 'Молочная продукция',
+        stock: 10,
+        unitPrice: 100,
+        expiryDate: '2025-12-31',
+        responsible: 'Главный склад',
+        supplier: 'ООО "Поставщик"'
+      },
+    ];
+
+    component.ngOnChanges({ data: new SimpleChange([], component.data, true) } as SimpleChanges);
+    fixture.detectChanges();
+
+    const emptyState = fixture.debugElement.query(By.css('app-empty'));
+    expect(emptyState).toBeNull();
+  });
+
   it('should emit onSettingsClick when settings button is clicked', () => {
     const supply = {
       productName: 'Молоко',

--- a/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.ts
+++ b/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.ts
@@ -53,6 +53,8 @@ export class SupplyTableComponent implements OnChanges {
   rowsPerPage = 10;
   currentPage = 1;
   filteredData: any[] = [];
+  /** Показывает, есть ли хотя бы одна непустая поставка в исходных данных */
+  hasAnySupply = false;
 
   sortState: SortState | null = null;
 
@@ -90,6 +92,8 @@ export class SupplyTableComponent implements OnChanges {
       !!(item.category?.toString().trim()) ||
       !!(item.supplier?.toString().trim())
     );
+
+    this.hasAnySupply = nonEmpty.length > 0;
 
     // 2) поиск
     const q = this.searchQuery.toLowerCase();


### PR DESCRIPTION
## Summary
- hide the supply empty state card when the data set contains at least one supply
- track whether supplies exist inside the table component so the template can conditionally render the empty state
- cover the new behaviour with unit tests for empty and non-empty datasets

## Testing
- npm run test *(fails: ChromeHeadless cannot start because libatk-1.0.so.0 is missing in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d9c7acb3d88323b95a84126bec3e8e