### PR TITLE
feat: refresh warehouse catalog and supplies flows

### DIFF
--- a/feedme.client/src/app/warehouse/catalog/catalog.component.html
+++ b/feedme.client/src/app/warehouse/catalog/catalog.component.html
@@ -1,0 +1,202 @@
+<section class="catalog">
+  <header class="catalog__header">
+    <div>
+      <h1 class="catalog__title">Каталог</h1>
+      <p class="catalog__subtitle">{{ productsCount() }} позиций</p>
+    </div>
+    <button type="button" class="button button--primary" (click)="openDialog()">
+      + Новый товар
+    </button>
+  </header>
+
+  <div class="table-wrapper" *ngIf="products().length; else emptyCatalog">
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Название</th>
+          <th>Тип</th>
+          <th class="is-mono">SKU</th>
+          <th>Категория</th>
+          <th class="is-centered">Ед. изм.</th>
+          <th class="is-right">Цена закупки</th>
+          <th class="is-right">Цена продажи</th>
+          <th>Поставщик</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let product of products(); trackBy: trackByProductId">
+          <td>
+            <div class="truncate" [title]="product.name">{{ product.name }}</div>
+          </td>
+          <td>{{ product.type }}</td>
+          <td class="is-mono">
+            <span class="truncate" [title]="product.sku">{{ product.sku }}</span>
+          </td>
+          <td>
+            <div class="truncate" [title]="product.category">{{ product.category }}</div>
+          </td>
+          <td class="is-centered">{{ product.unit }}</td>
+          <td class="is-right">
+            {{ product.purchasePrice ?? '—' }}
+          </td>
+          <td class="is-right">
+            {{ product.salePrice ?? '—' }}
+          </td>
+          <td>
+            <div class="truncate" [title]="product.supplierMain || '—'">
+              {{ product.supplierMain || '—' }}
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <ng-template #emptyCatalog>
+    <div class="catalog__empty">Каталог пока пуст. Добавьте первую позицию.</div>
+  </ng-template>
+
+  <div class="dialog-backdrop" *ngIf="dialogOpen()">
+    <form class="dialog" [formGroup]="productForm" (ngSubmit)="submit()">
+      <header class="dialog__header">
+        <h2 class="dialog__title">Новый товар</h2>
+        <button type="button" class="dialog__close" aria-label="Закрыть" (click)="closeDialog()">×</button>
+      </header>
+
+      <section class="dialog__section">
+        <h3 class="dialog__section-title">Основная информация</h3>
+        <div class="form-grid">
+          <label class="field" [ngClass]="{ 'field--invalid': productForm.controls.name.touched && productForm.controls.name.invalid }">
+            <span class="field__label">Название товара *</span>
+            <input class="field__control" type="text" formControlName="name" placeholder="Например, Курица гриль" />
+            <span class="field__error" *ngIf="productForm.controls.name.touched && productForm.controls.name.invalid">
+              Укажите название товара
+            </span>
+          </label>
+
+          <label class="field">
+            <span class="field__label">Тип номенклатуры</span>
+            <select class="field__control" formControlName="type">
+              <option value="Товар">Товар</option>
+              <option value="Заготовка">Заготовка</option>
+              <option value="Полуфабрикат">Полуфабрикат</option>
+            </select>
+          </label>
+
+          <label class="field" [ngClass]="{ 'field--invalid': productForm.controls.sku.touched && productForm.controls.sku.invalid }">
+            <span class="field__label">Номенклатурный код *</span>
+            <input class="field__control" type="text" formControlName="sku" placeholder="MEAT-003" />
+            <span class="field__error" *ngIf="productForm.controls.sku.touched && productForm.controls.sku.invalid">
+              Укажите SKU
+            </span>
+          </label>
+
+          <label class="field" [ngClass]="{ 'field--invalid': productForm.controls.category.touched && productForm.controls.category.invalid }">
+            <span class="field__label">Категория *</span>
+            <input class="field__control" type="text" formControlName="category" placeholder="Мясные блюда" />
+            <span class="field__error" *ngIf="productForm.controls.category.touched && productForm.controls.category.invalid">
+              Укажите категорию
+            </span>
+          </label>
+
+          <label class="field" [ngClass]="{ 'field--invalid': productForm.controls.unit.touched && productForm.controls.unit.invalid }">
+            <span class="field__label">Единица измерения *</span>
+            <select class="field__control" formControlName="unit">
+              <option value="кг">кг</option>
+              <option value="л">л</option>
+              <option value="шт">шт</option>
+            </select>
+            <span class="field__error" *ngIf="productForm.controls.unit.touched && productForm.controls.unit.invalid">
+              Укажите единицу измерения
+            </span>
+          </label>
+
+          <label class="field">
+            <span class="field__label">Вес единицы, кг</span>
+            <input class="field__control" type="number" formControlName="unitWeight" min="0" step="0.01" />
+          </label>
+
+          <label class="field">
+            <span class="field__label">Метод списания</span>
+            <select class="field__control" formControlName="writeoff">
+              <option value="FIFO">FIFO</option>
+              <option value="FEFO">FEFO</option>
+              <option value="LIFO">LIFO</option>
+            </select>
+          </label>
+
+          <label class="field">
+            <span class="field__label">Аллергены</span>
+            <input class="field__control" type="text" formControlName="allergens" placeholder="Например, молоко" />
+          </label>
+
+          <label class="checkbox">
+            <input type="checkbox" formControlName="needsPacking" />
+            <span>Требует фасовки</span>
+          </label>
+
+          <label class="checkbox">
+            <input type="checkbox" formControlName="perishableAfterOpen" />
+            <span>Портится после вскрытия</span>
+          </label>
+        </div>
+      </section>
+
+      <section class="dialog__section">
+        <h3 class="dialog__section-title">Закупка и логистика</h3>
+        <div class="form-grid">
+          <label class="field">
+            <span class="field__label">Поставщик (основной)</span>
+            <input class="field__control" type="text" formControlName="supplierMain" placeholder="ООО Курица Дуо" />
+          </label>
+
+          <label class="field">
+            <span class="field__label">Срок поставки, дней</span>
+            <input class="field__control" type="number" formControlName="leadTimeDays" min="0" />
+          </label>
+
+          <label class="field">
+            <span class="field__label">Оценочная себестоимость</span>
+            <input class="field__control" type="number" formControlName="costEst" min="0" step="0.01" />
+          </label>
+
+          <label class="field">
+            <span class="field__label">Ставка НДС</span>
+            <input class="field__control" type="text" formControlName="vat" placeholder="Без НДС / 10% / 20%" />
+          </label>
+
+          <label class="field">
+            <span class="field__label">Цена закупки</span>
+            <input class="field__control" type="number" formControlName="purchasePrice" min="0" step="0.01" />
+          </label>
+
+          <label class="field">
+            <span class="field__label">Цена продажи</span>
+            <input class="field__control" type="number" formControlName="salePrice" min="0" step="0.01" />
+          </label>
+
+          <label class="field">
+            <span class="field__label">Код ТН ВЭД</span>
+            <input class="field__control" type="text" formControlName="tnvCode" placeholder="1602310000" />
+          </label>
+
+          <label class="checkbox">
+            <input type="checkbox" formControlName="marked" />
+            <span>Маркируемый товар</span>
+          </label>
+
+          <label class="checkbox">
+            <input type="checkbox" formControlName="alcohol" />
+            <span>Алкогольная продукция</span>
+          </label>
+        </div>
+      </section>
+
+      <footer class="dialog__actions">
+        <button type="button" class="button" (click)="closeDialog()">Отмена</button>
+        <button type="submit" class="button button--primary" [disabled]="submitting()">
+          {{ submitting() ? 'Сохранение…' : 'Сохранить' }}
+        </button>
+      </footer>
+    </form>
+  </div>
+</section>

--- a/feedme.client/src/app/warehouse/catalog/catalog.component.scss
+++ b/feedme.client/src/app/warehouse/catalog/catalog.component.scss
@@ -3,20 +3,20 @@
   color: #111827;
 }
 
-.supplies__header {
+.catalog__header {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
   margin-bottom: 1.5rem;
 }
 
-.supplies__title {
+.catalog__title {
   margin: 0;
   font-size: 1.5rem;
   font-weight: 700;
 }
 
-.supplies__subtitle {
+.catalog__subtitle {
   margin: 0.25rem 0 0;
   color: #6b7280;
 }
@@ -53,8 +53,8 @@
 }
 
 .button:disabled {
-  opacity: 0.6;
   cursor: not-allowed;
+  opacity: 0.6;
 }
 
 .table-wrapper {
@@ -101,21 +101,15 @@
   white-space: nowrap;
 }
 
-.meta {
-  margin-top: 0.25rem;
-  font-size: 0.75rem;
-  color: #6b7280;
-}
-
 .truncate {
   display: block;
-  max-width: 280px;
+  max-width: 320px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.supplies__empty {
+.catalog__empty {
   padding: 3rem 1.5rem;
   text-align: center;
   border: 1px dashed #d1d5db;
@@ -132,11 +126,11 @@
   justify-content: center;
   padding: 4rem 1rem;
   overflow-y: auto;
-  z-index: 30;
+  z-index: 20;
 }
 
 .dialog {
-  width: min(880px, 100%);
+  width: min(960px, 100%);
   background: #ffffff;
   border: 1px solid #d1d5db;
   border-radius: 0;
@@ -169,26 +163,10 @@
   border-radius: 0;
 }
 
-.tabs {
-  display: inline-flex;
-  border-bottom: 1px solid #e5e7eb;
-  gap: 0.25rem;
-}
-
-.tab {
-  border: none;
-  background: transparent;
-  padding: 0.75rem 1.25rem;
+.dialog__section-title {
+  margin: 0 0 1rem;
+  font-size: 1.1rem;
   font-weight: 600;
-  color: #6b7280;
-  cursor: pointer;
-  border-radius: 0;
-  transition: color 0.2s ease, background-color 0.2s ease;
-}
-
-.tab--active {
-  color: #fa4b00;
-  background: rgba(250, 75, 0, 0.08);
 }
 
 .form-grid {
@@ -233,68 +211,23 @@
   color: #dc2626;
 }
 
+.checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.checkbox input {
+  width: 1rem;
+  height: 1rem;
+  border-radius: 0;
+}
+
 .dialog__actions {
   display: flex;
   justify-content: flex-end;
   gap: 1rem;
-}
-
-.status-badge {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 3.5rem;
-  padding: 0.35rem 0.75rem;
-  font-size: 0.75rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  border-radius: 0;
-  border: 1px solid transparent;
-}
-
-.status-badge--ok {
-  background: rgba(16, 185, 129, 0.15);
-  color: #047857;
-  border-color: rgba(16, 185, 129, 0.45);
-}
-
-.status-badge--warning {
-  background: rgba(251, 146, 60, 0.15);
-  color: #c2410c;
-  border-color: rgba(251, 146, 60, 0.45);
-}
-
-.status-badge--expired {
-  background: rgba(239, 68, 68, 0.15);
-  color: #b91c1c;
-  border-color: rgba(239, 68, 68, 0.45);
-}
-
-.product-meta {
-  margin-top: 1.5rem;
-  border: 1px solid #e5e7eb;
-  background: #f9fafb;
-  padding: 1rem 1.25rem;
-  border-radius: 0;
-}
-
-.product-meta__title {
-  margin: 0 0 0.75rem;
-  font-size: 0.95rem;
-  font-weight: 600;
-}
-
-.product-meta__list {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  display: grid;
-  gap: 0.5rem;
-}
-
-.product-meta__list span {
-  color: #6b7280;
-  margin-right: 0.5rem;
 }
 
 @media (max-width: 900px) {
@@ -307,6 +240,6 @@
   }
 
   .truncate {
-    max-width: 200px;
+    max-width: 220px;
   }
 }

--- a/feedme.client/src/app/warehouse/catalog/catalog.component.ts
+++ b/feedme.client/src/app/warehouse/catalog/catalog.component.ts
@@ -1,0 +1,194 @@
+import { NgClass, NgFor, NgIf } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import {
+  NonNullableFormBuilder,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+import { firstValueFrom } from 'rxjs';
+import { toSignal } from '@angular/core/rxjs-interop';
+
+import { CatalogService } from './catalog.service';
+import { Product } from '../shared/models';
+
+interface ProductFormValue {
+  name: string;
+  type: Product['type'];
+  sku: string;
+  category: string;
+  unit: Product['unit'];
+  unitWeight: number | null;
+  writeoff: Product['writeoff'];
+  allergens: string;
+  needsPacking: boolean;
+  perishableAfterOpen: boolean;
+  supplierMain: string;
+  leadTimeDays: number | null;
+  costEst: number | null;
+  vat: string;
+  purchasePrice: number | null;
+  salePrice: number | null;
+  tnvCode: string;
+  marked: boolean;
+  alcohol: boolean;
+}
+
+@Component({
+  standalone: true,
+  selector: 'app-warehouse-catalog',
+  imports: [NgFor, NgIf, NgClass, ReactiveFormsModule],
+  templateUrl: './catalog.component.html',
+  styleUrl: './catalog.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CatalogComponent {
+  private readonly fb = inject(NonNullableFormBuilder);
+  private readonly catalogService = inject(CatalogService);
+
+  private readonly defaults: ProductFormValue = {
+    name: '',
+    type: 'Товар',
+    sku: '',
+    category: '',
+    unit: 'кг',
+    unitWeight: null,
+    writeoff: 'FIFO',
+    allergens: '',
+    needsPacking: false,
+    perishableAfterOpen: false,
+    supplierMain: '',
+    leadTimeDays: null,
+    costEst: null,
+    vat: '',
+    purchasePrice: null,
+    salePrice: null,
+    tnvCode: '',
+    marked: false,
+    alcohol: false,
+  };
+
+  readonly dialogOpen = signal(false);
+  readonly submitting = signal(false);
+
+  readonly productForm = this.fb.group({
+    name: this.fb.control(this.defaults.name, {
+      validators: [Validators.required, Validators.maxLength(200)],
+    }),
+    type: this.fb.control<Product['type']>(this.defaults.type, {
+      validators: [Validators.required],
+    }),
+    sku: this.fb.control(this.defaults.sku, {
+      validators: [Validators.required, Validators.maxLength(60)],
+    }),
+    category: this.fb.control(this.defaults.category, {
+      validators: [Validators.required, Validators.maxLength(120)],
+    }),
+    unit: this.fb.control<Product['unit']>(this.defaults.unit, {
+      validators: [Validators.required, Validators.maxLength(20)],
+    }),
+    unitWeight: this.fb.control<number | null>(this.defaults.unitWeight, {
+      validators: [Validators.min(0)],
+    }),
+    writeoff: this.fb.control<Product['writeoff']>(this.defaults.writeoff),
+    allergens: this.fb.control(this.defaults.allergens),
+    needsPacking: this.fb.control(this.defaults.needsPacking),
+    perishableAfterOpen: this.fb.control(this.defaults.perishableAfterOpen),
+    supplierMain: this.fb.control(this.defaults.supplierMain),
+    leadTimeDays: this.fb.control<number | null>(this.defaults.leadTimeDays, {
+      validators: [Validators.min(0)],
+    }),
+    costEst: this.fb.control<number | null>(this.defaults.costEst, {
+      validators: [Validators.min(0)],
+    }),
+    vat: this.fb.control(this.defaults.vat),
+    purchasePrice: this.fb.control<number | null>(this.defaults.purchasePrice, {
+      validators: [Validators.min(0)],
+    }),
+    salePrice: this.fb.control<number | null>(this.defaults.salePrice, {
+      validators: [Validators.min(0)],
+    }),
+    tnvCode: this.fb.control(this.defaults.tnvCode),
+    marked: this.fb.control(this.defaults.marked),
+    alcohol: this.fb.control(this.defaults.alcohol),
+  });
+
+  readonly products = toSignal(this.catalogService.getAll(), {
+    initialValue: [] as Product[],
+  });
+
+  readonly productsCount = computed(() => this.products().length);
+
+  openDialog(): void {
+    this.dialogOpen.set(true);
+  }
+
+  closeDialog(): void {
+    this.dialogOpen.set(false);
+    this.resetForm();
+  }
+
+  async submit(): Promise<void> {
+    if (this.productForm.invalid) {
+      this.productForm.markAllAsTouched();
+      return;
+    }
+
+    const raw = this.productForm.getRawValue();
+    const payload: Product = {
+      id: '',
+      name: raw.name.trim(),
+      type: raw.type,
+      sku: raw.sku.trim(),
+      category: raw.category.trim(),
+      unit: raw.unit,
+      unitWeight: this.normalizeNumber(raw.unitWeight),
+      writeoff: raw.writeoff,
+      allergens: raw.allergens.trim() || undefined,
+      needsPacking: raw.needsPacking || undefined,
+      perishableAfterOpen: raw.perishableAfterOpen || undefined,
+      supplierMain: raw.supplierMain.trim() || undefined,
+      leadTimeDays: this.normalizeNumber(raw.leadTimeDays),
+      costEst: this.normalizeNumber(raw.costEst),
+      vat: raw.vat.trim() || undefined,
+      purchasePrice: this.normalizeNumber(raw.purchasePrice),
+      salePrice: this.normalizeNumber(raw.salePrice),
+      tnvCode: raw.tnvCode.trim() || undefined,
+      marked: raw.marked || undefined,
+      alcohol: raw.alcohol || undefined,
+    };
+
+    this.submitting.set(true);
+    try {
+      await firstValueFrom(this.catalogService.add(payload));
+      this.closeDialog();
+    } finally {
+      this.submitting.set(false);
+    }
+  }
+
+  trackByProductId(_: number, product: Product): string {
+    return product.id;
+  }
+
+  private resetForm(): void {
+    this.productForm.reset(this.defaults);
+  }
+
+  private normalizeNumber(value: number | null): number | undefined {
+    if (value === null || Number.isNaN(value)) {
+      return undefined;
+    }
+
+    if (value < 0) {
+      return undefined;
+    }
+
+    return value;
+  }
+}

--- a/feedme.client/src/app/warehouse/catalog/catalog.service.ts
+++ b/feedme.client/src/app/warehouse/catalog/catalog.service.ts
@@ -1,0 +1,76 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable, of } from 'rxjs';
+
+import { Product } from '../shared/models';
+
+function createId(prefix: string): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID();
+  }
+
+  return `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+@Injectable({ providedIn: 'root' })
+export class CatalogService {
+  private readonly productsSubject = new BehaviorSubject<Product[]>([
+    {
+      id: createId('product'),
+      name: 'Курица гриль',
+      type: 'Товар',
+      sku: 'MEAT-001',
+      category: 'Горячие блюда',
+      unit: 'кг',
+      unitWeight: 1,
+      writeoff: 'FIFO',
+      allergens: 'Соя',
+      needsPacking: false,
+      perishableAfterOpen: true,
+      supplierMain: 'ООО «Курица Дуо»',
+      leadTimeDays: 3,
+      costEst: 180,
+      vat: '10%',
+      purchasePrice: 220,
+      salePrice: 390,
+      tnvCode: '1602310000',
+      marked: false,
+      alcohol: false,
+    },
+    {
+      id: createId('product'),
+      name: 'Сок апельсиновый',
+      type: 'Товар',
+      sku: 'DRINK-014',
+      category: 'Напитки',
+      unit: 'л',
+      unitWeight: 1,
+      writeoff: 'FEFO',
+      allergens: 'Цитрусовые',
+      needsPacking: false,
+      perishableAfterOpen: true,
+      supplierMain: 'ООО «ФруктСнаб»',
+      leadTimeDays: 5,
+      costEst: 45,
+      vat: '20%',
+      purchasePrice: 65,
+      salePrice: 120,
+      tnvCode: '2009192000',
+      marked: false,
+      alcohol: false,
+    },
+  ]);
+
+  getAll(): Observable<Product[]> {
+    return this.productsSubject.asObservable();
+  }
+
+  add(product: Product): Observable<Product> {
+    const newProduct: Product = {
+      ...product,
+      id: createId('product'),
+    };
+
+    this.productsSubject.next([newProduct, ...this.productsSubject.value]);
+    return of(newProduct);
+  }
+}

--- a/feedme.client/src/app/warehouse/shared/models.ts
+++ b/feedme.client/src/app/warehouse/shared/models.ts
@@ -1,0 +1,40 @@
+export type SupplyStatus = 'ok' | 'warning' | 'expired';
+
+export interface Product {
+  id: string;
+  name: string;
+  type: 'Товар' | 'Заготовка' | 'Полуфабрикат';
+  sku: string;
+  category: string;
+  unit: 'кг' | 'л' | 'шт' | string;
+  unitWeight?: number;
+  writeoff?: 'FIFO' | 'FEFO' | 'LIFO' | string;
+  allergens?: string;
+  needsPacking?: boolean;
+  perishableAfterOpen?: boolean;
+  supplierMain?: string;
+  leadTimeDays?: number;
+  costEst?: number;
+  vat?: string;
+  purchasePrice?: number;
+  salePrice?: number;
+  tnvCode?: string;
+  marked?: boolean;
+  alcohol?: boolean;
+}
+
+export interface SupplyRow {
+  id: string;
+  docNo: string;
+  arrivalDate: string;
+  warehouse: string;
+  responsible?: string;
+  productId: string;
+  sku: string;
+  name: string;
+  qty: number;
+  unit: string;
+  expiryDate: string;
+  supplier?: string;
+  status: SupplyStatus;
+}

--- a/feedme.client/src/app/warehouse/shared/status.util.ts
+++ b/feedme.client/src/app/warehouse/shared/status.util.ts
@@ -1,0 +1,20 @@
+export function computeExpiryStatus(
+  expiryISO: string,
+  warnDays = 14,
+): 'ok' | 'warning' | 'expired' {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const expiry = new Date(expiryISO);
+  expiry.setHours(0, 0, 0, 0);
+
+  if (Number.isNaN(expiry.getTime())) {
+    return 'ok';
+  }
+
+  if (expiry < today) {
+    return 'expired';
+  }
+
+  const diffDays = Math.ceil((expiry.getTime() - today.getTime()) / 86400000);
+  return diffDays <= warnDays ? 'warning' : 'ok';
+}

--- a/feedme.client/src/app/warehouse/supplies/supplies.component.html
+++ b/feedme.client/src/app/warehouse/supplies/supplies.component.html
@@ -1,61 +1,162 @@
-<div class="card supplies__filters-card">
-  <form class="card__content p-4 flex flex-wrap items-center gap-3" (submit)="$event.preventDefault()">
-    <div class="supplies__filters-control">
-      <label class="supplies__filters-field">
-        <span class="supplies__filters-label">Поиск</span>
-        <input
-          type="search"
-          class="input w-[320px]"
-          placeholder="Поиск по номеру, SKU или названию"
-          aria-label="Поиск по поставкам"
-        />
-      </label>
+<section class="supplies">
+  <header class="supplies__header">
+    <div>
+      <h1 class="supplies__title">Поставки</h1>
+      <p class="supplies__subtitle">{{ supplies().length }} записей</p>
     </div>
+    <button type="button" class="button button--primary" (click)="openDialog()">
+      + Новая поставка
+    </button>
+  </header>
 
-    <div class="supplies__filters-control">
-      <label class="supplies__filters-field">
-        <span class="supplies__filters-label">Дата от</span>
-        <input type="date" class="input w-[160px]" aria-label="Дата прихода от" />
-      </label>
-    </div>
-
-    <div class="supplies__filters-control">
-      <label class="supplies__filters-field">
-        <span class="supplies__filters-label">Дата до</span>
-        <input type="date" class="input w-[160px]" aria-label="Дата прихода до" />
-      </label>
-    </div>
-
-    <div class="supplies__filters-control supplies__filters-control--chips">
-      <span class="sr-only">Склад</span>
-      <div class="chips" aria-label="Фильтр по складам">
-        <div class="chip chip--filled">Главный склад</div>
-      </div>
-    </div>
-
-    <div class="supplies__filters-control supplies__filters-control--chips">
-      <span class="sr-only">Статус</span>
-      <div class="chips" aria-label="Фильтр по статусам">
-        <div class="chip">Ок</div>
-        <div class="chip chip--danger">Просрочено</div>
-        <div class="chip chip--draft">Черновик</div>
-        <div class="chip chip--transit">В пути</div>
-      </div>
-    </div>
-
-    <button type="button" class="btn btn--outline">Сброс</button>
-    <button type="button" class="btn btn-brand-outline">Импорт</button>
-    <button type="button" class="btn btn--secondary">Экспорт</button>
-    <button type="button" class="btn btn--primary ml-auto">+ Новая поставка</button>
-  </form>
-</div>
-
-<div class="bulkbar"> <!-- TODO: show on selection -->
-  <span class="bulkbar__hint">Выбрано: 3</span>
-  <div class="bulkbar__actions">
-    <button class="btn btn--outline btn-sm" type="button">Списать</button>
-    <button class="btn btn--outline btn-sm" type="button">Переместить</button>
-    <button class="btn btn--outline btn-sm" type="button">Печать</button>
-    <button class="btn btn-danger btn-sm" type="button">Удалить</button>
+  <div class="table-wrapper" *ngIf="supplies().length; else emptySupplies">
+    <table class="table">
+      <thead>
+        <tr>
+          <th class="is-mono">Номер</th>
+          <th class="is-centered">Дата прихода</th>
+          <th>Склад</th>
+          <th>Ответственный</th>
+          <th>Товар</th>
+          <th class="is-right">Количество</th>
+          <th class="is-centered">Годен до</th>
+          <th>Поставщик</th>
+          <th class="is-centered">Статус</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let row of supplies(); trackBy: trackBySupplyId">
+          <td class="is-mono">{{ row.docNo }}</td>
+          <td class="is-centered">{{ row.arrivalDate }}</td>
+          <td>
+            <div class="truncate" [title]="row.warehouse">{{ row.warehouse }}</div>
+          </td>
+          <td>
+            <div class="truncate" [title]="row.responsible || '—'">{{ row.responsible || '—' }}</div>
+          </td>
+          <td>
+            <div class="truncate" [title]="row.name">{{ row.name }}</div>
+            <div class="meta">SKU: {{ row.sku }}</div>
+          </td>
+          <td class="is-right">{{ row.qty }} {{ row.unit }}</td>
+          <td class="is-centered">{{ row.expiryDate }}</td>
+          <td>
+            <div class="truncate" [title]="row.supplier || '—'">{{ row.supplier || '—' }}</div>
+          </td>
+          <td class="is-centered">
+            <span [class]="badgeClass(row.status)">{{ row.status | uppercase }}</span>
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </div>
-</div>
+  <ng-template #emptySupplies>
+    <div class="supplies__empty">Записей пока нет. Создайте первую поставку.</div>
+  </ng-template>
+
+  <div class="dialog-backdrop" *ngIf="dialogOpen()">
+    <form class="dialog" [formGroup]="supplyForm" (ngSubmit)="submit()">
+      <header class="dialog__header">
+        <h2 class="dialog__title">Новая поставка</h2>
+        <button type="button" class="dialog__close" aria-label="Закрыть" (click)="closeDialog()">×</button>
+      </header>
+
+      <nav class="tabs" role="tablist">
+        <button
+          type="button"
+          *ngFor="let tab of tabs"
+          class="tab"
+          [ngClass]="{ 'tab--active': activeTab() === tab.key }"
+          (click)="setActiveTab(tab.key)"
+        >
+          {{ tab.label }}
+        </button>
+      </nav>
+
+      <section class="tab-panel" *ngIf="activeTab() === 'details'">
+        <div class="form-grid">
+          <label class="field" [ngClass]="{ 'field--invalid': supplyForm.controls.docNo.touched && supplyForm.controls.docNo.invalid }">
+            <span class="field__label">Номер документа *</span>
+            <input class="field__control" type="text" formControlName="docNo" placeholder="PRH-00045" />
+            <span class="field__error" *ngIf="supplyForm.controls.docNo.touched && supplyForm.controls.docNo.invalid">
+              Укажите номер документа
+            </span>
+          </label>
+
+          <label class="field" [ngClass]="{ 'field--invalid': supplyForm.controls.arrivalDate.touched && supplyForm.controls.arrivalDate.invalid }">
+            <span class="field__label">Дата прихода *</span>
+            <input class="field__control" type="date" formControlName="arrivalDate" />
+            <span class="field__error" *ngIf="supplyForm.controls.arrivalDate.touched && supplyForm.controls.arrivalDate.invalid">
+              Укажите дату в формате ГГГГ-ММ-ДД
+            </span>
+          </label>
+
+          <label class="field" [ngClass]="{ 'field--invalid': supplyForm.controls.warehouse.touched && supplyForm.controls.warehouse.invalid }">
+            <span class="field__label">Склад *</span>
+            <input class="field__control" type="text" formControlName="warehouse" placeholder="Главный склад" />
+            <span class="field__error" *ngIf="supplyForm.controls.warehouse.touched && supplyForm.controls.warehouse.invalid">
+              Укажите склад
+            </span>
+          </label>
+
+          <label class="field" [ngClass]="{ 'field--invalid': supplyForm.controls.responsible.touched && supplyForm.controls.responsible.invalid }">
+            <span class="field__label">Ответственный *</span>
+            <input class="field__control" type="text" formControlName="responsible" placeholder="Имя сотрудника" />
+            <span class="field__error" *ngIf="supplyForm.controls.responsible.touched && supplyForm.controls.responsible.invalid">
+              Укажите ответственного
+            </span>
+          </label>
+        </div>
+      </section>
+
+      <section class="tab-panel" *ngIf="activeTab() === 'product'">
+        <div class="form-grid">
+          <label class="field" [ngClass]="{ 'field--invalid': supplyForm.controls.productId.touched && supplyForm.controls.productId.invalid }">
+            <span class="field__label">Товар *</span>
+            <select class="field__control" formControlName="productId">
+              <option value="" disabled>Выберите товар</option>
+              <option *ngFor="let product of products(); trackBy: trackByProductId" [value]="product.id">
+                {{ product.name }} · {{ product.sku }}
+              </option>
+            </select>
+            <span class="field__error" *ngIf="supplyForm.controls.productId.touched && supplyForm.controls.productId.invalid">
+              Выберите товар из каталога
+            </span>
+          </label>
+
+          <label class="field" [ngClass]="{ 'field--invalid': supplyForm.controls.qty.touched && supplyForm.controls.qty.invalid }">
+            <span class="field__label">Количество *</span>
+            <input class="field__control" type="number" formControlName="qty" min="0" step="0.01" />
+            <span class="field__error" *ngIf="supplyForm.controls.qty.touched && supplyForm.controls.qty.invalid">
+              Укажите положительное количество
+            </span>
+          </label>
+
+          <label class="field" [ngClass]="{ 'field--invalid': supplyForm.controls.expiryDate.touched && supplyForm.controls.expiryDate.invalid }">
+            <span class="field__label">Срок годности *</span>
+            <input class="field__control" type="date" formControlName="expiryDate" />
+            <span class="field__error" *ngIf="supplyForm.controls.expiryDate.touched && supplyForm.controls.expiryDate.invalid">
+              Укажите корректную дату
+            </span>
+          </label>
+        </div>
+
+        <aside class="product-meta" *ngIf="selectedProduct() as current">
+          <h4 class="product-meta__title">Данные из каталога</h4>
+          <ul class="product-meta__list">
+            <li><span>SKU:</span> {{ current.sku }}</li>
+            <li><span>Поставщик:</span> {{ current.supplierMain || '—' }}</li>
+            <li><span>Единица:</span> {{ current.unit }}</li>
+          </ul>
+        </aside>
+      </section>
+
+      <footer class="dialog__actions">
+        <button type="button" class="button" (click)="closeDialog()">Отмена</button>
+        <button type="submit" class="button button--primary" [disabled]="submitting()">
+          {{ submitting() ? 'Сохранение…' : 'Сохранить' }}
+        </button>
+      </footer>
+    </form>
+  </div>
+</section>

--- a/feedme.client/src/app/warehouse/supplies/supplies.component.ts
+++ b/feedme.client/src/app/warehouse/supplies/supplies.component.ts
@@ -1,0 +1,208 @@
+import { NgClass, NgFor, NgIf } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import {
+  NonNullableFormBuilder,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { firstValueFrom } from 'rxjs';
+
+import { CatalogService } from '../catalog/catalog.service';
+import { SuppliesService } from './supplies.service';
+import { Product, SupplyRow } from '../shared/models';
+
+interface SupplyFormValue {
+  docNo: string;
+  arrivalDate: string;
+  warehouse: string;
+  responsible: string;
+  productId: string;
+  qty: number | null;
+  expiryDate: string;
+}
+
+@Component({
+  standalone: true,
+  selector: 'app-warehouse-supplies',
+  imports: [NgIf, NgFor, NgClass, ReactiveFormsModule],
+  templateUrl: './supplies.component.html',
+  styleUrl: './supplies.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SuppliesComponent {
+  private readonly fb = inject(NonNullableFormBuilder);
+  private readonly suppliesService = inject(SuppliesService);
+  private readonly catalogService = inject(CatalogService);
+
+  readonly tabs: ReadonlyArray<{ key: 'details' | 'product'; label: string }> = [
+    { key: 'details', label: 'Детали документа' },
+    { key: 'product', label: 'Товар' },
+  ];
+
+  readonly dialogOpen = signal(false);
+  readonly submitting = signal(false);
+  readonly activeTab = signal<'details' | 'product'>('details');
+
+  private readonly defaults: SupplyFormValue = {
+    docNo: '',
+    arrivalDate: '',
+    warehouse: '',
+    responsible: '',
+    productId: '',
+    qty: null,
+    expiryDate: '',
+  };
+
+  readonly supplyForm = this.fb.group({
+    docNo: this.fb.control(this.defaults.docNo, {
+      validators: [Validators.required, Validators.maxLength(60)],
+    }),
+    arrivalDate: this.fb.control(this.defaults.arrivalDate, {
+      validators: [Validators.required, Validators.pattern(/^\d{4}-\d{2}-\d{2}$/)],
+    }),
+    warehouse: this.fb.control(this.defaults.warehouse, {
+      validators: [Validators.required, Validators.maxLength(120)],
+    }),
+    responsible: this.fb.control(this.defaults.responsible, {
+      validators: [Validators.required, Validators.maxLength(120)],
+    }),
+    productId: this.fb.control(this.defaults.productId, {
+      validators: [Validators.required],
+    }),
+    qty: this.fb.control<number | null>(this.defaults.qty, {
+      validators: [Validators.required, Validators.min(0.0000001)],
+    }),
+    expiryDate: this.fb.control(this.defaults.expiryDate, {
+      validators: [Validators.required, Validators.pattern(/^\d{4}-\d{2}-\d{2}$/)],
+    }),
+  });
+
+  readonly products = toSignal(this.catalogService.getAll(), {
+    initialValue: [] as Product[],
+  });
+
+  readonly supplies = toSignal(this.suppliesService.getAll(), {
+    initialValue: [] as SupplyRow[],
+  });
+
+  private readonly selectedProductId = toSignal(
+    this.supplyForm.controls.productId.valueChanges,
+    { initialValue: this.supplyForm.controls.productId.value },
+  );
+
+  readonly selectedProduct = computed(() => {
+    const id = this.selectedProductId();
+    if (!id) {
+      return null;
+    }
+    return this.products().find((product) => product.id === id) ?? null;
+  });
+
+  readonly selectedSupplier = computed(() => this.selectedProduct()?.supplierMain ?? '—');
+  readonly selectedUnit = computed(() => this.selectedProduct()?.unit ?? '—');
+  readonly selectedSku = computed(() => this.selectedProduct()?.sku ?? '—');
+
+  openDialog(): void {
+    this.dialogOpen.set(true);
+    this.activeTab.set('details');
+  }
+
+  closeDialog(): void {
+    this.dialogOpen.set(false);
+    this.resetForm();
+  }
+
+  setActiveTab(tab: 'details' | 'product'): void {
+    this.activeTab.set(tab);
+  }
+
+  async submit(): Promise<void> {
+    if (this.supplyForm.invalid) {
+      this.supplyForm.markAllAsTouched();
+      return;
+    }
+
+    const raw = this.supplyForm.getRawValue();
+    const product = this.products().find((item) => item.id === raw.productId);
+    if (!product) {
+      this.supplyForm.controls.productId.setErrors({ required: true });
+      this.activeTab.set('product');
+      return;
+    }
+
+    if (!raw.qty || raw.qty <= 0) {
+      this.supplyForm.controls.qty.setErrors({ min: true });
+      this.activeTab.set('product');
+      return;
+    }
+
+    if (!this.isValidISODate(raw.expiryDate)) {
+      this.supplyForm.controls.expiryDate.setErrors({ pattern: true });
+      this.activeTab.set('product');
+      return;
+    }
+
+    const payload: SupplyRow = {
+      id: '',
+      docNo: raw.docNo.trim(),
+      arrivalDate: raw.arrivalDate,
+      warehouse: raw.warehouse.trim(),
+      responsible: raw.responsible.trim() || undefined,
+      productId: product.id,
+      sku: product.sku,
+      name: product.name,
+      qty: raw.qty,
+      unit: product.unit,
+      expiryDate: raw.expiryDate,
+      supplier: product.supplierMain,
+      status: 'ok',
+    };
+
+    this.submitting.set(true);
+    try {
+      await firstValueFrom(this.suppliesService.add(payload));
+      this.closeDialog();
+    } finally {
+      this.submitting.set(false);
+    }
+  }
+
+  trackBySupplyId(_: number, row: SupplyRow): string {
+    return row.id;
+  }
+
+  trackByProductId(_: number, product: Product): string {
+    return product.id;
+  }
+
+  badgeClass(status: SupplyRow['status']): string {
+    switch (status) {
+      case 'warning':
+        return 'status-badge status-badge--warning';
+      case 'expired':
+        return 'status-badge status-badge--expired';
+      default:
+        return 'status-badge status-badge--ok';
+    }
+  }
+
+  private resetForm(): void {
+    this.supplyForm.reset(this.defaults);
+  }
+
+  private isValidISODate(value: string): boolean {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+      return false;
+    }
+
+    const parsed = new Date(value);
+    return !Number.isNaN(parsed.getTime());
+  }
+}

--- a/feedme.client/src/app/warehouse/supplies/supplies.service.ts
+++ b/feedme.client/src/app/warehouse/supplies/supplies.service.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable, of } from 'rxjs';
+
+import { SupplyRow } from '../shared/models';
+import { computeExpiryStatus } from '../shared/status.util';
+
+function createId(prefix: string): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID();
+  }
+
+  return `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+@Injectable({ providedIn: 'root' })
+export class SuppliesService {
+  private readonly suppliesSubject = new BehaviorSubject<SupplyRow[]>([]);
+
+  getAll(): Observable<SupplyRow[]> {
+    return this.suppliesSubject.asObservable();
+  }
+
+  add(row: SupplyRow): Observable<SupplyRow> {
+    const newRow: SupplyRow = {
+      ...row,
+      id: createId('supply'),
+      status: computeExpiryStatus(row.expiryDate),
+    };
+
+    this.suppliesSubject.next([newRow, ...this.suppliesSubject.value]);
+    return of(newRow);
+  }
+}


### PR DESCRIPTION
## Summary
- redesign the warehouse catalog table and new-product dialog with validation and catalog service persistence
- add shared warehouse models and expiry status utility consumed by the new catalog and supplies services
- rebuild the supplies view with a service-backed table, status badges, and a two-tab dialog for creating supply rows

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9c931f270832396434dda6b25225c