### PR TITLE
Implement shelf-life status calculations

### DIFF
--- a/feedme.Server/Contracts/ReceiptLineResponse.cs
+++ b/feedme.Server/Contracts/ReceiptLineResponse.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace feedme.Server.Contracts;
+
+public sealed record ReceiptLineResponse(
+    string CatalogItemId,
+    string ItemName,
+    decimal Quantity,
+    string Unit,
+    decimal UnitPrice,
+    decimal TotalCost,
+    DateTime? ExpiryDate,
+    string Status
+);

--- a/feedme.Server/Contracts/ReceiptResponse.cs
+++ b/feedme.Server/Contracts/ReceiptResponse.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+
+namespace feedme.Server.Contracts;
+
+public sealed record ReceiptResponse(
+    string Id,
+    string Number,
+    string Supplier,
+    string Warehouse,
+    DateTime ReceivedAt,
+    IReadOnlyList<ReceiptLineResponse> Items,
+    decimal TotalAmount
+);

--- a/feedme.Server/Controllers/ReceiptsController.cs
+++ b/feedme.Server/Controllers/ReceiptsController.cs
@@ -1,5 +1,9 @@
+using System.Collections.Generic;
+using System.Linq;
+using feedme.Server.Contracts;
 using feedme.Server.Models;
 using feedme.Server.Repositories;
+using feedme.Server.Services;
 using Microsoft.AspNetCore.Mvc;
 
 namespace feedme.Server.Controllers;
@@ -16,23 +20,57 @@ public class ReceiptsController : ControllerBase
     }
 
     [HttpGet]
-    public async Task<ActionResult<IEnumerable<Receipt>>> Get()
+    public async Task<ActionResult<IEnumerable<ReceiptResponse>>> Get()
     {
         var receipts = await _repository.GetAllAsync();
-        return Ok(receipts);
+        return Ok(receipts.Select(MapReceipt));
     }
 
     [HttpGet("{id}")]
-    public async Task<ActionResult<Receipt>> GetById(string id)
+    public async Task<ActionResult<ReceiptResponse>> GetById(string id)
     {
         var receipt = await _repository.GetByIdAsync(id);
-        return receipt is null ? NotFound() : Ok(receipt);
+        return receipt is null ? NotFound() : Ok(MapReceipt(receipt));
     }
 
     [HttpPost]
-    public async Task<ActionResult<Receipt>> Create([FromBody] Receipt receipt)
+    public async Task<ActionResult<ReceiptResponse>> Create([FromBody] Receipt receipt)
     {
         var created = await _repository.AddAsync(receipt);
-        return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
+        var response = MapReceipt(created);
+        return CreatedAtAction(nameof(GetById), new { id = response.Id }, response);
+    }
+
+    private static ReceiptResponse MapReceipt(Receipt receipt)
+    {
+        var lines = (receipt.Items ?? Enumerable.Empty<ReceiptLine>())
+            .Select(line => MapLine(line, receipt.ReceivedAt))
+            .ToArray();
+
+        return new ReceiptResponse(
+            receipt.Id,
+            receipt.Number,
+            receipt.Supplier,
+            receipt.Warehouse,
+            receipt.ReceivedAt,
+            lines,
+            receipt.TotalAmount);
+    }
+
+    private static ReceiptLineResponse MapLine(ReceiptLine line, DateTime receivedAt)
+    {
+        var status = line.ExpiryDate.HasValue
+            ? ShelfLifeStatusCalculator.Evaluate(receivedAt, line.ExpiryDate.Value).ToCode()
+            : ShelfLifeState.Ok.ToCode();
+
+        return new ReceiptLineResponse(
+            line.CatalogItemId,
+            line.ItemName,
+            line.Quantity,
+            line.Unit,
+            line.UnitPrice,
+            line.TotalCost,
+            line.ExpiryDate,
+            status);
     }
 }

--- a/feedme.Server/Data/Configurations/ReceiptConfiguration.cs
+++ b/feedme.Server/Data/Configurations/ReceiptConfiguration.cs
@@ -80,6 +80,9 @@ public class ReceiptConfiguration : IEntityTypeConfiguration<Receipt>
                 .HasPrecision(18, 4)
                 .IsRequired();
 
+            items.Property(line => line.ExpiryDate)
+                .HasColumnName("expiry_date");
+
             items.Ignore(line => line.TotalCost);
 
             items.HasIndex("receipt_id");

--- a/feedme.Server/Data/Migrations/20250220000000_AddReceiptLineExpiryDate.cs
+++ b/feedme.Server/Data/Migrations/20250220000000_AddReceiptLineExpiryDate.cs
@@ -1,0 +1,26 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace feedme.Server.Data.Migrations
+{
+    public partial class AddReceiptLineExpiryDate : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "expiry_date",
+                table: "receipt_lines",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "expiry_date",
+                table: "receipt_lines");
+        }
+    }
+}

--- a/feedme.Server/Data/Migrations/AppDbContextModelSnapshot.cs
+++ b/feedme.Server/Data/Migrations/AppDbContextModelSnapshot.cs
@@ -222,6 +222,10 @@ namespace feedme.Server.Data.Migrations
                                 .HasColumnType("numeric(18,4)")
                                 .HasColumnName("unit_price");
 
+                            b1.Property<DateTime?>("ExpiryDate")
+                                .HasColumnType("timestamp with time zone")
+                                .HasColumnName("expiry_date");
+
                             b1.HasKey("receipt_id", "Id");
 
                             b1.HasIndex("receipt_id");

--- a/feedme.Server/Models/ReceiptLine.cs
+++ b/feedme.Server/Models/ReceiptLine.cs
@@ -22,5 +22,7 @@ public class ReceiptLine
     [Range(typeof(decimal), "0.00", "79228162514264337593543950335", ErrorMessage = "Unit price must be non-negative.")]
     public decimal UnitPrice { get; set; }
 
+    public DateTime? ExpiryDate { get; set; }
+
     public decimal TotalCost => UnitPrice * Quantity;
 }

--- a/feedme.Server/Models/ShelfLifeState.cs
+++ b/feedme.Server/Models/ShelfLifeState.cs
@@ -1,0 +1,18 @@
+namespace feedme.Server.Models;
+
+public enum ShelfLifeState
+{
+    Ok,
+    Warning,
+    Expired
+}
+
+public static class ShelfLifeStateExtensions
+{
+    public static string ToCode(this ShelfLifeState state) => state switch
+    {
+        ShelfLifeState.Warning => "warning",
+        ShelfLifeState.Expired => "expired",
+        _ => "ok"
+    };
+}

--- a/feedme.Server/Repositories/PostgresReceiptRepository.cs
+++ b/feedme.Server/Repositories/PostgresReceiptRepository.cs
@@ -68,7 +68,8 @@ public class PostgresReceiptRepository(AppDbContext context) : IReceiptRepositor
             ItemName = Sanitize(item.ItemName),
             Quantity = item.Quantity,
             Unit = Sanitize(item.Unit),
-            UnitPrice = item.UnitPrice
+            UnitPrice = item.UnitPrice,
+            ExpiryDate = NormalizeDate(item.ExpiryDate)
         };
     }
 
@@ -91,4 +92,21 @@ public class PostgresReceiptRepository(AppDbContext context) : IReceiptRepositor
     }
 
     private static string Sanitize(string value) => value?.Trim() ?? string.Empty;
+
+    private static DateTime? NormalizeDate(DateTime? value)
+    {
+        if (value is null)
+        {
+            return null;
+        }
+
+        var date = value.Value.Date;
+
+        return date.Kind switch
+        {
+            DateTimeKind.Unspecified => DateTime.SpecifyKind(date, DateTimeKind.Utc),
+            DateTimeKind.Local => date.ToUniversalTime(),
+            _ => date
+        };
+    }
 }

--- a/feedme.Server/Services/ShelfLifeStatusCalculator.cs
+++ b/feedme.Server/Services/ShelfLifeStatusCalculator.cs
@@ -1,0 +1,50 @@
+using System;
+using feedme.Server.Models;
+
+namespace feedme.Server.Services;
+
+public static class ShelfLifeStatusCalculator
+{
+    private const double WarningThreshold = 0.8;
+
+    public static ShelfLifeState Evaluate(DateTime receivedAt, DateTime expiryDate, DateTime? reference = null)
+    {
+        var arrival = ToDateOnly(receivedAt);
+        var expiry = ToDateOnly(expiryDate);
+        var today = ToDateOnly(reference ?? DateTime.UtcNow);
+
+        if (expiry <= today)
+        {
+            return ShelfLifeState.Expired;
+        }
+
+        if (expiry <= arrival)
+        {
+            return ShelfLifeState.Expired;
+        }
+
+        var shelfLifeDays = expiry.DayNumber - arrival.DayNumber;
+        if (shelfLifeDays <= 0)
+        {
+            return ShelfLifeState.Expired;
+        }
+
+        var elapsedDays = Math.Clamp(today.DayNumber - arrival.DayNumber, 0, shelfLifeDays);
+        var progress = elapsedDays / (double)shelfLifeDays;
+
+        return progress >= WarningThreshold ? ShelfLifeState.Warning : ShelfLifeState.Ok;
+    }
+
+    private static DateOnly ToDateOnly(DateTime value)
+    {
+        var normalized = value.Kind switch
+        {
+            DateTimeKind.Unspecified => DateTime.SpecifyKind(value, DateTimeKind.Utc),
+            DateTimeKind.Local => value.ToUniversalTime(),
+            _ => value
+        };
+
+        return DateOnly.FromDateTime(normalized);
+    }
+
+}

--- a/feedme.client/src/app/components/add-receipt-popup/add-receipt-popup.component.spec.ts
+++ b/feedme.client/src/app/components/add-receipt-popup/add-receipt-popup.component.spec.ts
@@ -59,7 +59,9 @@ describe('AddReceiptPopupComponent', () => {
           quantity: 5,
           unit: 'кг',
           unitPrice: catalogItem.unitPrice,
-          totalCost: catalogItem.unitPrice * 5
+          totalCost: catalogItem.unitPrice * 5,
+          expiryDate: '2024-04-25T00:00:00.000Z',
+          status: 'warning'
         }
       ],
       totalAmount: catalogItem.unitPrice * 5
@@ -103,6 +105,7 @@ describe('AddReceiptPopupComponent', () => {
       component.form.controls.receivedAt.setValue('2024-04-15');
       component.form.controls.quantity.setValue(5);
       component.form.controls.unit.setValue('кг');
+      component.form.controls.expiryDate.setValue('2024-04-25');
 
       component.onSubmit();
 
@@ -117,7 +120,8 @@ describe('AddReceiptPopupComponent', () => {
             itemName: catalogItem.name,
             quantity: 5,
             unit: 'кг',
-            unitPrice: catalogItem.unitPrice
+            unitPrice: catalogItem.unitPrice,
+            expiryDate: '2024-04-25T00:00:00.000Z'
           }
         ]
       });

--- a/feedme.client/src/app/components/add-receipt-popup/add-receipt-popup.component.ts
+++ b/feedme.client/src/app/components/add-receipt-popup/add-receipt-popup.component.ts
@@ -156,6 +156,8 @@ export class AddReceiptPopupComponent implements OnInit {
       return;
     }
 
+    const expiryIso = rawValue.expiryDate ? this.toIsoDate(rawValue.expiryDate) : null;
+
     const payload: CreateReceipt = {
       number,
       supplier: rawValue.supplier?.trim() || product.supplier,
@@ -167,7 +169,8 @@ export class AddReceiptPopupComponent implements OnInit {
           itemName: product.name,
           quantity,
           unit,
-          unitPrice: product.unitPrice
+          unitPrice: product.unitPrice,
+          expiryDate: expiryIso,
         }
       ]
     };

--- a/feedme.client/src/app/services/receipt.service.spec.ts
+++ b/feedme.client/src/app/services/receipt.service.spec.ts
@@ -37,7 +37,8 @@ describe('ReceiptService', () => {
           itemName: 'Помидоры',
           quantity: 5,
           unit: 'кг',
-          unitPrice: 150
+          unitPrice: 150,
+          expiryDate: '2024-04-25T00:00:00.000Z'
         }
       ]
     };
@@ -51,7 +52,8 @@ describe('ReceiptService', () => {
       items: [
         {
           ...payload.items[0],
-          totalCost: payload.items[0].quantity * payload.items[0].unitPrice
+          totalCost: payload.items[0].quantity * payload.items[0].unitPrice,
+          status: 'warning'
         }
       ],
       totalAmount: payload.items[0].quantity * payload.items[0].unitPrice

--- a/feedme.client/src/app/services/receipt.service.ts
+++ b/feedme.client/src/app/services/receipt.service.ts
@@ -3,6 +3,8 @@ import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { ApiUrlService } from './api-url.service';
 
+export type ShelfLifeStatus = 'ok' | 'warning' | 'expired';
+
 export interface ReceiptLine {
   catalogItemId: string;
   itemName: string;
@@ -10,6 +12,8 @@ export interface ReceiptLine {
   unit: string;
   unitPrice: number;
   totalCost: number;
+  expiryDate: string | null;
+  status: ShelfLifeStatus;
 }
 
 export interface Receipt {
@@ -22,7 +26,7 @@ export interface Receipt {
   totalAmount: number;
 }
 
-export type CreateReceiptLine = Omit<ReceiptLine, 'totalCost'>;
+export type CreateReceiptLine = Omit<ReceiptLine, 'totalCost' | 'status'>;
 
 export interface CreateReceipt {
   number: string;

--- a/feedme.client/src/app/warehouse/shared/status.util.spec.ts
+++ b/feedme.client/src/app/warehouse/shared/status.util.spec.ts
@@ -17,17 +17,32 @@ describe('computeExpiryStatus', () => {
     expect(computeExpiryStatus(toISO(yesterday))).toBe('expired');
   });
 
-  it('returns "warning" when expiry date is within 14 days', () => {
-    const nextWeek = new Date();
-    nextWeek.setDate(nextWeek.getDate() + 7);
+  it('returns "warning" when 80% of shelf life has passed', () => {
+    const arrival = new Date();
+    arrival.setDate(arrival.getDate() - 8);
+    const expiry = new Date();
+    expiry.setDate(expiry.getDate() + 2);
 
-    expect(computeExpiryStatus(toISO(nextWeek))).toBe('warning');
+    expect(computeExpiryStatus(toISO(expiry), toISO(arrival))).toBe('warning');
   });
 
-  it('returns "ok" when expiry date is more than 14 days away', () => {
-    const nextMonth = new Date();
-    nextMonth.setDate(nextMonth.getDate() + 30);
+  it('returns "ok" when shelf life consumption is below threshold', () => {
+    const arrival = new Date();
+    arrival.setDate(arrival.getDate() - 2);
+    const expiry = new Date();
+    expiry.setDate(expiry.getDate() + 8);
 
-    expect(computeExpiryStatus(toISO(nextMonth))).toBe('ok');
+    expect(computeExpiryStatus(toISO(expiry), toISO(arrival))).toBe('ok');
+  });
+
+  it('falls back to remaining days when arrival is unknown', () => {
+    const expirySoon = new Date();
+    expirySoon.setDate(expirySoon.getDate() + 2);
+
+    const expiryLater = new Date();
+    expiryLater.setDate(expiryLater.getDate() + 10);
+
+    expect(computeExpiryStatus(toISO(expirySoon))).toBe('warning');
+    expect(computeExpiryStatus(toISO(expiryLater))).toBe('ok');
   });
 });

--- a/feedme.client/src/app/warehouse/shared/status.util.ts
+++ b/feedme.client/src/app/warehouse/shared/status.util.ts
@@ -1,20 +1,53 @@
+type DateInput = string | Date | null | undefined;
 
-export function computeExpiryStatus(expiryISO: string, warnDays = 14): 'ok' | 'warning' | 'expired' {
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
+const MS_IN_DAY = 86_400_000;
+const WARNING_THRESHOLD = 0.8;
 
-
-  const expiry = new Date(expiryISO);
-  expiry.setHours(0, 0, 0, 0);
-
-  if (Number.isNaN(expiry.getTime())) {
+export function computeExpiryStatus(
+  expiryInput: DateInput,
+  arrivalInput?: DateInput,
+  referenceInput: DateInput = new Date()
+): 'ok' | 'warning' | 'expired' {
+  const expiry = normalizeDate(expiryInput);
+  if (!expiry) {
     return 'ok';
   }
 
-  if (expiry < today) {
+  const reference = normalizeDate(referenceInput) ?? startOfDay(new Date());
+  if (expiry <= reference) {
     return 'expired';
   }
 
-  const diffDays = Math.ceil((expiry.getTime() - today.getTime()) / 86400000);
-  return diffDays <= warnDays ? 'warning' : 'ok';
+  const arrival = normalizeDate(arrivalInput);
+  if (!arrival || arrival >= expiry) {
+    const daysRemaining = differenceInDays(expiry, reference);
+    return daysRemaining <= 2 ? 'warning' : 'ok';
+  }
+
+  const totalDays = Math.max(0, differenceInDays(expiry, arrival));
+  if (totalDays === 0) {
+    return 'expired';
+  }
+
+  const elapsed = Math.min(totalDays, Math.max(0, differenceInDays(reference, arrival)));
+  const progress = elapsed / totalDays;
+
+  return progress >= WARNING_THRESHOLD ? 'warning' : 'ok';
+}
+
+function normalizeDate(value: DateInput): Date | null {
+  if (!value) {
+    return null;
+  }
+
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : startOfDay(date);
+}
+
+function startOfDay(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+function differenceInDays(later: Date, earlier: Date): number {
+  return Math.round((later.getTime() - earlier.getTime()) / MS_IN_DAY);
 }

--- a/feedme.client/src/app/warehouse/supplies/supplies.component.spec.ts
+++ b/feedme.client/src/app/warehouse/supplies/supplies.component.spec.ts
@@ -76,12 +76,12 @@ describe('SuppliesComponent', () => {
 
   it('computes status before saving and sends payload to service', () => {
     const addSpy = spyOn(service, 'add').and.callThrough();
-    const expiry = formatISO(7);
+    const expiry = formatISO(2);
 
     component.openDialog();
     component.form.setValue({
       docNo: 'PO-999999',
-      arrivalDate: formatISO(0),
+      arrivalDate: formatISO(-8),
       warehouse: 'Главный склад',
       responsible: 'Петров П.',
       productId: 'prod-chicken',

--- a/feedme.client/src/app/warehouse/supplies/supplies.component.ts
+++ b/feedme.client/src/app/warehouse/supplies/supplies.component.ts
@@ -137,7 +137,7 @@ export class SuppliesComponent {
       unit: product.unit,
       expiryDate: value.expiryDate,
       supplier: product.supplier,
-      status: computeExpiryStatus(value.expiryDate),
+      status: computeExpiryStatus(value.expiryDate, value.arrivalDate),
     };
 
     this.suppliesService

--- a/feedme.client/src/app/warehouse/supplies/supplies.service.ts
+++ b/feedme.client/src/app/warehouse/supplies/supplies.service.ts
@@ -59,6 +59,7 @@ export class SuppliesService {
     const record: SupplyRow = {
       ...payload,
       id: typeof payload.id === 'string' && payload.id ? payload.id : this.generateId(),
+      status: computeExpiryStatus(payload.expiryDate, payload.arrivalDate),
     };
 
     this.rowsSubject.next([record, ...this.rowsSubject.value]);
@@ -126,7 +127,7 @@ export class SuppliesService {
         unit: product.unit,
         expiryDate,
         supplier: product.supplier,
-        status: computeExpiryStatus(expiryDate),
+        status: computeExpiryStatus(expiryDate, arrivalDate),
       } satisfies SupplyRow;
     };
 


### PR DESCRIPTION
## Summary
- add a reusable shelf-life status calculator on the backend and persist expiry dates for receipt lines
- expose expiry metadata and computed statuses in receipt API contracts with updated repository normalization and migration
- adjust Angular utilities, supplies workflows, and stock table badges to apply the 80% shelf-life rule and forward expiry data to the server

## Testing
- `dotnet test feedme.sln` *(fails: .NET SDK is not installed in the execution environment)*
- `npm run test` *(fails: ChromeHeadless cannot start because required system libraries such as libatk-1.0.so.0 are missing)*

------
https://chatgpt.com/codex/tasks/task_e_68da8bded3a483239ddf88107a40e166