### PR TITLE
feat: refresh catalog product popup styling

### DIFF
--- a/feedme.client/src/app/components/catalog-new-product-popup/catalog-new-product-popup.component.css
+++ b/feedme.client/src/app/components/catalog-new-product-popup/catalog-new-product-popup.component.css
@@ -1,119 +1,246 @@
 .popup-backdrop {
   position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background-color: rgba(0, 0, 0, 0.5);
+  inset: 0;
   display: flex;
-  justify-content: center;
   align-items: center;
+  justify-content: center;
+  background: rgba(10, 14, 29, 0.48);
+  padding: 24px;
   z-index: 1000;
 }
 
 .popup-content {
-  width: 800px;
-  max-width: 95%;
-  background-color: #fff;
-  border-radius: 10px;
-  padding: 20px;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
-  position: relative;
+  width: min(960px, 100%);
+  max-height: calc(100vh - 48px);
+  background: #ffffff;
+  border-radius: 20px;
+  padding: 32px;
+  box-shadow: 0 24px 48px rgba(15, 21, 48, 0.18);
   display: flex;
   flex-direction: column;
-  overflow-y: auto;
+  overflow: hidden;
 }
 
-  .popup-content h2 {
-    margin-top: 0;
-    text-align: center;
-    margin-bottom: 16px;
-  }
-.error-message {
-  color: #dc3545;
-  text-align: center;
-  margin-bottom: 16px;
+.popup-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 24px;
 }
+
+.popup-title {
+  margin: 0;
+  font-size: 24px;
+  font-weight: 600;
+  color: #1b1c1d;
+}
+
+.close-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: 1px solid transparent;
+  background: transparent;
+  color: #8a8f98;
+  font-size: 24px;
+  line-height: 1;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.close-btn:hover,
+.close-btn:focus-visible {
+  background: rgba(138, 143, 152, 0.12);
+  border-color: rgba(138, 143, 152, 0.24);
+  color: #1b1c1d;
+  outline: none;
+}
+
+.form {
+  overflow-y: auto;
+  padding-right: 8px;
+  margin-right: -8px;
+}
+
+.error-message {
+  margin: -8px 0 16px;
+  color: #d92d20;
+  text-align: left;
+  font-size: 14px;
+}
+
+.section {
+  margin-bottom: 32px;
+}
+
+.section:last-of-type {
+  margin-bottom: 0;
+}
+
+.section-title {
+  margin: 0 0 16px;
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: #8a8f98;
+}
+
 .form-grid {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 16px;
- 
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 20px 24px;
 }
 
 .input-container {
   display: flex;
   flex-direction: column;
-  flex: 1 1 calc(50% - 16px);
-  min-width: 260px;
+  gap: 8px;
 }
 
-  .input-container textarea {
-    height: 80px;
-  }
-.textarea-container {
-  flex-basis: 100%;
+label {
+  font-size: 13px;
+  font-weight: 500;
+  color: #4e5259;
 }
 
-.section {
-  margin-bottom: 20px;
+input,
+select {
+  display: block;
+  width: 100%;
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid #d6dade;
+  background: #ffffff;
+  font-size: 14px;
+  line-height: 1.4;
+  color: #1b1c1d;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
-.section-title {
-  margin-bottom: 8px;
-  font-weight: 600;
+input::placeholder {
+  color: #a1a6ae;
 }
+
+input:focus-visible,
+select:focus-visible {
+  border-color: #ff8c2a;
+  box-shadow: 0 0 0 4px rgba(255, 140, 42, 0.18);
+  outline: none;
+}
+
+select {
+  appearance: none;
+  background-image: linear-gradient(45deg, transparent 50%, #8a8f98 50%),
+    linear-gradient(135deg, #8a8f98 50%, transparent 50%);
+  background-position: calc(100% - 18px) calc(50% - 4px), calc(100% - 12px) calc(50% - 4px);
+  background-size: 6px 6px, 6px 6px;
+  background-repeat: no-repeat;
+  padding-right: 36px;
+}
+
 .checkbox-container {
   display: flex;
   align-items: center;
-  flex: 1 1 ;
+  padding: 12px 16px;
+  border-radius: 12px;
+  border: 1px solid #e6e9ed;
+  background: #f8f9fb;
 }
-  .checkbox-container input[type="checkbox"] {
-    width: 2em;
-    height: 2em;
-  }
+
 .checkbox-label {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 12px;
+  width: 100%;
   font-size: 14px;
-  white-space: nowrap;
+  color: #1b1c1d;
+  cursor: pointer;
 }
+
+.checkbox-label input[type='checkbox'] {
+  width: 18px;
+  height: 18px;
+  accent-color: #ff8c2a;
+}
+
 .popup-buttons {
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
   gap: 16px;
-  margin-top: 20px;
+  margin-top: 24px;
+  padding-top: 16px;
+  border-top: 1px solid #eef1f4;
 }
 
-  .popup-buttons button {
-    width: 48%;
-    padding: 12px;
-    border-radius: 6px;
-    cursor: pointer;
-    border: none;
-  }
+.popup-buttons button {
+  min-width: 160px;
+  padding: 12px 20px;
+  border-radius: 12px;
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
 
 .cancel-btn {
-  background-color: #ccc;
+  background: #ffffff;
+  border-color: #d6dade;
+  color: #1b1c1d;
+}
+
+.cancel-btn:hover,
+.cancel-btn:focus-visible {
+  border-color: #ff8c2a;
+  color: #ff8c2a;
+  outline: none;
 }
 
 .save-btn {
-  background-color: #007bff;
-  color: white;
+  background: linear-gradient(135deg, #ff952d 0%, #ff7a1a 100%);
+  color: #ffffff;
+  box-shadow: 0 12px 24px rgba(255, 123, 26, 0.28);
 }
 
-.close-btn {
-  position: absolute;
-  top: 10px;
-  right: 15px;
-  background: none;
-  border: none;
-  font-size: 24px;
-  cursor: pointer;
-  color: #777;
+.save-btn:disabled {
+  background: #f0f1f3;
+  color: #a1a6ae;
+  box-shadow: none;
+  cursor: not-allowed;
 }
+
+.save-btn:not(:disabled):hover,
+.save-btn:not(:disabled):focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 28px rgba(255, 123, 26, 0.32);
+  outline: none;
+}
+
 input.ng-invalid.ng-touched,
 select.ng-invalid.ng-touched {
-  border-color: #dc3545;
+  border-color: #d92d20;
+}
+
+@media (max-width: 768px) {
+  .popup-content {
+    padding: 24px;
+  }
+
+  .form {
+    margin-right: 0;
+    padding-right: 0;
+  }
+
+  .popup-buttons {
+    flex-direction: column-reverse;
+    align-items: stretch;
+  }
+
+  .popup-buttons button {
+    width: 100%;
+  }
 }

--- a/feedme.client/src/app/components/catalog-new-product-popup/catalog-new-product-popup.component.html
+++ b/feedme.client/src/app/components/catalog-new-product-popup/catalog-new-product-popup.component.html
@@ -1,138 +1,184 @@
 <div class="popup-backdrop">
-  <div class="popup-content">
-    <button class="close-btn" type="button" (click)="close()">×</button>
-    <h2>Новый товар</h2>
+  <div class="popup-content" role="dialog" aria-modal="true" aria-labelledby="new-product-title">
+    <div class="popup-header">
+      <h2 id="new-product-title" class="popup-title">Новый товар</h2>
+      <button class="close-btn" type="button" (click)="close()" aria-label="Закрыть окно">
+        ×
+      </button>
+    </div>
+
     <p class="error-message" *ngIf="errorMessage">{{ errorMessage }}</p>
-    <form [formGroup]="form" (ngSubmit)="onSubmit()">
-      <div class="section">
+
+    <form class="form" [formGroup]="form" (ngSubmit)="onSubmit()">
+      <section class="section">
         <h3 class="section-title">Основная информация</h3>
         <div class="form-grid">
           <div class="input-container">
-            <label>Название товара</label>
-            <input formControlName="name" />
+            <label for="new-product-name">Название товара</label>
+            <input id="new-product-name" formControlName="name" autocomplete="off" placeholder="Например, Курица гриль" />
           </div>
           <div class="input-container">
-            <label>Тип номенклатуры</label>
-            <select formControlName="type">
+            <label for="new-product-type">Тип номенклатуры</label>
+            <select id="new-product-type" formControlName="type">
               <option *ngFor="let t of types" [value]="t">{{ t }}</option>
             </select>
           </div>
           <div class="input-container">
-            <label>Номенклатурный код</label>
-            <input formControlName="code" />
+            <label for="new-product-code">Номенклатурный код</label>
+            <input id="new-product-code" formControlName="code" autocomplete="off" placeholder="Например, MEAT-003" />
           </div>
           <div class="input-container">
-            <label>Категория</label>
-            <input formControlName="category" />
+            <label for="new-product-category">Категория</label>
+            <input id="new-product-category" formControlName="category" autocomplete="off" placeholder="Например, Мясные заготовки" />
           </div>
           <div class="input-container">
-            <label>Единица измерения (базовая)</label>
-            <select formControlName="unit">
+            <label for="new-product-unit">Единица измерения (базовая)</label>
+            <select id="new-product-unit" formControlName="unit">
               <option *ngFor="let u of units" [value]="u">{{ u }}</option>
             </select>
           </div>
           <div class="input-container">
-            <label>Вес/объем единицы</label>
-            <input type="number" formControlName="weight" />
+            <label for="new-product-weight">Вес/объем единицы</label>
+            <input
+              id="new-product-weight"
+              type="number"
+              formControlName="weight"
+              inputmode="decimal"
+              placeholder="Например, 2.5"
+            />
           </div>
           <div class="input-container">
-            <label>Метод списания</label>
-            <select formControlName="writeoffMethod">
+            <label for="new-product-writeoff">Метод списания</label>
+            <select id="new-product-writeoff" formControlName="writeoffMethod">
               <option value="FIFO">FIFO</option>
               <option value="FEFO">FEFO</option>
+              <option value="LIFO">LIFO</option>
             </select>
           </div>
           <div class="input-container">
-            <label>Аллергены</label>
-            <input formControlName="allergens" />
+            <label for="new-product-allergens">Аллергены</label>
+            <input id="new-product-allergens" formControlName="allergens" autocomplete="off" placeholder="Например, молоко" />
           </div>
           <div class="checkbox-container">
-            <label class="checkbox-label">
-              <input type="checkbox" formControlName="packagingRequired" />
+            <label class="checkbox-label" for="new-product-packaging">
+              <input id="new-product-packaging" type="checkbox" formControlName="packagingRequired" />
               Требует фасовки
             </label>
           </div>
           <div class="checkbox-container">
-            <label class="checkbox-label">
-              <input type="checkbox" formControlName="spoilsAfterOpening" />
+            <label class="checkbox-label" for="new-product-spoils">
+              <input id="new-product-spoils" type="checkbox" formControlName="spoilsAfterOpening" />
               Портится после вскрытия
             </label>
           </div>
         </div>
-      </div>
+      </section>
 
-      <div class="section">
+      <section class="section">
         <h3 class="section-title">Закупка и логистика</h3>
         <div class="form-grid">
           <div class="input-container">
-            <label>Поставщик (основной)</label>
-            <input formControlName="supplier" />
+            <label for="new-product-supplier">Поставщик (основной)</label>
+            <input id="new-product-supplier" formControlName="supplier" autocomplete="off" placeholder="Например, ООО Кури Дурс" />
           </div>
           <div class="input-container">
-            <label>Срок поставки (дней)</label>
-            <input type="number" formControlName="deliveryTime" />
+            <label for="new-product-delivery-time">Срок поставки (дней)</label>
+            <input
+              id="new-product-delivery-time"
+              type="number"
+              formControlName="deliveryTime"
+              inputmode="numeric"
+              placeholder="Например, 2"
+            />
           </div>
           <div class="input-container">
-            <label>Оценочная себестоимость</label>
-            <input type="number" formControlName="costEstimate" />
+            <label for="new-product-cost">Оценочная себестоимость</label>
+            <input
+              id="new-product-cost"
+              type="number"
+              formControlName="costEstimate"
+              inputmode="decimal"
+              placeholder="Например, 350"
+            />
           </div>
           <div class="input-container">
-            <label>Ставка НДС</label>
-            <select formControlName="taxRate">
+            <label for="new-product-tax">Ставка НДС</label>
+            <select id="new-product-tax" formControlName="taxRate">
               <option *ngFor="let rate of taxRates" [value]="rate">{{ rate }}</option>
             </select>
           </div>
           <div class="input-container">
-            <label>Цена за единицу</label>
-            <input type="number" formControlName="unitPrice" />
+            <label for="new-product-unit-price">Цена за единицу</label>
+            <input
+              id="new-product-unit-price"
+              type="number"
+              formControlName="unitPrice"
+              inputmode="decimal"
+              placeholder="Например, 420"
+            />
           </div>
           <div class="input-container">
-            <label>Цена продажи (опционально)</label>
-            <input type="number" formControlName="salePrice" />
+            <label for="new-product-sale-price">Цена продажи (опционально)</label>
+            <input
+              id="new-product-sale-price"
+              type="number"
+              formControlName="salePrice"
+              inputmode="decimal"
+              placeholder="Например, 520"
+            />
           </div>
           <div class="input-container">
-            <label>Код ТН ВЭД</label>
-            <input formControlName="tnved" />
+            <label for="new-product-tnved">Код ТН ВЭД</label>
+            <input id="new-product-tnved" formControlName="tnved" autocomplete="off" placeholder="Например, 0207" />
           </div>
           <div class="checkbox-container">
-            <label class="checkbox-label">
-              <input type="checkbox" formControlName="isMarked" />
+            <label class="checkbox-label" for="new-product-marked">
+              <input id="new-product-marked" type="checkbox" formControlName="isMarked" />
               Маркируемый товар
             </label>
           </div>
           <div class="checkbox-container">
-            <label class="checkbox-label">
-              <input type="checkbox" formControlName="isAlcohol" />
+            <label class="checkbox-label" for="new-product-alcohol">
+              <input id="new-product-alcohol" type="checkbox" formControlName="isAlcohol" />
               Алкогольная продукция
             </label>
           </div>
         </div>
-      </div>
+      </section>
 
-      <div class="section" *ngIf="form.get('isAlcohol')?.value">
+      <section class="section" *ngIf="form.get('isAlcohol')?.value">
         <h3 class="section-title">Алкогольная продукция</h3>
         <div class="form-grid">
           <div class="input-container">
-            <label>Код вида алкоголя</label>
-            <input formControlName="alcoholCode" />
+            <label for="new-product-alcohol-code">Код вида алкоголя</label>
+            <input id="new-product-alcohol-code" formControlName="alcoholCode" autocomplete="off" />
           </div>
           <div class="input-container">
-            <label>Крепость (%)</label>
-            <input type="number" formControlName="alcoholStrength" />
+            <label for="new-product-alcohol-strength">Крепость (%)</label>
+            <input
+              id="new-product-alcohol-strength"
+              type="number"
+              formControlName="alcoholStrength"
+              inputmode="decimal"
+              placeholder="Например, 40"
+            />
           </div>
           <div class="input-container">
-            <label>Объем тары, л</label>
-            <input type="number" formControlName="alcoholVolume" />
+            <label for="new-product-alcohol-volume">Объем тары, л</label>
+            <input
+              id="new-product-alcohol-volume"
+              type="number"
+              formControlName="alcoholVolume"
+              inputmode="decimal"
+              placeholder="Например, 0.75"
+            />
           </div>
         </div>
-      </div>
+      </section>
+
       <div class="popup-buttons">
         <button type="button" class="cancel-btn" (click)="close()">Отмена</button>
-
-        <button type="submit" class="save-btn" [disabled]="form.invalid">
-
-          Сохранить
-        </button>
+        <button type="submit" class="save-btn" [disabled]="form.invalid">Сохранить</button>
       </div>
     </form>
   </div>


### PR DESCRIPTION
## Summary
- restyle the catalog new product popup to align with the supplied design, including a dedicated header and section layout
- enhance the form fields with accessible labels, helpful placeholders, and additional write-off options
- refresh control styling for inputs, checkboxes, and actions with the updated color palette and responsive behaviour

## Testing
- npm run build -- --configuration=development

------
https://chatgpt.com/codex/tasks/task_e_68d9d05655308323823c0b607db2d7fd