### PR TITLE
Add CSV import drag-and-drop dialog to supplies page

### DIFF
--- a/feedme.client/src/app/warehouse/supplies/supplies.component.html
+++ b/feedme.client/src/app/warehouse/supplies/supplies.component.html
@@ -11,6 +11,7 @@
     <input class="fm-input w-140" type="date" />
     <button class="btn btn-outline" type="button">Сброс</button>
     <button class="btn btn-secondary" type="button">Экспорт</button>
+    <button class="btn btn-secondary" type="button" (click)="openImportDialog()">Импорт</button>
     <button class="btn btn-primary" type="button" (click)="openDialog()">+ Новая поставка</button>
   </section>
 
@@ -67,6 +68,38 @@
     </div>
   </div>
 </section>
+
+<ng-container *ngIf="importDialogOpen()">
+  <div class="fm-dialog-backdrop" (click)="closeImportDialog()"></div>
+  <div class="fm-dialog square" role="dialog" aria-modal="true" aria-labelledby="supplies-import-title">
+    <header class="fm-dialog__header">
+      <div class="fm-dialog__title" id="supplies-import-title">Импорт CSV</div>
+      <button class="fm-dialog__close" type="button" (click)="closeImportDialog()" aria-label="Закрыть">×</button>
+    </header>
+
+    <section
+      class="fm-dropzone"
+      (dragover)="onDragOver($event)"
+      (drop)="onDrop($event)"
+    >
+      <div class="fm-dropzone__icon">⬇</div>
+      <div class="fm-dropzone__title">Перетащите файл CSV сюда</div>
+      <div class="fm-dropzone__sub">
+        или
+        <label class="link">
+          <input type="file" accept=".csv,text/csv" (change)="onFile($event)" hidden />
+          выберите с диска
+        </label>
+      </div>
+      <div class="fm-dropzone__file" *ngIf="selectedFileName() as fileName">Выбрано: {{ fileName }}</div>
+    </section>
+
+    <footer class="fm-dialog__footer">
+      <button class="btn btn-outline" type="button" (click)="closeImportDialog()">Отмена</button>
+      <button class="btn btn-primary" type="button" (click)="mockImport()">Импортировать</button>
+    </footer>
+  </div>
+</ng-container>
 
 <section class="supplies-dialog" *ngIf="dialogOpen()">
   <div class="supplies-dialog__backdrop" (click)="closeDialog()"></div>

--- a/feedme.client/src/app/warehouse/supplies/supplies.component.scss
+++ b/feedme.client/src/app/warehouse/supplies/supplies.component.scss
@@ -355,6 +355,87 @@
   gap: 0.75rem;
 }
 
+.fm-dialog-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.25);
+  z-index: 40;
+}
+
+.fm-dialog {
+  position: fixed;
+  inset: auto 0 0 0;
+  margin: auto;
+  top: 10%;
+  width: min(560px, 92vw);
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  z-index: 41;
+}
+
+.fm-dialog__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.fm-dialog__title {
+  font-weight: 700;
+}
+
+.fm-dialog__close {
+  border: 0;
+  background: transparent;
+  font-size: 1.25rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.fm-dropzone {
+  margin: 1rem;
+  padding: 1.5rem;
+  border: 1px dashed #d1d5db;
+  text-align: center;
+  background: #fafafa;
+}
+
+.fm-dropzone__icon {
+  font-size: 1.75rem;
+  margin-bottom: 0.25rem;
+}
+
+.fm-dropzone__title {
+  font-weight: 700;
+  margin-bottom: 0.25rem;
+}
+
+.fm-dropzone__sub {
+  color: #6b7280;
+  font-size: 0.8125rem;
+}
+
+.fm-dropzone__file {
+  margin-top: 0.75rem;
+  font-size: 0.875rem;
+  color: #374151;
+}
+
+.link {
+  color: var(--brand);
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.fm-dialog__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  border-top: 1px solid #e5e7eb;
+}
+
 @media (max-width: 900px) {
   .supplies__filters {
     flex-direction: column;

--- a/feedme.client/src/app/warehouse/supplies/supplies.component.ts
+++ b/feedme.client/src/app/warehouse/supplies/supplies.component.ts
@@ -39,6 +39,8 @@ export class SuppliesComponent {
   readonly products$ = this.suppliesService.getProducts();
 
   readonly dialogOpen = signal(false);
+  readonly importDialogOpen = signal(false);
+  readonly selectedFileName = signal<string | null>(null);
 
   private readonly statusLabels: Record<SupplyStatus, string> = {
     ok: 'Ок',
@@ -85,6 +87,15 @@ export class SuppliesComponent {
   closeDialog(): void {
     this.dialogOpen.set(false);
     this.resetForm();
+  }
+
+  openImportDialog(): void {
+    this.importDialogOpen.set(true);
+  }
+
+  closeImportDialog(): void {
+    this.importDialogOpen.set(false);
+    this.selectedFileName.set(null);
   }
 
 
@@ -159,6 +170,36 @@ export class SuppliesComponent {
 
   getStatusClass(status: SupplyStatus): string {
     return this.statusClasses[status];
+  }
+
+  onDragOver(event: DragEvent): void {
+    event.preventDefault();
+  }
+
+  onDrop(event: DragEvent): void {
+    event.preventDefault();
+    const file = event.dataTransfer?.files?.item(0);
+
+    if (file) {
+      this.selectedFileName.set(file.name);
+    }
+  }
+
+  onFile(event: Event): void {
+    const input = event.target as HTMLInputElement | null;
+    const file = input?.files?.item(0);
+
+    if (file) {
+      this.selectedFileName.set(file.name);
+    }
+
+    if (input) {
+      input.value = '';
+    }
+  }
+
+  mockImport(): void {
+    this.closeImportDialog();
   }
 
   private resetForm(): void {


### PR DESCRIPTION
## Summary
- add an Import action to the supplies filter bar and render a CSV import dialog with drag-and-drop UI
- manage dialog visibility and selected file state with Angular signals and handlers for drop and file input events
- style the dialog and dropzone to match the Feedme visual language

## Testing
- npm run lint *(fails: workspace does not define a lint target yet)*

------
https://chatgpt.com/codex/tasks/task_e_68da969e47088323b70ea697228d22d9