### PR TITLE
style: refresh catalog focus states

### DIFF
--- a/feedme.client/src/app/components/catalog/catalog.component.css
+++ b/feedme.client/src/app/components/catalog/catalog.component.css
@@ -3,6 +3,11 @@
   align-items: center;
   gap: 8px;
 }
+
+:host {
+  --catalog-focus-ring: rgba(37, 99, 235, 0.4);
+  --ring: var(--catalog-focus-ring);
+}
 .tabs button {
   padding: 6px 12px;
   border: none;
@@ -10,6 +15,12 @@
   cursor: pointer;
   font-weight: 500;
   font-size: 16px;
+}
+.tabs button:focus-visible {
+  outline: 2px solid rgba(37, 99, 235, 0.8);
+  outline-offset: 2px;
+  box-shadow: none;
+  border-radius: 6px;
 }
 .tabs button.active {
   border-bottom: 2px solid #007bff;


### PR DESCRIPTION
## Summary
- replace the catalog focus ring color with a softer blue tone scoped to the component
- customize tab focus outlines to remove the orange glow while keeping a clear accessible indicator

## Testing
- npm run lint *(fails: no Angular lint target is configured for this project)*
- npm test *(fails: ChromeHeadless cannot start because libatk-1.0.so.0 is missing in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68da884c88c08323ac1c7638558fd8f9