### PR TITLE
fix: remove warehouse page vertical scrollbar

### DIFF
--- a/feedme.client/src/app/warehouse/warehouse-page.component.css
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.css
@@ -10,7 +10,7 @@
 .warehouse-page {
   display: grid;
   grid-template-columns: 260px 1fr;
-  height: 100vh;
+  min-height: 100vh;
   background-color: #f8fafc;
 }
 
@@ -77,8 +77,8 @@
   display: flex;
   flex-direction: column;
   min-width: 0;
-  height: 100vh;
-  overflow-y: auto;
+  min-height: 100vh;
+  overflow: visible;
 }
 
 .warehouse-page__overview {
@@ -437,8 +437,7 @@
 }
 
 .warehouse-page__table-wrapper {
-  max-height: 56vh;
-  overflow: auto;
+  overflow: visible;
 }
 
 .warehouse-page__table {


### PR DESCRIPTION
## Summary
- relax the warehouse page layout height so the content no longer forces an internal scrollbar
- allow the supplies table wrapper to expand with its content to eliminate the vertical scroll bar

## Testing
- npm run lint *(fails: project has no lint target configured)*

------
https://chatgpt.com/codex/tasks/task_e_68dabd0c0594832397547201b3557de2