### PR TITLE
feat: refresh warehouse overview layout

### DIFF
--- a/feedme.client/src/app/warehouse/warehouse-page.component.css
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.css
@@ -81,115 +81,158 @@
   overflow-y: auto;
 }
 
-.warehouse-page__top-bar {
+.warehouse-page__overview {
   position: sticky;
   top: 0;
   z-index: 15;
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
-  flex-wrap: wrap;
-  padding: 16px 32px;
-  background-color: rgba(248, 250, 252, 0.95);
+  flex-direction: column;
+  gap: 24px;
+  padding: 28px 32px 32px;
+  background: rgba(248, 250, 252, 0.95);
   border-bottom: 1px solid #e2e8f0;
   backdrop-filter: blur(12px);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.04);
 }
 
-.warehouse-page__breadcrumbs {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 0.875rem;
-  font-weight: 500;
+.warehouse-page__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.warehouse-page__header-context {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.warehouse-page__title {
+  margin: 0;
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.warehouse-page__subtitle {
+  margin: 0;
+  font-size: 0.9375rem;
   color: #64748b;
 }
 
-.warehouse-page__breadcrumb {
-  color: inherit;
+.warehouse-page__warehouse-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  color: #64748b;
 }
 
-.warehouse-page__breadcrumb--current {
-  color: #111827;
+.warehouse-page__warehouse-picker-label {
+  letter-spacing: 0.04em;
   font-weight: 600;
 }
 
+.warehouse-page__warehouse-picker-control {
+  position: relative;
+}
 
-.warehouse-page__actions {
+.warehouse-page__warehouse-select {
+  appearance: none;
+  width: min(260px, 100%);
+  padding: 12px 42px 12px 16px;
+  border-radius: 12px;
+  border: 1px solid #d0d5dd;
+  background-color: #ffffff;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: #0f172a;
+  line-height: 1.4;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' stroke='%2364748b' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3e%3cpath d='M4 6l4 4 4-4'/%3e%3c/svg%3e");
+  background-repeat: no-repeat;
+  background-position: right 14px center;
+  background-size: 16px;
+  cursor: pointer;
+}
+
+.warehouse-page__warehouse-select:focus {
+  outline: none;
+  border-color: rgba(59, 130, 246, 0.6);
+  box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.15);
+}
+
+.warehouse-page__snapshot {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  gap: 16px;
+}
+
+.warehouse-page__metric-card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 20px 24px;
+  border-radius: 16px;
+  border: 1px solid #e2e8f0;
+  background: #ffffff;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.06);
+  min-height: 120px;
+}
+
+.warehouse-page__overview-footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.warehouse-page__tabs {
+  display: inline-flex;
+  gap: 8px;
+  padding: 6px;
+  border-radius: 9999px;
+  background: rgba(148, 163, 184, 0.16);
+}
+
+.warehouse-page__tab {
+  border: 0;
+  border-radius: 9999px;
+  padding: 10px 22px;
+  background: transparent;
+  color: #475569;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.warehouse-page__tab:hover {
+  color: #0f172a;
+}
+
+.warehouse-page__tab:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.25);
+}
+
+.warehouse-page__tab--active {
+  background: #ffffff;
+  color: #0f172a;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.12);
+}
+
+.warehouse-page__header-actions {
   display: flex;
   align-items: center;
   gap: 12px;
-  flex-wrap: wrap;
-}
-
-.warehouse-page__actions-buttons {
-  display: inline-flex;
+  margin-left: auto;
   flex-wrap: wrap;
   justify-content: flex-end;
-  gap: 12px;
-  margin-left: auto;
-}
-
-.density-switch {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px;
-  border-radius: 12px;
-  border: 1px solid #e2e8f0;
-  background: color-mix(in srgb, #f1f5f9 65%, transparent);
-}
-
-.density-switch__btn {
-  width: 40px;
-  height: 40px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border: 1px solid transparent;
-  border-radius: 10px;
-  background: transparent;
-  color: #475569;
-  cursor: pointer;
-  transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease,
-    color 0.2s ease;
-}
-
-.density-switch__btn:hover {
-  background: rgba(148, 163, 184, 0.16);
-  color: #1f2937;
-}
-
-.density-switch__btn:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.35);
-}
-
-.density-switch__btn--active {
-  border-color: rgba(59, 130, 246, 0.4);
-  background: #ffffff;
-  color: #2563eb;
-  box-shadow: inset 0 0 0 1px rgba(59, 130, 246, 0.25);
-}
-
-.density-switch__icon {
-  --line-thickness: 2px;
-  --line-gap: 3px;
-  width: 18px;
-  height: 18px;
-  border-radius: 6px;
-  background-image: repeating-linear-gradient(
-    to bottom,
-    currentColor 0,
-    currentColor var(--line-thickness),
-    transparent var(--line-thickness),
-    transparent calc(var(--line-thickness) + var(--line-gap))
-  );
-}
-
-.density-switch__icon--comfortable {
-  --line-thickness: 2px;
-  --line-gap: 6px;
 }
 
 .sr-only {
@@ -205,35 +248,6 @@
 
 }
 
-.warehouse-page__body {
-  padding: 32px;
-  display: flex;
-  flex-direction: column;
-  gap: 32px;
-}
-
-.warehouse-page__snapshot {
-  display: grid;
-  gap: 16px;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-}
-
-.square {
-  border-radius: 0;
-}
-
-.warehouse-page__metric-card {
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 24px;
-  border: 1px solid var(--border, #e5e7eb);
-  background-color: #ffffff;
-  aspect-ratio: 1 / 1;
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06);
-}
-
 .warehouse-page__metric-label {
   font-size: 0.875rem;
   line-height: 1.4;
@@ -242,10 +256,10 @@
 }
 
 .warehouse-page__metric-value {
-  font-size: 1.5rem;
+  font-size: 1.75rem;
   line-height: 1.25;
-  font-weight: 600;
-  color: var(--brand, #fa4b00);
+  font-weight: 700;
+  color: #0f172a;
 }
 
 .warehouse-page__metric-value--currency {
@@ -270,91 +284,11 @@
   color: #b91c1c;
 }
 
-@media (max-width: 1024px) {
-  .warehouse-page__snapshot {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
-.warehouse-page__tabs {
-  width: 100%;
-}
-
-
-.tabs-underline {
-  display: flex;
-  gap: 1.25rem;
-  align-items: center;
-  border-bottom: 1px solid #e5e7eb;
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
-}
-
-.tabs-underline__btn {
-  padding: 0.5rem 0;
-  background: transparent;
-  border: 0;
-  border-radius: 0;
-  color: #6b7280;
-  font-weight: 600;
-  font-size: 0.9375rem;
-  white-space: nowrap;
-  cursor: pointer;
-  transition: color 0.2s ease;
-}
-
-.tabs-underline__btn:hover {
-  color: #111827;
-}
-
-.tabs-underline__btn:focus-visible {
-  outline: none;
-  color: #111827;
-}
-
-.tabs-underline__btn.is-active,
-.tabs-underline__btn.active {
-  color: #111827;
-  position: relative;
-}
-
-.tabs-underline__btn.is-active::after,
-.tabs-underline__btn.active::after {
-  content: "";
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: -1px;
-  height: 2px;
-  background: var(--brand);
-}
-
-.warehouse-page__tab--active {
-  font-weight: 600;
-}
-
-/* Тёмная тема */
-@media (prefers-color-scheme: dark) {
-  .tabs-underline {
-    border-bottom-color: rgba(255, 255, 255, 0.12);
-  }
-
-  .tabs-underline__btn {
-    color: rgba(255, 255, 255, 0.65);
-  }
-
-  .tabs-underline__btn:hover,
-  .tabs-underline__btn:focus-visible,
-  .tabs-underline__btn.is-active,
-  .tabs-underline__btn.active {
-    color: #ffffff;
-  }
-}
-
 .warehouse-page__tab-panel {
   display: flex;
   flex-direction: column;
   gap: 24px;
+  padding: 32px;
 }
 
 .card {
@@ -751,7 +685,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  padding: 48px 0;
+  padding: 48px 32px;
 }
 
 .warehouse-page__drawer {

--- a/feedme.client/src/app/warehouse/warehouse-page.component.html
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.html
@@ -22,63 +22,53 @@
   </aside>
 
   <main class="warehouse-page__content">
-
-    <header class="warehouse-page__top-bar">
-      <div class="warehouse-page__breadcrumbs">
-        Главный склад / <span class="warehouse-page__breadcrumb-current">Поставки</span>
-      </div>
-      <div class="warehouse-page__actions">
-        <div class="density-switch" role="group" aria-label="Плотность строк">
-          <button
-            type="button"
-            class="density-switch__btn density-switch__btn--active"
-            aria-pressed="true"
-          >
-            <span aria-hidden="true" class="density-switch__icon density-switch__icon--compact"></span>
-            <span class="sr-only">Compact</span>
-          </button>
-          <button type="button" class="density-switch__btn" aria-pressed="false">
-            <span
-              aria-hidden="true"
-              class="density-switch__icon density-switch__icon--comfortable"
-            ></span>
-            <span class="sr-only">Comfortable</span>
-          </button>
+    <section class="warehouse-page__overview" aria-label="Обзор склада">
+      <div class="warehouse-page__header">
+        <div class="warehouse-page__header-context">
+          <h1 class="warehouse-page__title">Поставки</h1>
+          <p class="warehouse-page__subtitle">Контролируйте движение товаров и запасы</p>
         </div>
-        <div class="warehouse-page__actions-buttons">
-          <button type="button" class="btn btn-outline" (click)="openCreateDialog()">
-            + Новая поставка
-          </button>
-          <button type="button" class="btn btn-ghost">Ещё</button>
-        </div>
+        <label class="warehouse-page__warehouse-picker">
+          <span class="warehouse-page__warehouse-picker-label">Склад</span>
+          <div class="warehouse-page__warehouse-picker-control">
+            <select
+              #activeWarehouse
+              class="warehouse-page__warehouse-select"
+              [value]="selectedWarehouse()"
+              (change)="selectWarehouse(activeWarehouse.value)"
+              aria-label="Выбор активного склада"
+            >
+              <option *ngFor="let warehouseName of warehouses()" [value]="warehouseName">
+                {{ warehouseName }}
+              </option>
+            </select>
+          </div>
+        </label>
       </div>
 
-    </header>
-
-    <section class="warehouse-page__body">
       <section
-        *ngIf="metrics() as snapshot"
+        *ngIf="overviewMetrics() as snapshot"
         class="warehouse-page__snapshot"
         aria-label="Ключевые показатели склада"
       >
-        <article class="square warehouse-page__metric-card" aria-live="polite">
+        <article class="warehouse-page__metric-card" aria-live="polite">
           <p class="warehouse-page__metric-label">Поставок за 7 дней</p>
           <p class="warehouse-page__metric-value">{{ snapshot.suppliesLastWeek }}</p>
         </article>
 
-        <article class="square warehouse-page__metric-card" aria-live="polite">
+        <article class="warehouse-page__metric-card" aria-live="polite">
           <p class="warehouse-page__metric-label">Сумма закупок / 7 дн.</p>
           <p class="warehouse-page__metric-value warehouse-page__metric-value--currency">
             {{ formatCurrency(snapshot.purchaseAmountLastWeek) }}
           </p>
         </article>
 
-        <article class="square warehouse-page__metric-card" aria-live="polite">
+        <article class="warehouse-page__metric-card" aria-live="polite">
           <p class="warehouse-page__metric-label">Позиций на складе</p>
           <p class="warehouse-page__metric-value">{{ snapshot.positions }}</p>
         </article>
 
-        <article class="square warehouse-page__metric-card warehouse-page__metric-card--expired" aria-live="polite">
+        <article class="warehouse-page__metric-card warehouse-page__metric-card--expired" aria-live="polite">
           <p class="warehouse-page__metric-label">Просрочено</p>
           <p class="warehouse-page__metric-value">
             <span class="warehouse-page__metric-badge">{{ snapshot.expired }}</span>
@@ -86,22 +76,30 @@
         </article>
       </section>
 
-      <nav class="warehouse-page__tabs tabs-underline" role="tablist">
-        <button
-          type="button"
-          *ngFor="let entry of tabKeys"
-          class="warehouse-page__tab tabs-underline__btn"
-          [class.warehouse-page__tab--active]="activeTab() === entry"
-          [class.is-active]="activeTab() === entry"
-          (click)="selectTab(entry)"
-          role="tab"
-          [attr.aria-selected]="activeTab() === entry ? 'true' : 'false'"
-        >
-          {{ tabLabels[entry] }}
-        </button>
-      </nav>
+      <div class="warehouse-page__overview-footer">
+        <nav class="warehouse-page__tabs" role="tablist" aria-label="Разделы склада">
+          <button
+            type="button"
+            *ngFor="let entry of tabKeys"
+            class="warehouse-page__tab"
+            [class.warehouse-page__tab--active]="activeTab() === entry"
+            (click)="selectTab(entry)"
+            role="tab"
+            [attr.aria-selected]="activeTab() === entry ? 'true' : 'false'"
+          >
+            {{ tabLabels[entry] }}
+          </button>
+        </nav>
+        <div class="warehouse-page__header-actions">
+          <button type="button" class="btn btn-secondary">Экспорт</button>
+          <button type="button" class="btn btn-primary" (click)="openCreateDialog()">
+            + Новая поставка
+          </button>
+        </div>
+      </div>
+    </section>
 
-      <section *ngIf="activeTab() === 'supplies'" class="warehouse-page__tab-panel">
+    <section *ngIf="activeTab() === 'supplies'" class="warehouse-page__tab-panel">
         <div class="card warehouse-page__filters-card">
           <form
             class="warehouse-page__filters card__content p-4 flex flex-wrap items-center gap-3"
@@ -151,23 +149,6 @@
                   <option value="">Все поставщики</option>
                   <option *ngFor="let supplierName of suppliers()" [value]="supplierName">
                     {{ supplierName }}
-                  </option>
-                </select>
-              </label>
-            </div>
-            <div class="warehouse-page__filters-control warehouse-page__filters-control--select">
-              <label class="warehouse-page__filters-field">
-                <span class="warehouse-page__filters-label">Склад</span>
-                <select
-                  #warehouseSelect
-                  class="select"
-                  [value]="warehouseFilter()"
-                  (change)="updateWarehouse(warehouseSelect.value)"
-                  aria-label="Фильтр по складу"
-                >
-                  <option value="">Все склады</option>
-                  <option *ngFor="let warehouseName of warehouses()" [value]="warehouseName">
-                    {{ warehouseName }}
                   </option>
                 </select>
               </label>
@@ -382,7 +363,6 @@
       <section *ngIf="activeTab() === 'inventory'" class="warehouse-page__empty">
         <app-empty title="Инвентаризация" subtitle="Создайте обход или запустите экспресс-пересчёт"></app-empty>
       </section>
-    </section>
   </main>
 
   <aside class="warehouse-page__drawer" *ngIf="drawerOpen() && selectedRow() as row">


### PR DESCRIPTION
## Summary
- redesign the warehouse overview with a hero header, active-warehouse selector, and tabbed action bar
- compute overview metrics for the selected warehouse and reuse the selection to filter supplies
- refresh page styles to match the new layout and remove the redundant warehouse filter control

## Testing
- npm run lint *(fails: Angular workspace has no lint target configured)*

------
https://chatgpt.com/codex/tasks/task_e_68dab05736e88323a1ec3c5b17bcc833