### PR TITLE
Rebuild supplies layout for compact KPI-first view

### DIFF
--- a/feedme.client/src/app/warehouse/supplies/supplies.component.html
+++ b/feedme.client/src/app/warehouse/supplies/supplies.component.html
@@ -1,67 +1,89 @@
-<section class="supplies">
-
-  <section class="filters">
-    <input class="fm-input w-280" placeholder="Поиск по номеру, SKU или названию" />
-    <input class="fm-input w-140" type="date" />
-    <input class="fm-input w-140" type="date" />
-    <button class="btn btn-outline" type="button">Сброс</button>
-    <button class="btn btn-secondary" type="button">Экспорт</button>
-    <button class="btn btn-primary" type="button" (click)="openDialog()">+ Новая поставка</button>
-  </section>
-
-  <div class="card supplies__table-card">
-    <div class="card__content supplies__table-wrapper">
-      <ng-container *ngIf="rows$ | async as rows; else loading">
-        <table class="supplies-table" *ngIf="rows.length > 0; else empty">
-          <thead>
-            <tr>
-              <th class="supplies-table__checkbox">
-                <input type="checkbox" aria-label="Выбрать все" />
-              </th>
-              <th>№ док.</th>
-              <th>Дата прихода</th>
-              <th>Склад</th>
-              <th>Ответственный</th>
-              <th>SKU</th>
-              <th>Название</th>
-              <th class="supplies-table__numeric">Кол-во</th>
-              <th class="supplies-table__center">Срок годности</th>
-              <th class="supplies-table__truncate">Поставщик</th>
-              <th>Статус</th>
-              <th class="supplies-table__actions" aria-label="Действия"></th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr *ngFor="let row of rows; trackBy: trackBySupplyId">
-              <td class="supplies-table__checkbox">
-                <input type="checkbox" [attr.aria-label]="'Выбрать поставку ' + row.docNo" />
-              </td>
-              <td class="supplies-table__mono">{{ row.docNo }}</td>
-              <td>{{ row.arrivalDate | date: 'dd.MM.yyyy' }}</td>
-              <td>{{ row.warehouse }}</td>
-              <td>{{ row.responsible || '—' }}</td>
-              <td class="supplies-table__mono">{{ row.sku }}</td>
-              <td>{{ row.name }}</td>
-              <td class="supplies-table__numeric">{{ row.qty | number: '1.0-2' }} {{ row.unit }}</td>
-              <td class="supplies-table__center">{{ row.expiryDate | date: 'dd.MM.yyyy' }}</td>
-              <td class="supplies-table__truncate" [title]="row.supplier || '—'">{{ row.supplier || '—' }}</td>
-              <td>
-                <span [class]="getStatusClass(row.status)">{{ getStatusLabel(row.status) }}</span>
-              </td>
-              <td class="supplies-table__actions">⋯</td>
-            </tr>
-          </tbody>
-        </table>
-        <ng-template #empty>
-          <div class="supplies__empty">Поставки пока не добавлены</div>
-        </ng-template>
-      </ng-container>
-      <ng-template #loading>
-        <div class="supplies__empty">Загрузка...</div>
-      </ng-template>
-    </div>
+<header class="fm-topbar">
+  <div>
+    <h1 class="fm-topbar__title">Поставки</h1>
   </div>
+  <div class="fm-topbar__actions">
+    <button class="btn btn-primary" type="button" (click)="openDialog()">+ Новая поставка</button>
+  </div>
+</header>
+
+<section class="kpis">
+  <article class="kpis__item">
+    <span class="kpis__label">Активные поставки</span>
+    <span class="kpis__value">{{ supplyKpis().ok }}</span>
+  </article>
+  <article class="kpis__item">
+    <span class="kpis__label">Скоро срок</span>
+    <span class="kpis__value">{{ supplyKpis().warning }}</span>
+  </article>
+  <article class="kpis__item">
+    <span class="kpis__label">Просрочено</span>
+    <span class="kpis__value">{{ supplyKpis().expired }}</span>
+  </article>
+  <article class="kpis__item">
+    <span class="kpis__label">Всего поставок</span>
+    <span class="kpis__value">{{ supplyKpis().total }}</span>
+  </article>
 </section>
+
+<section class="filters">
+  <input class="fm-input w-280" placeholder="Поиск по номеру, SKU или названию" />
+  <input class="fm-input w-140" type="date" />
+  <input class="fm-input w-140" type="date" />
+  <button class="btn btn-outline" type="button">Сброс</button>
+  <button class="btn btn-secondary" type="button">Экспорт</button>
+</section>
+
+<ng-container *ngIf="rowsReady(); else loading">
+  <table class="fm-table supplies-table" *ngIf="rows().length > 0; else empty">
+    <thead>
+      <tr>
+        <th class="fm-table__checkbox">
+          <input type="checkbox" aria-label="Выбрать все" />
+        </th>
+        <th>№ док.</th>
+        <th>Дата прихода</th>
+        <th>Склад</th>
+        <th>Ответственный</th>
+        <th>SKU</th>
+        <th>Название</th>
+        <th class="fm-table__numeric">Кол-во</th>
+        <th class="fm-table__center">Срок годности</th>
+        <th class="fm-table__truncate">Поставщик</th>
+        <th>Статус</th>
+        <th class="fm-table__actions" aria-label="Действия"></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr *ngFor="let row of rows(); trackBy: trackBySupplyId">
+        <td class="fm-table__checkbox">
+          <input type="checkbox" [attr.aria-label]="'Выбрать поставку ' + row.docNo" />
+        </td>
+        <td class="fm-table__mono">{{ row.docNo }}</td>
+        <td>{{ row.arrivalDate | date: 'dd.MM.yyyy' }}</td>
+        <td>{{ row.warehouse }}</td>
+        <td>{{ row.responsible || '—' }}</td>
+        <td class="fm-table__mono">{{ row.sku }}</td>
+        <td>{{ row.name }}</td>
+        <td class="fm-table__numeric">{{ row.qty | number: '1.0-2' }} {{ row.unit }}</td>
+        <td class="fm-table__center">{{ row.expiryDate | date: 'dd.MM.yyyy' }}</td>
+        <td class="fm-table__truncate" [title]="row.supplier || '—'">{{ row.supplier || '—' }}</td>
+        <td>
+          <span [class]="getStatusClass(row.status)">{{ getStatusLabel(row.status) }}</span>
+        </td>
+        <td class="fm-table__actions">⋯</td>
+      </tr>
+    </tbody>
+  </table>
+</ng-container>
+
+<ng-template #empty>
+  <div class="supplies__empty">Поставки пока не добавлены</div>
+</ng-template>
+
+<ng-template #loading>
+  <div class="supplies__empty">Загрузка...</div>
+</ng-template>
 
 <section class="supplies-dialog" *ngIf="dialogOpen()">
   <div class="supplies-dialog__backdrop" (click)="closeDialog()"></div>

--- a/feedme.client/src/app/warehouse/supplies/supplies.component.scss
+++ b/feedme.client/src/app/warehouse/supplies/supplies.component.scss
@@ -1,26 +1,55 @@
 :host {
-  display: block;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
   color: #111827;
   --brand: #ff6a00;
 }
 
-.supplies {
+.fm-topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.fm-topbar__title {
+  margin: 0;
+  font-size: 1.75rem;
+  font-weight: 700;
+}
+
+.fm-topbar__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.kpis {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.75rem;
+}
+
+.kpis__item {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
-}
-
-.card {
-  border-radius: 0;
-  box-shadow: none;
-  border: 1px solid #e5e7eb;
+  gap: 0.25rem;
+  padding: 0.75rem 1rem;
   background: #ffffff;
+  border: 1px solid #e5e7eb;
 }
 
-.card__content {
-  padding: 1.5rem;
+.kpis__label {
+  font-size: 0.8125rem;
+  color: #6b7280;
 }
 
+.kpis__value {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #111827;
+}
 
 .filters {
   display: flex;
@@ -41,15 +70,12 @@
 }
 
 
-.supplies__input:focus {
-  outline: none;
-  border-color: #fa4b00;
-  box-shadow: inset 0 0 0 1px var(--ring-shadow, rgba(37, 99, 235, 0.35));
-
-}
-
 .w-140 {
   width: 140px;
+}
+
+.w-280 {
+  width: 280px;
 }
 
 .btn {
@@ -87,74 +113,68 @@
   filter: brightness(0.96);
 }
 
-.supplies__table-card {
-  border-radius: 0;
-}
-
-.supplies__table-wrapper {
-  padding: 0;
-}
-
-.supplies-table {
+.fm-table {
   width: 100%;
   border-collapse: collapse;
   border-spacing: 0;
   font-size: 0.9375rem;
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
 }
 
-.supplies-table thead {
+.fm-table thead {
   background: #f9fafb;
   border-bottom: 1px solid #e5e7eb;
 }
 
-.supplies-table th,
-.supplies-table td {
+.fm-table th,
+.fm-table td {
   padding: 0.75rem 1rem;
   border-bottom: 1px solid #e5e7eb;
   text-align: left;
   vertical-align: middle;
 }
 
-.supplies-table__checkbox {
+.fm-table__checkbox {
   width: 48px;
   text-align: center;
 }
 
-.supplies-table__mono {
+.fm-table__mono {
   font-family: 'Roboto Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
     monospace;
   white-space: nowrap;
 }
 
-.supplies-table__numeric {
+.fm-table__numeric {
   text-align: right;
   white-space: nowrap;
 }
 
-.supplies-table__center {
+.fm-table__center {
   text-align: center;
   white-space: nowrap;
 }
 
-.supplies-table__truncate {
+.fm-table__truncate {
   max-width: 200px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-.supplies-table__actions {
+.fm-table__actions {
   width: 40px;
   text-align: center;
   font-size: 1.25rem;
   color: #9ca3af;
 }
 
-.supplies-table tbody tr:nth-child(even) {
+.fm-table tbody tr:nth-child(even) {
   background: #f9fafb;
 }
 
-.supplies-table tbody tr:hover {
+.fm-table tbody tr:hover {
   background: #f3f4f6;
 }
 

--- a/feedme.client/src/app/warehouse/supplies/supplies.component.ts
+++ b/feedme.client/src/app/warehouse/supplies/supplies.component.ts
@@ -3,7 +3,7 @@ import { CommonModule } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
 import { NonNullableFormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { startWith, take } from 'rxjs';
+import { startWith, take, tap } from 'rxjs';
 
 import { SupplyProduct, SupplyRow, SupplyStatus } from '../shared/models';
 import { computeExpiryStatus } from '../shared/status.util';
@@ -35,7 +35,36 @@ export class SuppliesComponent {
   private readonly suppliesService = inject(SuppliesService);
 
 
-  readonly rows$ = this.suppliesService.getAll();
+  readonly rowsReady = signal(false);
+
+  readonly rows = toSignal(
+    this.suppliesService.getAll().pipe(tap(() => this.rowsReady.set(true))),
+    { initialValue: [] as SupplyRow[] },
+  );
+
+  readonly supplyKpis = computed(() => {
+    const rows = this.rows();
+
+    let warning = 0;
+    let expired = 0;
+
+    for (const row of rows) {
+      if (row.status === 'warning') {
+        warning += 1;
+      } else if (row.status === 'expired') {
+        expired += 1;
+      }
+    }
+
+    const ok = rows.length - warning - expired;
+
+    return {
+      total: rows.length,
+      ok: ok < 0 ? 0 : ok,
+      warning,
+      expired,
+    } as const;
+  });
   readonly products$ = this.suppliesService.getProducts();
 
   readonly dialogOpen = signal(false);


### PR DESCRIPTION
## Summary
- reorder the supplies page markup to render the topbar, KPIs, filters, and table without extra padding wrappers
- surface KPI counters and move the primary action into the topbar for the new layout
- refresh local styles to support the fm-table structure and tighter spacing

## Testing
- npm run lint *(fails: lint target is not configured yet)*

------
https://chatgpt.com/codex/tasks/task_e_68da9527817883239f99bd5cfe3cee00