### PR TITLE
Refine stock table layout

### DIFF
--- a/feedme.client/src/app/components/StockTableComponent/stock-table.component.css
+++ b/feedme.client/src/app/components/StockTableComponent/stock-table.component.css
@@ -1,3 +1,10 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
 .table-header {
   display: flex;
   align-items: center;
@@ -8,7 +15,9 @@
 }
 
 .table-container {
+  flex: 1 1 auto;
   overflow-x: auto;
+  overflow-y: auto;
   border-radius: 12px;
   border: 1px solid #e2e8f0;
   background-color: #ffffff;

--- a/feedme.client/src/app/components/StockTableComponent/stock-table.component.html
+++ b/feedme.client/src/app/components/StockTableComponent/stock-table.component.html
@@ -1,8 +1,7 @@
 <div class="table-header">
   <app-table-controls [searchQuery]="searchQuery"
-                      [rowsPerPage]="rowsPerPage"
-                      (searchQueryChange)="onSearchChange($event)"
-                      (rowsPerPageChange)="onRowsChange($event)">
+                      [showRowsSelector]="false"
+                      (searchQueryChange)="onSearchChange($event)">
   </app-table-controls>
 </div>
 
@@ -38,7 +37,7 @@
       </tr>
     </thead>
     <tbody>
-      <ng-container *ngFor="let item of paginatedData">
+      <ng-container *ngFor="let item of visibleData">
         <ng-container *ngIf="getExpiryInfo(item) as expiry">
           <tr
             class="stock-table__row h-11 align-middle hover:bg-muted/40 odd:bg-muted/10"
@@ -95,23 +94,17 @@
           </tr>
         </ng-container>
       </ng-container>
-      <tr *ngIf="paginatedData.length === 0">
+      <tr *ngIf="visibleData.length === 0">
         <td [attr.colspan]="columns.length + 1" class="no-data">Нет данных</td>
       </tr>
     </tbody>
   </table>
 </div>
 
-<!-- TODO: toggle by data -->
 <app-empty
+  *ngIf="visibleData.length === 0 && !searchQuery"
   class="mt-6 block"
   title="Нет остатков"
   subtitle="Добавьте товары или обновите их остатки, чтобы увидеть список."
   ctaText="+ Новый товар"
 ></app-empty>
-
-<div class="pagination-controls">
-  <button (click)="prevPage()" [disabled]="currentPage === 1">Назад</button>
-  <span>Страница {{ currentPage }} из {{ totalPages }}</span>
-  <button (click)="nextPage()" [disabled]="currentPage === totalPages">Далее</button>
-</div>

--- a/feedme.client/src/app/components/content/content.component.css
+++ b/feedme.client/src/app/components/content/content.component.css
@@ -1,7 +1,17 @@
-.content {
-  flex-grow: 1;
+:host {
   display: flex;
   flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.content {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
 
   padding: 0;
   background-color: #ffffff;

--- a/feedme.client/src/app/components/content/content.component.html
+++ b/feedme.client/src/app/components/content/content.component.html
@@ -1,52 +1,54 @@
-<app-warehouse-tabs [selectedTab]="selectedTab"
-                    (selectedTabChange)="setSelectedTab($event)">
-</app-warehouse-tabs>
+<div class="content">
+  <app-warehouse-tabs [selectedTab]="selectedTab"
+                      (selectedTabChange)="setSelectedTab($event)">
+  </app-warehouse-tabs>
 
-<app-supply-controls [(selectedSupply)]="selectedSupply"
-                     (goToCatalog)="goToCatalog()"
-                     (addSupply)="openNewProductPopup()">
-</app-supply-controls>
+  <app-supply-controls [(selectedSupply)]="selectedSupply"
+                       (goToCatalog)="goToCatalog()"
+                       (addSupply)="openNewProductPopup()">
+  </app-supply-controls>
 
-<p class="error-message" *ngIf="errorMessage">{{ errorMessage }}</p>
+  <p class="error-message" *ngIf="errorMessage">{{ errorMessage }}</p>
 
-<app-new-product *ngIf="showPopup && selectedSupply !== 'catalog'"
-                [warehouse]="selectedTab"
-                (onSubmit)="onNewProductSubmit($event)"
-                (onCancel)="showPopup = false">
-</app-new-product>
+  <app-new-product *ngIf="showPopup && selectedSupply !== 'catalog'"
+                  [warehouse]="selectedTab"
+                  (onSubmit)="onNewProductSubmit($event)"
+                  (onCancel)="showPopup = false">
+  </app-new-product>
 
-<app-catalog-new-product-popup *ngIf="showPopup && selectedSupply === 'catalog'"
-                               (save)="onNewProductSubmit($event)"
-                               (cancel)="closeNewProductPopup()"
+  <app-catalog-new-product-popup *ngIf="showPopup && selectedSupply === 'catalog'"
+                                 (save)="onNewProductSubmit($event)"
+                                 (cancel)="closeNewProductPopup()"
 
-                               [errorMessage]="errorMessage">
+                                 [errorMessage]="errorMessage">
 
-</app-catalog-new-product-popup>
+  </app-catalog-new-product-popup>
 
-<app-info-cards-wrapper *ngIf="selectedSupply !== 'catalog' && selectedItem"
-                        [item]="selectedItem"
-                        (onClose)="closeInfoCards()">
-</app-info-cards-wrapper>
+  <app-info-cards-wrapper *ngIf="selectedSupply !== 'catalog' && selectedItem"
+                          [item]="selectedItem"
+                          (onClose)="closeInfoCards()">
+  </app-info-cards-wrapper>
 
-<!-- Таблица Поставок -->
-<app-supply-table *ngIf="selectedSupply === 'supplies'"
-                  [data]="supplyData"
-                  (onAddSupply)="openNewProductPopup()"
-                  (onSettingsClick)="handleSettingsClick($event)">
-</app-supply-table>
+  <!-- Таблица Поставок -->
+  <app-supply-table *ngIf="selectedSupply === 'supplies'"
+                    [data]="supplyData"
+                    (onAddSupply)="openNewProductPopup()"
+                    (onSettingsClick)="handleSettingsClick($event)">
+  </app-supply-table>
 
-<!-- Таблица Остатков -->
-<app-stock-table *ngIf="selectedSupply === 'stock'"
-                 [data]="stockData"
-                 (onSettingsClick)="handleSettingsClick($event)">
-</app-stock-table>
+  <!-- Таблица Остатков -->
+  <app-stock-table *ngIf="selectedSupply === 'stock'"
+                   [data]="stockData"
+                   (onSettingsClick)="handleSettingsClick($event)">
+  </app-stock-table>
 
-<!-- Таблица Каталога -->
-<app-catalog-table *ngIf="selectedSupply === 'catalog'"
-                   [data]="catalogData"
-                   (onAddSupply)="openNewProductPopup()"
+  <!-- Таблица Каталога -->
+  <app-catalog-table *ngIf="selectedSupply === 'catalog'"
+                     [data]="catalogData"
+                     (onAddSupply)="openNewProductPopup()"
 
-                   (deleteRow)="onCatalogRemove($event)">
+                     (deleteRow)="onCatalogRemove($event)">
 
 
-</app-catalog-table>
+  </app-catalog-table>
+</div>

--- a/feedme.client/src/app/components/table-controls/table-controls.component.html
+++ b/feedme.client/src/app/components/table-controls/table-controls.component.html
@@ -1,5 +1,5 @@
 <div class="table-controls">
-  <div class="rows-selector-container">
+  <div class="rows-selector-container" *ngIf="showRowsSelector">
     <span class="rows-label">Строк:</span>
     <select [value]="rowsPerPage"
             (change)="onRowsPerPageChange($event.target.value)"

--- a/feedme.client/src/app/components/table-controls/table-controls.component.ts
+++ b/feedme.client/src/app/components/table-controls/table-controls.component.ts
@@ -11,6 +11,7 @@ import { CommonModule } from '@angular/common';
 export class TableControlsComponent {
   @Input() searchQuery: string = '';
   @Input() rowsPerPage: number = 10;
+  @Input() showRowsSelector = true;
 
   @Output() searchQueryChange = new EventEmitter<string>();
   @Output() rowsPerPageChange = new EventEmitter<number>();


### PR DESCRIPTION
## Summary
- remove pagination from the stock table and hide the rows selector so the grid renders the entire filtered dataset
- adjust the stock table layout to flex within the available viewport space and only show the empty state when no records remain
- wrap the main content area with a flex container to eliminate the extra page scrollbar

## Testing
- npm run lint *(fails: Angular project does not define a lint target and prompts to install ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_68daafd47f788323a3c0b358f25a78a4