### PR TITLE
Fix new supply dialog title and remove horizontal scroll

### DIFF
--- a/feedme.client/src/app/components/new-product/new-product.component.html
+++ b/feedme.client/src/app/components/new-product/new-product.component.html
@@ -2,7 +2,7 @@
   <div class="dialog">
     <form [formGroup]="form" class="npd">
       <div class="npd__header">
-        <h2 class="npd__title">Новый товар</h2>
+        <h2 class="npd__title">Новая поставка</h2>
         <button type="button" class="npd__close" (click)="cancel()" aria-label="Закрыть диалог">
           ×
         </button>

--- a/feedme.client/src/styles.css
+++ b/feedme.client/src/styles.css
@@ -24,6 +24,7 @@ html, body {
   padding: 0;
   height: 100%;
   font-family: Arial, sans-serif;
+  overflow-x: hidden;
 }
 
 button,


### PR DESCRIPTION
## Summary
- rename the new supply popup header to "Новая поставка"
- hide horizontal page scrolling to remove the stray horizontal scrollbar when the dialog is open

## Testing
- npm test *(fails: ChromeHeadless cannot start because libatk-1.0.so.0 is missing in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dabe48a8448323bd443b6893cad9ae