### PR TITLE
Refine supply controls integration

### DIFF
--- a/feedme.client/src/app/components/supply-controls/supply-controls.component.css
+++ b/feedme.client/src/app/components/supply-controls/supply-controls.component.css
@@ -1,127 +1,72 @@
-.container {
+:host {
+  display: block;
+}
+
+.supply-controls {
   display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  gap: 20px;
-  padding: 0 16px;
-  height: 59px;
-  background-color: #f5f5f5;
-  width: 100%;
-  box-shadow: none;
-}
-
-.item,
-.catalog-button {
-  display: flex;
-  align-items: center;
-  font-size: 16px;
-  gap: 6px;
-  padding: 8px 12px;
-  color: #000000;
-  cursor: pointer;
-  position: relative;
-  transition: color 0.3s ease;
-}
-
-  .item img {
-    width: 24px;
-    height: 24px;
-    margin-right: 8px;
-  }
-
-  .item.selected,
-  .catalog-button.selected {
-    font-weight: bold;
-    color: #4F6BD1;
-  }
-
-    .item.selected::after,
-    .catalog-button.selected::after {
-      content: "";
-      position: absolute;
-      bottom: -2px;
-      left: 0;
-      right: 0;
-      height: 2px;
-      background-color: #4F6BD1;
-    }
-
-  .item:hover,
-  .catalog-button:hover {
-    color: #4F6BD1;
-  }
-
-
-.primary-action-btn {
-  width: 180px;
-  height: 40px;
-  background-color: #fa502d;
-  color: #ffffff;
-  border-radius: 8px;
-  border: none;
-  cursor: pointer;
-  font-size: 14px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: background-color 0.3s ease;
-}
-
-  .primary-action-btn:hover {
-    background-color: #e64827;
-  }
-
-  .primary-action-btn img {
-    width: 20px;
-    height: 20px;
-    margin-right: 6px;
-  }
-.add-button-wrapper {
-  margin-left: auto;
-  padding-right: 16px;
-}
-
-.add-button {
-  display: inline-block;
-  background-color: #fa4b00;
-  color: #fff;
-  border: none;
-  border-radius: 0.375rem;
-  padding: 0.5rem 1rem;
-  font-size: 1rem;
-  font-weight: 500;
-  cursor: pointer;
-  transition: background-color 0.2s ease;
-  /* прижать вправо, если в flex-контейнере */
-  margin-left: auto;
-}
-
-  .add-btn:hover {
-    background-color: #d94300;
-  }
-.table-header {
-  display: flex;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
-  width: 100%;
-  box-sizing: border-box;
-  padding: 0 1rem  0.5rem;
+  gap: 16px;
+  padding: 0 4px;
 }
 
-.new-supply-btn {
-  margin-left: auto; /* прижать вправо */
-  background-color: #fa4b00; /* оранжевый */
-  color: #fff;
-  border: none;
-  border-radius: 6px;
-  padding: 8px 16px;
-  font-size: 14px;
+.supply-controls__tabs {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px;
+  border-radius: 9999px;
+  background: rgba(148, 163, 184, 0.16);
+}
+
+.supply-controls__tab {
+  border: 0;
+  border-radius: 9999px;
+  padding: 10px 22px;
+  background: transparent;
+  color: #475569;
+  font-size: 0.9375rem;
+  font-weight: 600;
   cursor: pointer;
-  transition: background-color 0.2s;
+  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
 }
 
-  .new-supply-btn:hover {
-    background-color: #d94300;
+.supply-controls__tab:hover {
+  color: #0f172a;
+}
+
+.supply-controls__tab:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.25);
+}
+
+.supply-controls__tab--active {
+  background: #ffffff;
+  color: #0f172a;
+  box-shadow: 0 8px 16px rgba(15, 23, 42, 0.12);
+}
+
+.supply-controls__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+}
+
+@media (max-width: 768px) {
+  .supply-controls {
+    flex-direction: column;
+    align-items: stretch;
   }
 
-/* остальной CSS оставляем без изменений */
+  .supply-controls__actions {
+    width: 100%;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .supply-controls__actions .btn {
+    width: 100%;
+    justify-content: center;
+  }
+}

--- a/feedme.client/src/app/components/supply-controls/supply-controls.component.html
+++ b/feedme.client/src/app/components/supply-controls/supply-controls.component.html
@@ -1,22 +1,24 @@
-<div class="container supply-controls">
+<div class="supply-controls" role="navigation" aria-label="Управление разделами склада">
+  <nav class="supply-controls__tabs" role="tablist" aria-label="Разделы склада">
+    <button
+      type="button"
+      *ngFor="let tab of tabs; trackBy: trackByTab"
+      class="supply-controls__tab"
+      [class.supply-controls__tab--active]="tab.key === activeTab"
+      (click)="onSelect(tab.key)"
+      role="tab"
+      [attr.aria-selected]="tab.key === activeTab ? 'true' : 'false'"
+    >
+      {{ tab.label }}
+    </button>
+  </nav>
 
-  <div class="item" [class.selected]="selectedSupply === 'supplies'" (click)="setSupplyType('supplies')">
-    <img src="assets/truck.svg" alt="Поставки товара" class="item-icon">
-    <span>Поставки товара</span>
+  <div class="supply-controls__actions">
+    <button type="button" class="btn btn-secondary">
+      Экспорт
+    </button>
+    <button type="button" class="btn btn-primary" (click)="onCreateSupply()">
+      + Новая поставка
+    </button>
   </div>
-
-  <div class="item" [class.selected]="selectedSupply === 'stock'" (click)="setSupplyType('stock')">
-    <img src="assets/box.svg" alt="Остаток товара" class="item-icon">
-    <span>Остаток товара</span>
-  </div>
-
-
-
-  <div class="item catalog-button" [class.selected]=" selectedSupply === 'catalog'" (click)="handleGoToCatalog()">
-    <img src="assets/catalog.svg" alt="Каталог" class="item-icon">
-    <span>Каталог</span>
-  </div>
-
 </div>
-
-

--- a/feedme.client/src/app/components/supply-controls/supply-controls.component.ts
+++ b/feedme.client/src/app/components/supply-controls/supply-controls.component.ts
@@ -1,45 +1,44 @@
-import { Component, Input, Output, EventEmitter } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { NgFor } from '@angular/common';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
+
+type SupplySection = 'supplies' | 'stock' | 'catalog' | 'inventory';
+
+type SupplyTab = {
+  readonly key: SupplySection;
+  readonly label: string;
+};
 
 @Component({
   selector: 'app-supply-controls',
   standalone: true,
-  imports: [CommonModule],
+  imports: [NgFor],
   templateUrl: './supply-controls.component.html',
-  styleUrls: ['./supply-controls.component.css']
+  styleUrls: ['./supply-controls.component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SupplyControlsComponent {
-  @Input() selectedSupply: string = 'supplies';
-  @Output() selectedSupplyChange = new EventEmitter<string>();
-  @Output() openNewProduct = new EventEmitter<void>();  // ← новое
-  @Output() addSupply = new EventEmitter<void>();
-  @Output() goToCatalog = new EventEmitter<void>();
+  @Input() activeTab: SupplySection = 'supplies';
+  @Output() activeTabChange = new EventEmitter<SupplySection>();
+  @Output() createSupply = new EventEmitter<void>();
 
-  setSupplyType(type: 'supplies' | 'stock' | 'catalog'): void {
-    // если та же вкладка — ничего не делать
-    if (this.selectedSupply === type) {
+  readonly tabs: ReadonlyArray<SupplyTab> = [
+    { key: 'supplies', label: 'Поставки' },
+    { key: 'stock', label: 'Остатки' },
+    { key: 'catalog', label: 'Каталог' },
+    { key: 'inventory', label: 'Инвентаризация' },
+  ];
+
+  onSelect(tab: SupplySection): void {
+    if (this.activeTab === tab) {
       return;
     }
 
-    // установить новую вкладку
-    this.selectedSupply = type;
-    // уведомить родителя об изменении
-    this.selectedSupplyChange.emit(this.selectedSupply);
-
-    // при переходе на каталог можно дополнительно вызвать навигацию
-    if (type === 'catalog') {
-      this.goToCatalog.emit();
-    }
+    this.activeTabChange.emit(tab);
   }
-  
 
-
-
-  handleGoToCatalog(): void {
-    this.setSupplyType('catalog');
-    this.goToCatalog.emit();
+  onCreateSupply(): void {
+    this.createSupply.emit();
   }
-  onAddClick() {
-    this.addSupply.emit();
-  }
+
+  trackByTab = (_: number, tab: SupplyTab) => tab.key;
 }

--- a/feedme.client/src/app/warehouse/warehouse-page.component.css
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.css
@@ -183,58 +183,6 @@
   min-height: 120px;
 }
 
-.warehouse-page__overview-footer {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 16px;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.warehouse-page__tabs {
-  display: inline-flex;
-  gap: 8px;
-  padding: 6px;
-  border-radius: 9999px;
-  background: rgba(148, 163, 184, 0.16);
-}
-
-.warehouse-page__tab {
-  border: 0;
-  border-radius: 9999px;
-  padding: 10px 22px;
-  background: transparent;
-  color: #475569;
-  font-size: 0.9375rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.warehouse-page__tab:hover {
-  color: #0f172a;
-}
-
-.warehouse-page__tab:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.25);
-}
-
-.warehouse-page__tab--active {
-  background: #ffffff;
-  color: #0f172a;
-  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.12);
-}
-
-.warehouse-page__header-actions {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  margin-left: auto;
-  flex-wrap: wrap;
-  justify-content: flex-end;
-}
-
 .sr-only {
   position: absolute;
   width: 1px;

--- a/feedme.client/src/app/warehouse/warehouse-page.component.html
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.html
@@ -76,27 +76,11 @@
         </article>
       </section>
 
-      <div class="warehouse-page__overview-footer">
-        <nav class="warehouse-page__tabs" role="tablist" aria-label="Разделы склада">
-          <button
-            type="button"
-            *ngFor="let entry of tabKeys"
-            class="warehouse-page__tab"
-            [class.warehouse-page__tab--active]="activeTab() === entry"
-            (click)="selectTab(entry)"
-            role="tab"
-            [attr.aria-selected]="activeTab() === entry ? 'true' : 'false'"
-          >
-            {{ tabLabels[entry] }}
-          </button>
-        </nav>
-        <div class="warehouse-page__header-actions">
-          <button type="button" class="btn btn-secondary">Экспорт</button>
-          <button type="button" class="btn btn-primary" (click)="openCreateDialog()">
-            + Новая поставка
-          </button>
-        </div>
-      </div>
+      <app-supply-controls
+        [activeTab]="activeTab()"
+        (activeTabChange)="selectTab($event)"
+        (createSupply)="openCreateDialog()"
+      ></app-supply-controls>
     </section>
 
     <section *ngIf="activeTab() === 'supplies'" class="warehouse-page__tab-panel">

--- a/feedme.client/src/app/warehouse/warehouse-page.component.ts
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.ts
@@ -22,6 +22,7 @@ import { EmptyStateComponent } from './ui/empty-state.component';
 import { FieldComponent } from './ui/field.component';
 import { StatusBadgeClassPipe } from '../pipes/status-badge-class.pipe';
 import { StatusBadgeLabelPipe } from '../pipes/status-badge-label.pipe';
+import { SupplyControlsComponent } from '../components/supply-controls/supply-controls.component';
 
 const RUB_FORMATTER = new Intl.NumberFormat('ru-RU', {
   style: 'currency',
@@ -30,6 +31,8 @@ const RUB_FORMATTER = new Intl.NumberFormat('ru-RU', {
 });
 
 type EditDialogTab = 'details' | 'items' | 'history';
+
+type WarehouseTab = 'supplies' | 'stock' | 'catalog' | 'inventory';
 
 type SupplyHistoryEntry = {
   date: string;
@@ -49,6 +52,7 @@ type SupplyHistoryEntry = {
     EmptyStateComponent,
     StatusBadgeClassPipe,
     StatusBadgeLabelPipe,
+    SupplyControlsComponent,
   ],
   templateUrl: './warehouse-page.component.html',
   styleUrl: './warehouse-page.component.css',
@@ -60,7 +64,7 @@ export class WarehousePageComponent {
 
   @ViewChild('searchInput') private readonly searchInput?: ElementRef<HTMLInputElement>;
 
-  readonly activeTab = signal<'supplies' | 'stock' | 'catalog' | 'inventory'>('supplies');
+  readonly activeTab = signal<WarehouseTab>('supplies');
   readonly query = signal('');
   readonly status = signal<SupplyStatus | ''>('');
   readonly statuses = SUPPLY_STATUSES;
@@ -173,14 +177,6 @@ export class WarehousePageComponent {
     return this.rows().find((row) => row.id === id) ?? null;
   });
 
-  readonly tabKeys = ['supplies', 'stock', 'catalog', 'inventory'] as const;
-  readonly tabLabels: Record<'supplies' | 'stock' | 'catalog' | 'inventory', string> = {
-    supplies: 'Поставки',
-    stock: 'Остатки',
-    catalog: 'Каталог',
-    inventory: 'Инвентаризация',
-  };
-
   readonly editForm = this.fb.group({
     docNo: this.fb.control('', { validators: [Validators.required] }),
     arrivalDate: this.fb.control('', { validators: [Validators.required] }),
@@ -253,7 +249,7 @@ export class WarehousePageComponent {
     this.editDialogTab.set(tab);
   }
 
-  selectTab(tab: 'supplies' | 'stock' | 'catalog' | 'inventory'): void {
+  selectTab(tab: WarehouseTab): void {
     this.activeTab.set(tab);
   }
 


### PR DESCRIPTION
## Summary
- refactor the supply controls into a reusable, OnPush standalone component with clear tab metadata and actions
- replace the warehouse page header markup with the new component and remove redundant tab configuration
- clean up styles by introducing scoped supply control styles and deleting unused warehouse tab rules

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68daccf660e88323ab06aea2ac26a0d3