### PR TITLE
Fix new product popup overflow

### DIFF
--- a/feedme.client/src/app/components/catalog-new-product-popup/catalog-new-product-popup.component.css
+++ b/feedme.client/src/app/components/catalog-new-product-popup/catalog-new-product-popup.component.css
@@ -18,6 +18,7 @@
   box-shadow: 0 24px 48px rgba(15, 21, 48, 0.18);
   display: flex;
   flex-direction: column;
+  box-sizing: border-box;
   overflow: hidden;
 }
 

--- a/feedme.client/src/app/warehouse/supplies/supplies.component.ts
+++ b/feedme.client/src/app/warehouse/supplies/supplies.component.ts
@@ -146,7 +146,6 @@ export class SuppliesComponent {
       .subscribe(() => {
         this.closeDialog();
       });
-r
   }
 
   trackBySupplyId(_: number, row: SupplyRow): string {


### PR DESCRIPTION
## Summary
- apply border-box sizing to the new product dialog container to stop horizontal overflow
- remove a stray character left in the supplies component submission handler

## Testing
- `npm run test` *(fails: ChromeHeadless cannot start because libatk-1.0.so.0 is missing in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9d50541288323a827c6a057557f60