### PR TITLE
Fix new supply dialog title and remove horizontal scroll

### DIFF
--- a/feedme.client/src/app/components/new-product/new-product.component.html
+++ b/feedme.client/src/app/components/new-product/new-product.component.html
@@ -2,7 +2,7 @@
   <div class="dialog">
     <form [formGroup]="form" class="npd">
       <div class="npd__header">
-        <h2 class="npd__title">Новый товар</h2>
+        <h2 class="npd__title">Новая поставка</h2>
         <button type="button" class="npd__close" (click)="cancel()" aria-label="Закрыть диалог">
           ×
         </button>

--- a/feedme.client/src/app/warehouse/supplies/supplies.component.scss
+++ b/feedme.client/src/app/warehouse/supplies/supplies.component.scss
@@ -224,6 +224,9 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: 1.5rem;
+  overflow-y: auto;
+  box-sizing: border-box;
   z-index: 1000;
 }
 
@@ -236,8 +239,8 @@
 .supplies-dialog__panel {
   position: relative;
   z-index: 1;
-  width: 640px;
-  max-width: calc(100vw - 2rem);
+  width: min(640px, 100%);
+  max-width: 640px;
   background: #ffffff;
   border: 1px solid #e5e7eb;
   border-radius: 0;
@@ -361,9 +364,12 @@
 }
 
 @media (max-width: 900px) {
+  .supplies-dialog {
+    align-items: flex-start;
+  }
+
   .supplies-dialog__panel {
     width: 100%;
-    margin: 1.5rem;
   }
 
   .supplies-dialog__grid {

--- a/feedme.client/src/styles.css
+++ b/feedme.client/src/styles.css
@@ -24,6 +24,7 @@ html, body {
   padding: 0;
   height: 100%;
   font-family: Arial, sans-serif;
+  overflow-x: hidden;
 }
 
 button,


### PR DESCRIPTION
## Summary
- rename the new supply popup header to "Новая поставка"
- adjust the supplies dialog layout so opening it no longer creates a horizontal scrollbar on the page

## Testing
- npm test -- --watch=false *(fails: ChromeHeadless cannot start because libatk-1.0.so.0 is missing in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dabe48a8448323bd443b6893cad9ae