### PR TITLE
Remove static chips from supply filters

### DIFF
--- a/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.css
+++ b/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.css
@@ -106,51 +106,6 @@
   color: #64748b;
 }
 
-.multi-select__control {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 8px;
-  min-height: 44px;
-  border: 1px solid #cbd5f0;
-  border-radius: 8px;
-  padding: 6px 8px;
-  background-color: #ffffff;
-}
-
-.chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 10px;
-  border-radius: 9999px;
-  background-color: rgba(59, 130, 246, 0.15);
-  color: #1d4ed8;
-  font-size: 0.75rem;
-  font-weight: 600;
-  line-height: 1;
-}
-
-.chip--secondary {
-  background-color: rgba(245, 158, 11, 0.16);
-  color: #b45309;
-}
-
-.chip--destructive {
-  background-color: rgba(248, 113, 113, 0.16);
-  color: #b91c1c;
-}
-
-.chip--muted {
-  background-color: rgba(148, 163, 184, 0.16);
-  color: #475569;
-}
-
-.chip--info {
-  background-color: rgba(59, 130, 246, 0.16);
-  color: #1d4ed8;
-}
-
 .btn {
   display: inline-flex;
   align-items: center;

--- a/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.html
+++ b/feedme.client/src/app/components/SupplyTableComponent/supply-table.component.html
@@ -23,25 +23,6 @@
       <input type="date" class="input w-[160px]" aria-label="Дата прихода до" />
     </label>
 
-    <div class="filters-control multi-select">
-      <span class="filters-control__label">Склад</span>
-      <div class="multi-select__control">
-        <span class="chip">Главный склад</span>
-        <span class="chip">Кухня</span>
-      </div>
-    </div>
-
-    <div class="filters-control multi-select">
-      <span class="filters-control__label">Статус</span>
-      <div class="multi-select__control">
-        <span class="chip">Ок</span>
-        <span class="chip chip--secondary">Скоро срок</span>
-        <span class="chip chip--destructive">Просрочено</span>
-        <span class="chip chip--muted">Черновик</span>
-        <span class="chip chip--info">В пути</span>
-      </div>
-    </div>
-
     <button type="button" class="btn btn-outline">Сброс</button>
     <button type="button" class="btn btn-brand-outline">Импорт</button>
     <button type="button" class="btn btn-secondary">Экспорт</button>

--- a/feedme.client/src/app/warehouse/supplies/supplies.component.ts
+++ b/feedme.client/src/app/warehouse/supplies/supplies.component.ts
@@ -146,7 +146,6 @@ export class SuppliesComponent {
       .subscribe(() => {
         this.closeDialog();
       });
-r
   }
 
   trackBySupplyId(_: number, row: SupplyRow): string {


### PR DESCRIPTION
## Summary
- remove the static warehouse and status multi-select chips from the supplies filter toolbar
- clean up the related styling helpers that are no longer used
- tidy the supplies form submission flow by removing an accidental stray character

## Testing
- npm run test *(fails: ChromeHeadless missing libatk-1.0.so.0 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d9d4f11e748323b0773445dc27a090