### PR TITLE
Simplify warehouse view to only show tabs

### DIFF
--- a/feedme.client/src/app/components/content/content.component.css
+++ b/feedme.client/src/app/components/content/content.component.css
@@ -3,70 +3,13 @@
   flex-direction: column;
   flex: 1 1 auto;
   min-height: 0;
-  overflow: hidden;
+  background-color: #ffffff;
 }
 
 .content {
   flex: 1 1 auto;
   display: flex;
-  flex-direction: column;
-  min-height: 0;
-  overflow: hidden;
-
-  padding: 0;
-  background-color: #ffffff;
-  position: relative;
-}
-
-.container {
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  height: 60px;
-  background-color: transparent;
-  box-shadow: none;
-  width: 100%;
-}
-
-  .container + .container {
-    border-top: 1px solid #e6e6e6;
-  }
-
-.item {
-  display: flex;
-  align-items: center;
-  font-size: 14px;
-  color: #8c8c8c;
-  cursor: pointer;
-  margin-right: 20px;
-  margin-left: 10px;
-  position: relative;
-  padding: 5px 0;
-  transition: color 0.3s ease;
-}
-
-  .item.selected {
-    color: #0056b3;
-    font-weight: 500;
-  }
-
-    .item.selected::after {
-      content: "";
-      position: absolute;
-      bottom: -2px;
-      left: 0;
-      right: 0;
-      height: 2px;
-      background-color: #0056b3;
-    }
-
-  .item img {
-    width: 24px;
-    height: 24px;
-    margin-right: 8px;
-  }
-
-.error-message {
-  color: #dc3545;
-  margin: 8px 0;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 24px;
 }

--- a/feedme.client/src/app/components/content/content.component.html
+++ b/feedme.client/src/app/components/content/content.component.html
@@ -1,54 +1,6 @@
 <div class="content">
-  <app-warehouse-tabs [selectedTab]="selectedTab"
-                      (selectedTabChange)="setSelectedTab($event)">
-  </app-warehouse-tabs>
-
-  <app-supply-controls [(selectedSupply)]="selectedSupply"
-                       (goToCatalog)="goToCatalog()"
-                       (addSupply)="openNewProductPopup()">
-  </app-supply-controls>
-
-  <p class="error-message" *ngIf="errorMessage">{{ errorMessage }}</p>
-
-  <app-new-product *ngIf="showPopup && selectedSupply !== 'catalog'"
-                  [warehouse]="selectedTab"
-                  (onSubmit)="onNewProductSubmit($event)"
-                  (onCancel)="showPopup = false">
-  </app-new-product>
-
-  <app-catalog-new-product-popup *ngIf="showPopup && selectedSupply === 'catalog'"
-                                 (save)="onNewProductSubmit($event)"
-                                 (cancel)="closeNewProductPopup()"
-
-                                 [errorMessage]="errorMessage">
-
-  </app-catalog-new-product-popup>
-
-  <app-info-cards-wrapper *ngIf="selectedSupply !== 'catalog' && selectedItem"
-                          [item]="selectedItem"
-                          (onClose)="closeInfoCards()">
-  </app-info-cards-wrapper>
-
-  <!-- Таблица Поставок -->
-  <app-supply-table *ngIf="selectedSupply === 'supplies'"
-                    [data]="supplyData"
-                    (onAddSupply)="openNewProductPopup()"
-                    (onSettingsClick)="handleSettingsClick($event)">
-  </app-supply-table>
-
-  <!-- Таблица Остатков -->
-  <app-stock-table *ngIf="selectedSupply === 'stock'"
-                   [data]="stockData"
-                   (onSettingsClick)="handleSettingsClick($event)">
-  </app-stock-table>
-
-  <!-- Таблица Каталога -->
-  <app-catalog-table *ngIf="selectedSupply === 'catalog'"
-                     [data]="catalogData"
-                     (onAddSupply)="openNewProductPopup()"
-
-                     (deleteRow)="onCatalogRemove($event)">
-
-
-  </app-catalog-table>
+  <app-warehouse-tabs
+    [selectedTab]="selectedWarehouse()"
+    (selectedTabChange)="selectWarehouse($event)"
+  ></app-warehouse-tabs>
 </div>

--- a/feedme.client/src/app/components/content/content.component.ts
+++ b/feedme.client/src/app/components/content/content.component.ts
@@ -1,173 +1,22 @@
-import { Component, OnInit, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { FormsModule } from '@angular/forms';
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
 
-import { EMPTY, catchError, take, tap } from 'rxjs';
 import { WarehouseTabsComponent } from '../warehouse-tabs/warehouse-tabs.component';
-import { SupplyControlsComponent } from '../supply-controls/supply-controls.component';
-import { InfoCardsWrapperComponent } from '../info-cards-wrapper/info-cards-wrapper.component';
-import { SupplyTableComponent } from '../SupplyTableComponent/supply-table.component';
-import { StockTableComponent } from '../StockTableComponent/stock-table.component';
-import { CatalogTableComponent } from '../CatalogTableComponent/catalog-table.component';
-import { NewProductComponent } from '../new-product/new-product.component';
-import { CatalogNewProductPopupComponent } from '../catalog-new-product-popup/catalog-new-product-popup.component';
-import { CatalogItem, CatalogService } from '../../services/catalog.service';
 
 @Component({
   selector: 'app-content',
   standalone: true,
-  imports: [
-    CommonModule,
-    FormsModule,
-    WarehouseTabsComponent,
-    SupplyControlsComponent,
-    InfoCardsWrapperComponent,
-    SupplyTableComponent,
-    StockTableComponent,
-    CatalogTableComponent,
-    NewProductComponent,
-    CatalogNewProductPopupComponent
-  ],
+  imports: [CommonModule, WarehouseTabsComponent],
   templateUrl: './content.component.html',
-  styleUrls: ['./content.component.css']
+  styleUrls: ['./content.component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class ContentComponent implements OnInit {
-  private readonly catalogService = inject(CatalogService);
+export class ContentComponent {
+  private readonly activeWarehouse = signal('Главный склад');
 
-  /** Вкладка склада (для табов вверху) */
-  selectedTab: string = 'Главный склад';
+  selectedWarehouse = this.activeWarehouse.asReadonly();
 
-  /** Режим контента: supplies | stock | catalog */
-  selectedSupply: 'supplies' | 'stock' | 'catalog' = 'supplies';
-
-  supplyData: any[] = [];
-  stockData: any[] = [];
-  catalogData: CatalogItem[] = [];
-
-  selectedItem: any = null;
-  showPopup = false;
-  errorMessage: string | null = null;
-
-
-  ngOnInit(): void {
-    this.loadAllData();
-  }
-
-  /** Загружаем данные из localStorage и сервера */
-  private loadAllData(): void {
-    this.supplyData = JSON.parse(localStorage.getItem(`warehouseSupplies_${this.selectedTab}`) || '[]');
-    this.stockData = JSON.parse(localStorage.getItem(`warehouseStock_${this.selectedTab}`) || '[]');
-
-    this.loadCatalog();
-  }
-
-  private loadCatalog(): void {
-    this.catalogService
-      .getAll()
-      .pipe(
-        take(1),
-        tap(data => {
-          this.catalogData = data;
-          this.errorMessage = null;
-        }),
-        catchError(() => this.handleError('Не удалось загрузить каталог. Попробуйте ещё раз.'))
-      )
-      .subscribe();
-  }
-
-  /** Смена вкладки склада */
-  setSelectedTab(tab: string): void {
-    this.selectedTab = tab;
-    this.loadAllData();
-  }
-
-  /** Переключение modesupply из SupplyControlsComponent */
-  onSupplyModeChange(mode: 'supplies' | 'stock' | 'catalog'): void {
-    this.selectedSupply = mode;
-  }
-
-  /** Открыть попап добавления */
-  openNewProductPopup(): void {
-
-    this.errorMessage = null;
-
-    this.showPopup = true;
-  }
-  closeNewProductPopup(): void {
-    this.showPopup = false;
-
-    this.errorMessage = null;
-
-  }
-
-  /** Получить новые данные из формы */
-  onNewProductSubmit(item: any): void {
-    if (this.selectedSupply === 'supplies') {
-      this.supplyData = [...this.supplyData, item];
-      localStorage.setItem(`warehouseSupplies_${this.selectedTab}`, JSON.stringify(this.supplyData));
-      this.closeNewProductPopup();
-    } else if (this.selectedSupply === 'stock') {
-      this.stockData = [...this.stockData, item];
-      localStorage.setItem(`warehouseStock_${this.selectedTab}`, JSON.stringify(this.stockData));
-      this.closeNewProductPopup();
-    } else {
-      this.catalogService
-        .create(item)
-        .pipe(
-          take(1),
-          tap(created => {
-            this.catalogData = [...this.catalogData, created];
-            this.closeNewProductPopup();
-
-            this.errorMessage = null;
-          }),
-          catchError(() => this.handleError('Не удалось сохранить товар. Попробуйте ещё раз.'))
-        )
-        .subscribe();
-
-    }
-  }
-
-  handleSettingsClick(item: any): void {
-    this.selectedItem = item;
-  }
-  closeInfoCards(): void {
-    this.selectedItem = null;
-  }
-
-  /** Переход в каталог через кнопку из SupplyControlsComponent */
-  goToCatalog(): void {
-    this.selectedSupply = 'catalog';
-  }
-
-  onCatalogRemove(item: CatalogItem): void {
-    const targetId = item?.id?.trim();
-
-    if (!targetId) {
-      this.errorMessage = 'Не удалось удалить товар: отсутствует идентификатор.';
-      return;
-    }
-
-    this.errorMessage = null;
-
-    const previousCatalog = [...this.catalogData];
-    this.catalogData = this.catalogData.filter(catalogItem => catalogItem.id !== targetId);
-
-    this.catalogService
-      .delete(targetId)
-      .pipe(
-        take(1),
-        tap(() => this.loadCatalog()),
-        catchError(() => {
-          this.catalogData = previousCatalog;
-          return this.handleError('Не удалось удалить товар. Попробуйте ещё раз.');
-        })
-      )
-      .subscribe();
-  }
-
-  private handleError(message: string) {
-    this.errorMessage = message;
-    return EMPTY;
+  selectWarehouse(name: string): void {
+    this.activeWarehouse.set(name);
   }
 }

--- a/feedme.client/src/app/components/header/header.component.css
+++ b/feedme.client/src/app/components/header/header.component.css
@@ -1,233 +1,51 @@
 :host {
-  --warehouse-header-background: #f5f7fa;
-  --warehouse-header-panel: #ffffff;
-  --warehouse-header-text: #1f2937;
-  --warehouse-header-muted: #6b7280;
-  --warehouse-header-border: #e5e7eb;
-  --warehouse-header-shadow: 0 1px 2px rgba(0, 0, 0, 0.04), 0 6px 18px rgba(0, 0, 0, 0.06);
-  --warehouse-header-blue: #1f3b64;
-  --warehouse-header-blue-underline: #2b71d3;
-  --warehouse-header-orange: #ff6b35;
-  --warehouse-header-orange-border: #ffb892;
-  --warehouse-header-orange-text: #c2410c;
-  --warehouse-header-radius: 10px;
-
+  --header-background: #f5f7fa;
+  --header-panel: #ffffff;
+  --header-border: #e5e7eb;
+  --header-text: #1f2937;
+  --header-muted: #6b7280;
+  --header-active: #1f3b64;
+  --header-active-underline: #2b71d3;
   display: block;
-  background: var(--warehouse-header-background);
+  background: var(--header-background);
   padding: 18px;
-  color: var(--warehouse-header-text);
 }
 
 .warehouse-header {
   display: flex;
-  flex-direction: column;
-  gap: 14px;
-}
-
-.warehouse-header__panel {
-  background: var(--warehouse-header-panel);
-  border: 1px solid var(--warehouse-header-border);
-  border-radius: var(--warehouse-header-radius);
-  box-shadow: var(--warehouse-header-shadow);
-}
-
-.warehouse-header__breadcrumbs-panel {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 14px 16px;
-}
-
-.warehouse-header__breadcrumbs {
-  display: flex;
-  align-items: center;
-  font-weight: 700;
-  gap: 6px;
-}
-
-.warehouse-header__breadcrumb {
-  color: var(--warehouse-header-muted);
-}
-
-.warehouse-header__breadcrumb--current {
-  color: var(--warehouse-header-text);
-}
-
-.warehouse-header__breadcrumb-separator {
-  color: var(--warehouse-header-muted);
-}
-
-.warehouse-header__warehouse {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  color: var(--warehouse-header-muted);
-}
-
-.warehouse-header__warehouse-label {
-  font-weight: 500;
-}
-
-.warehouse-header__warehouse-tag {
-  display: inline-flex;
-  align-items: center;
-  padding: 6px 10px;
-  border-radius: 8px;
-  border: 1px solid var(--warehouse-header-border);
-  background: #f3f4f6;
-  color: #111827;
-  font-weight: 600;
-}
-
-.warehouse-header__kpi {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 14px;
-}
-
-.warehouse-header__metric {
-  padding: 16px;
-  border: 1px solid var(--warehouse-header-border);
-  border-radius: var(--warehouse-header-radius);
-  background: var(--warehouse-header-panel);
-  box-shadow: var(--warehouse-header-shadow);
-}
-
-.warehouse-header__metric-title {
-  margin: 0 0 6px;
-  color: var(--warehouse-header-muted);
-  font-size: 12px;
-}
-
-.warehouse-header__metric-value {
-  margin: 0;
-  font-size: 28px;
-  font-weight: 800;
-  color: var(--warehouse-header-text);
-}
-
-.warehouse-header__metric-value--negative {
-  color: #b91c1c;
-}
-
-.warehouse-header__toolbar {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 12px;
-}
-
-.warehouse-header__filters {
-  display: grid;
-  flex: 1;
-  grid-template-columns: 1.2fr 0.6fr 0.6fr auto;
-  gap: 10px;
-}
-
-.warehouse-header__input {
-  height: 36px;
-  padding: 0 12px;
-  border-radius: 8px;
-  border: 1px solid var(--warehouse-header-border);
-  background: var(--warehouse-header-panel);
-  color: var(--warehouse-header-text);
-  font-size: 14px;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.warehouse-header__input::placeholder {
-  color: #9aa3af;
-}
-
-.warehouse-header__input:focus-visible {
-  outline: none;
-  border-color: var(--warehouse-header-blue-underline);
-  box-shadow: 0 0 0 3px rgba(43, 113, 211, 0.15);
-}
-
-.warehouse-header__button {
-  display: inline-flex;
-  align-items: center;
   justify-content: center;
-  gap: 0.5rem;
-  padding: 0.55rem 0.95rem;
-  border-radius: 8px;
-  border: 1px solid transparent;
-  font-weight: 700;
-  font-size: 14px;
-  cursor: pointer;
-  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.warehouse-header__button:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 3px rgba(31, 59, 100, 0.18);
-}
-
-.warehouse-header__reset-button {
-  background: var(--warehouse-header-panel);
-  border-color: var(--warehouse-header-orange-border);
-  color: var(--warehouse-header-orange-text);
-}
-
-.warehouse-header__reset-button:hover {
-  background: rgba(255, 230, 210, 0.4);
-}
-
-.warehouse-header__actions {
-  display: flex;
-  gap: 10px;
-}
-
-.warehouse-header__export-button {
-  background: var(--warehouse-header-blue);
-  color: #ffffff;
-}
-
-.warehouse-header__export-button:hover {
-  background: #25497c;
-}
-
-.warehouse-header__cta-button {
-  background: var(--warehouse-header-orange);
-  color: #ffffff;
-}
-
-.warehouse-header__cta-button:hover {
-  background: #e55f2f;
 }
 
 .warehouse-header__tabs {
-  display: flex;
-  align-items: flex-end;
-  gap: 24px;
-  padding: 12px 0 0;
+  display: inline-flex;
+  gap: 12px;
+  padding: 10px 16px;
+  border-radius: 12px;
+  background: var(--header-panel);
+  border: 1px solid var(--header-border);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04), 0 6px 18px rgba(0, 0, 0, 0.06);
 }
 
 .warehouse-header__tab {
   position: relative;
-  padding: 8px 2px;
   border: none;
-  background: none;
-  color: #4b5563;
-  font-weight: 700;
+  background: transparent;
+  color: var(--header-muted);
+  font-weight: 600;
   font-size: 14px;
+  padding: 8px 4px;
   cursor: pointer;
   transition: color 0.2s ease;
 }
 
 .warehouse-header__tab:focus-visible {
   outline: none;
-  color: var(--warehouse-header-blue-underline);
-}
-
-.warehouse-header__tab:hover {
-  color: #1f2937;
+  color: var(--header-active);
+  box-shadow: inset 0 -2px 0 var(--header-active-underline);
 }
 
 .warehouse-header__tab--active {
-  color: #111827;
+  color: var(--header-active);
 }
 
 .warehouse-header__tab--active::after {
@@ -235,59 +53,8 @@
   position: absolute;
   left: 0;
   right: 0;
-  bottom: -10px;
+  bottom: 0;
   height: 3px;
-  border-radius: 6px;
-  background: var(--warehouse-header-blue-underline);
-}
-
-@media (max-width: 1100px) {
-  .warehouse-header__kpi {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .warehouse-header__filters {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
-@media (max-width: 768px) {
-  :host {
-    padding: 14px;
-  }
-
-  .warehouse-header__breadcrumbs-panel {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 12px;
-  }
-
-  .warehouse-header__toolbar {
-    flex-direction: column;
-    align-items: stretch;
-  }
-
-  .warehouse-header__filters {
-    width: 100%;
-    grid-template-columns: 1fr;
-  }
-
-  .warehouse-header__actions {
-    width: 100%;
-    justify-content: flex-end;
-  }
-}
-
-@media (max-width: 540px) {
-  .warehouse-header__kpi {
-    grid-template-columns: 1fr;
-  }
-
-  .warehouse-header__actions {
-    flex-direction: column;
-  }
-
-  .warehouse-header__actions .warehouse-header__button {
-    width: 100%;
-  }
+  border-radius: 999px;
+  background: var(--header-active-underline);
 }

--- a/feedme.client/src/app/components/header/header.component.html
+++ b/feedme.client/src/app/components/header/header.component.html
@@ -1,98 +1,12 @@
-<header class="warehouse-header">
-  <section class="warehouse-header__panel warehouse-header__breadcrumbs-panel">
-    <div class="warehouse-header__breadcrumbs" aria-label="Навигация по разделам">
-
-      <ng-container *ngFor="let breadcrumb of breadcrumbs(); let isLast = last">
-
-        <span
-          class="warehouse-header__breadcrumb"
-          [class.warehouse-header__breadcrumb--current]="isLast"
-        >
-          {{ breadcrumb }}
-        </span>
-        <span *ngIf="!isLast" class="warehouse-header__breadcrumb-separator">/</span>
-      </ng-container>
-    </div>
-    <div class="warehouse-header__warehouse">
-      <span class="warehouse-header__warehouse-label">Склад:</span>
-
-      <span class="warehouse-header__warehouse-tag">{{ selectedWarehouse() }}</span>
-
-    </div>
-  </section>
-
-  <section class="warehouse-header__kpi" aria-label="Ключевые показатели склада">
-
-    <article class="warehouse-header__metric" *ngFor="let metric of metrics()">
-
-      <p class="warehouse-header__metric-title">{{ metric.title }}</p>
-      <p
-        class="warehouse-header__metric-value"
-        [class.warehouse-header__metric-value--negative]="metric.isNegative"
-      >
-
-        <ng-container *ngIf="metric.format === 'currency'; else numberMetric">
-          {{ metric.value | currency: 'RUB':'symbol-narrow':'1.0-0':'ru-RU' }}
-        </ng-container>
-        <ng-template #numberMetric>
-          {{ metric.value | number: '1.0-0':'ru-RU' }}
-        </ng-template>
-
-      </p>
-    </article>
-  </section>
-
-  <section class="warehouse-header__panel warehouse-header__toolbar">
-    <div class="warehouse-header__filters" [formGroup]="filterForm">
-      <input
-        class="warehouse-header__input warehouse-header__search"
-        type="search"
-        formControlName="search"
-        [placeholder]="searchPlaceholder"
-        aria-label="Поиск по поставкам"
-      />
-      <input
-        class="warehouse-header__input warehouse-header__date-picker"
-        type="text"
-        inputmode="numeric"
-        formControlName="startDate"
-        [placeholder]="datePlaceholders.start"
-        aria-label="Дата начала периода"
-      />
-      <input
-        class="warehouse-header__input warehouse-header__date-picker"
-        type="text"
-        inputmode="numeric"
-        formControlName="endDate"
-        [placeholder]="datePlaceholders.end"
-        aria-label="Дата окончания периода"
-      />
-      <button
-        type="button"
-        class="warehouse-header__button warehouse-header__reset-button"
-        (click)="onResetFilters()"
-      >
-        Сброс
-      </button>
-    </div>
-    <div class="warehouse-header__actions">
-      <button type="button" class="warehouse-header__button warehouse-header__export-button">
-        Экспорт
-      </button>
-      <button type="button" class="warehouse-header__button warehouse-header__cta-button">
-        + Новая поставка
-      </button>
-    </div>
-  </section>
-
-  <nav class="warehouse-header__tabs" aria-label="Навигация по складским разделам">
+<header class="warehouse-header" aria-label="Навигация по складским разделам">
+  <nav class="warehouse-header__tabs" role="tablist">
     <button
       type="button"
       class="warehouse-header__tab"
       *ngFor="let tab of tabs"
-
       [class.warehouse-header__tab--active]="tab === activeTab()"
-
+      role="tab"
+      [attr.aria-selected]="tab === activeTab()"
       (click)="setActiveTab(tab)"
     >
       {{ tab }}

--- a/feedme.client/src/app/components/header/header.component.ts
+++ b/feedme.client/src/app/components/header/header.component.ts
@@ -1,127 +1,21 @@
 import { CommonModule } from '@angular/common';
-
-import {
-  ChangeDetectionStrategy,
-  Component,
-  computed,
-  inject,
-  signal,
-} from '@angular/core';
-import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
-
-import { WarehouseService } from '../../warehouse/warehouse.service';
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
 
 type TabName = 'Поставки' | 'Остатки' | 'Каталог' | 'Инвентаризация';
-
-type MetricFormat = 'number' | 'currency';
-
-interface WarehouseMetric {
-  readonly title: string;
-  readonly value: number;
-  readonly format: MetricFormat;
-  readonly isNegative?: boolean;
-}
-
-interface HeaderFilters {
-  readonly search: string;
-  readonly startDate: string;
-  readonly endDate: string;
-}
-
 
 @Component({
   selector: 'app-header',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule],
+  imports: [CommonModule],
   templateUrl: './header.component.html',
   styleUrls: ['./header.component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class HeaderComponent {
-  private readonly formBuilder = inject(FormBuilder);
-
-  private readonly warehouseService = inject(WarehouseService);
-
-  private readonly warehouseRows = this.warehouseService.list();
-  private readonly warehouseMetrics = this.warehouseService.metrics();
-
   readonly tabs: readonly TabName[] = ['Поставки', 'Остатки', 'Каталог', 'Инвентаризация'];
   readonly activeTab = signal<TabName>(this.tabs[0]);
 
-
-  readonly searchPlaceholder = 'Поиск по номеру, SKU или названию';
-  readonly datePlaceholders = { start: 'дд.мм.гггг', end: 'дд.мм.гггг' } as const;
-
-
-  private readonly filterDefaults: HeaderFilters = {
-    search: '',
-    startDate: '',
-    endDate: '',
-  } as const;
-
-  readonly filterForm = this.formBuilder.nonNullable.group(this.filterDefaults);
-
-  readonly selectedWarehouse = computed(() => {
-    const rows = this.warehouseRows();
-    if (rows.length === 0) {
-      return '—';
-    }
-
-    const warehouses = Array.from(new Set(rows.map((row) => row.warehouse)));
-    warehouses.sort((a, b) => {
-      if (a === b) {
-        return 0;
-      }
-      if (a === 'Главный склад') {
-        return -1;
-      }
-      if (b === 'Главный склад') {
-        return 1;
-      }
-
-      return a.localeCompare(b, 'ru');
-    });
-
-    return warehouses[0] ?? '—';
-  });
-
-  readonly breadcrumbs = computed(() => ['Поставки', this.selectedWarehouse()]);
-
-  readonly metrics = computed<readonly WarehouseMetric[]>(() => {
-    const snapshot = this.warehouseMetrics();
-    return [
-      {
-        title: 'Поставок за 7 дней',
-        value: snapshot.suppliesLastWeek,
-        format: 'number',
-      },
-      {
-        title: 'Сумма закупок / 7 дн.',
-        value: snapshot.purchaseAmountLastWeek,
-        format: 'currency',
-      },
-      {
-        title: 'Позиций на складе',
-        value: snapshot.positions,
-        format: 'number',
-      },
-      {
-        title: 'Просрочено',
-        value: snapshot.expired,
-        format: 'number',
-        isNegative: snapshot.expired > 0,
-      },
-    ] satisfies readonly WarehouseMetric[];
-
-  });
-
-  onResetFilters(): void {
-    this.filterForm.reset(this.filterDefaults);
-  }
-
   setActiveTab(tab: TabName): void {
-
     this.activeTab.set(tab);
-
   }
 }


### PR DESCRIPTION
## Summary
- reduce the warehouse header to a single tab navigation and remove breadcrumbs, filters, and actions
- streamline the warehouse content area so only the tab selector is rendered
- clean up related styles and logic to focus solely on the tab navigation visuals

## Testing
- npm run build -- --progress=false

------
https://chatgpt.com/codex/tasks/task_e_68dac4eeae288323a4cda8bad8e4f5cc