### PR TITLE
Remove supply action buttons from supplies container

### DIFF
--- a/feedme.client/src/app/components/supply-controls/supply-controls.component.css
+++ b/feedme.client/src/app/components/supply-controls/supply-controls.component.css
@@ -47,26 +47,9 @@
   box-shadow: 0 8px 16px rgba(15, 23, 42, 0.12);
 }
 
-.supply-controls__actions {
-  display: inline-flex;
-  align-items: center;
-  gap: 12px;
-}
-
 @media (max-width: 768px) {
   .supply-controls {
     flex-direction: column;
     align-items: stretch;
-  }
-
-  .supply-controls__actions {
-    width: 100%;
-    justify-content: flex-start;
-    flex-wrap: wrap;
-  }
-
-  .supply-controls__actions .btn {
-    width: 100%;
-    justify-content: center;
   }
 }

--- a/feedme.client/src/app/components/supply-controls/supply-controls.component.html
+++ b/feedme.client/src/app/components/supply-controls/supply-controls.component.html
@@ -13,12 +13,4 @@
     </button>
   </nav>
 
-  <div class="supply-controls__actions">
-    <button type="button" class="btn btn-secondary">
-      Экспорт
-    </button>
-    <button type="button" class="btn btn-primary" (click)="onCreateSupply()">
-      + Новая поставка
-    </button>
-  </div>
 </div>

--- a/feedme.client/src/app/components/supply-controls/supply-controls.component.ts
+++ b/feedme.client/src/app/components/supply-controls/supply-controls.component.ts
@@ -19,7 +19,6 @@ type SupplyTab = {
 export class SupplyControlsComponent {
   @Input() activeTab: SupplySection = 'supplies';
   @Output() activeTabChange = new EventEmitter<SupplySection>();
-  @Output() createSupply = new EventEmitter<void>();
 
   readonly tabs: ReadonlyArray<SupplyTab> = [
     { key: 'supplies', label: 'Поставки' },
@@ -34,10 +33,6 @@ export class SupplyControlsComponent {
     }
 
     this.activeTabChange.emit(tab);
-  }
-
-  onCreateSupply(): void {
-    this.createSupply.emit();
   }
 
   trackByTab = (_: number, tab: SupplyTab) => tab.key;

--- a/feedme.client/src/app/warehouse/warehouse-page.component.html
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.html
@@ -79,7 +79,6 @@
       <app-supply-controls
         [activeTab]="activeTab()"
         (activeTabChange)="selectTab($event)"
-        (createSupply)="openCreateDialog()"
       ></app-supply-controls>
     </section>
 


### PR DESCRIPTION
## Summary
- remove the export and “new supply” buttons from the supply controls navigation
- clean up the component outputs and styles that only supported the removed actions
- update the warehouse page to stop listening for the removed creation event

## Testing
- npm run lint *(fails: Angular workspace has no lint target configured)*
- npm test *(fails: ChromeHeadless cannot start because libatk-1.0.so.0 is missing in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dad40891b48323b4e9723aa3a5ea2d