### PR TITLE
Add quick period controls to supplies filters

### DIFF
--- a/feedme.client/src/app/warehouse/supplies/supplies.component.html
+++ b/feedme.client/src/app/warehouse/supplies/supplies.component.html
@@ -7,9 +7,34 @@
 
   <section class="filters">
     <input class="fm-input w-280" placeholder="Поиск по номеру, SKU или названию" />
-    <input class="fm-input w-140" type="date" />
-    <input class="fm-input w-140" type="date" />
-    <button class="btn btn-outline" type="button">Сброс</button>
+    <input
+      class="fm-input w-140"
+      type="date"
+      [ngModel]="dateFrom"
+      (ngModelChange)="onDateFromChange($event)"
+      ngModelOptions="{ standalone: true }"
+    />
+    <input
+      class="fm-input w-140"
+      type="date"
+      [ngModel]="dateTo"
+      (ngModelChange)="onDateToChange($event)"
+      ngModelOptions="{ standalone: true }"
+    />
+
+    <div class="period" aria-label="Быстрый выбор периода">
+      <button
+        *ngFor="let option of quickPeriods"
+        type="button"
+        class="chip"
+        [class.chip--active]="period === option.id"
+        (click)="setPeriod(option.id)"
+      >
+        {{ option.label }}
+      </button>
+    </div>
+
+    <button class="btn btn-outline" type="button" (click)="resetFilters()">Сброс</button>
     <button class="btn btn-secondary" type="button">Экспорт</button>
     <button class="btn btn-primary" type="button" (click)="openDialog()">+ Новая поставка</button>
   </section>

--- a/feedme.client/src/app/warehouse/supplies/supplies.component.scss
+++ b/feedme.client/src/app/warehouse/supplies/supplies.component.scss
@@ -50,6 +50,29 @@
   border: 1px solid #e5e7eb;
 }
 
+.period {
+  display: flex;
+  gap: 0.25rem;
+  margin-left: 0.25rem;
+}
+
+.chip {
+  height: 28px;
+  padding: 0 0.5rem;
+  border: 1px solid #d1d5db;
+  background: #ffffff;
+  color: #374151;
+  border-radius: 0;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.chip--active {
+  border-color: var(--brand);
+  color: var(--brand);
+  background: rgba(255, 106, 0, 0.08);
+}
+
 .fm-input {
   height: 36px;
   padding: 0 0.5rem;


### PR DESCRIPTION
## Summary
- add quick period buttons that prefill the supplies date filters for today, 7 days, or 30 days
- highlight the active quick period and clear it when dates are edited manually or reset
- style the quick period chips to keep the filter panel compact

## Testing
- npm run lint *(fails: Cannot find "lint" target for the specified project)*

------
https://chatgpt.com/codex/tasks/task_e_68da96a66d5c8323bc1c76ebb0202906