### PR TITLE
Restore legacy catalog logic in warehouse tab

### DIFF
--- a/feedme.client/src/app/components/catalog/catalog.component.css
+++ b/feedme.client/src/app/components/catalog/catalog.component.css
@@ -4,6 +4,28 @@
   gap: 8px;
 }
 
+.catalog-header__action {
+  margin-left: auto;
+  padding: 8px 16px;
+  border: none;
+  border-radius: 6px;
+  background-color: #2563eb;
+  color: #ffffff;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease-in-out;
+}
+
+.catalog-header__action:hover,
+.catalog-header__action:focus-visible {
+  background-color: #1d4ed8;
+}
+
+.catalog-header__action:focus-visible {
+  outline: 2px solid rgba(37, 99, 235, 0.8);
+  outline-offset: 2px;
+}
+
 :host {
   --catalog-focus-ring: rgba(37, 99, 235, 0.4);
   --ring: var(--catalog-focus-ring);
@@ -43,4 +65,33 @@
 }
 .catalog-table tbody tr:nth-child(even) {
   background-color: #f9f9f9;
+}
+
+.catalog-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  margin-top: 24px;
+}
+
+.catalog-empty__action {
+  padding: 10px 18px;
+  border: none;
+  border-radius: 6px;
+  background-color: #2563eb;
+  color: #ffffff;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease-in-out;
+}
+
+.catalog-empty__action:hover,
+.catalog-empty__action:focus-visible {
+  background-color: #1d4ed8;
+}
+
+.catalog-empty__action:focus-visible {
+  outline: 2px solid rgba(37, 99, 235, 0.8);
+  outline-offset: 2px;
 }

--- a/feedme.client/src/app/components/catalog/catalog.component.html
+++ b/feedme.client/src/app/components/catalog/catalog.component.html
@@ -1,80 +1,98 @@
 <div class="catalog-header">
   <input type="text" placeholder="Поиск…" [(ngModel)]="filter" />
   <div class="tabs">
-    <button (click)="activeTab='info'" [class.active]="activeTab==='info'">Основная информация</button>
-    <button (click)="activeTab='logistics'" [class.active]="activeTab==='logistics'">Закупка и логистика</button>
+    <button type="button" (click)="activeTab='info'" [class.active]="activeTab==='info'">Основная информация</button>
+    <button type="button" (click)="activeTab='logistics'" [class.active]="activeTab==='logistics'">Закупка и логистика</button>
   </div>
+  <button type="button" class="catalog-header__action" (click)="openNewProductPopup()">
+    + Новый товар
+  </button>
 </div>
 <div class="error-message" *ngIf="errorMessage">{{ errorMessage }}</div>
 
+<ng-container *ngIf="catalogData$ | async as catalogData">
+  <ng-container *ngIf="catalogData.length; else emptyCatalog">
+    <div *ngIf="activeTab==='info'">
+      <table class="catalog-table">
+        <thead>
+          <tr>
+            <th>Название</th>
+            <th>Тип</th>
+            <th>Код</th>
+            <th>Категория</th>
+            <th>Ед.изм.</th>
+            <th>Вес</th>
+            <th>Метод списания</th>
+            <th>Аллергены</th>
+            <th>Флаги</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr *ngFor="let item of catalogData | filter:filter">
+            <td>{{ item.name }}</td>
+            <td>{{ item.type }}</td>
+            <td>{{ item.code }}</td>
+            <td>{{ item.category }}</td>
+            <td>{{ item.unit }}</td>
+            <td>{{ item.weight }}</td>
+            <td>{{ item.writeoffMethod }}</td>
+            <td>{{ item.allergens }}</td>
+            <td>
+              <div>Требует фасовки: {{ item.packagingRequired | booleanLabel }}</div>
+              <div>Портится после вскрытия: {{ item.spoilsAfterOpening | booleanLabel }}</div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
 
-<div *ngIf="activeTab==='info'">
-  <table class="catalog-table">
-    <thead>
-      <tr>
-        <th>Название</th>
-        <th>Тип</th>
-        <th>Код</th>
-        <th>Категория</th>
-        <th>Ед.изм.</th>
-        <th>Вес</th>
-        <th>Метод списания</th>
-        <th>Аллергены</th>
-        <th>Флаги</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr *ngFor="let item of (catalogData$ | async) | filter:filter">
-        <td>{{ item.name }}</td>
-        <td>{{ item.type }}</td>
-        <td>{{ item.code }}</td>
-        <td>{{ item.category }}</td>
-        <td>{{ item.unit }}</td>
-        <td>{{ item.weight }}</td>
-        <td>{{ item.writeoffMethod }}</td>
-        <td>{{ item.allergens }}</td>
-        <td>
-          <div>Требует фасовки: {{ item.packagingRequired | booleanLabel }}</div>
-          <div>Портится после вскрытия: {{ item.spoilsAfterOpening | booleanLabel }}</div>
-        </td>
-      </tr>
-    </tbody>
-  </table>
-</div>
+    <div *ngIf="activeTab==='logistics'">
+      <table class="catalog-table">
+        <thead>
+          <tr>
+            <th>Поставщик</th>
+            <th>Срок поставки</th>
+            <th>Оценочная себестоимость</th>
+            <th>Ставка НДС</th>
+            <th>Цена за ед.</th>
+            <th>Цена продажи</th>
+            <th>Код ТН ВЭД</th>
+            <th>Маркируемый</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr *ngFor="let item of catalogData | filter:filter">
+            <td>{{ item.supplier }}</td>
+            <td>{{ item.deliveryTime }}</td>
+            <td>{{ item.costEstimate }}</td>
+            <td>{{ item.taxRate }}</td>
+            <td>{{ item.unitPrice }}</td>
+            <td>{{ item.salePrice }}</td>
+            <td>{{ item.tnved }}</td>
+            <td>{{ item.isMarked }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </ng-container>
+</ng-container>
 
-<div *ngIf="activeTab==='logistics'">
-  <table class="catalog-table">
-    <thead>
-      <tr>
-        <th>Поставщик</th>
-        <th>Срок поставки</th>
-        <th>Оценочная себестоимость</th>
-        <th>Ставка НДС</th>
-        <th>Цена за ед.</th>
-        <th>Цена продажи</th>
-        <th>Код ТН ВЭД</th>
-        <th>Маркируемый</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr *ngFor="let item of (catalogData$ | async) | filter:filter">
-        <td>{{ item.supplier }}</td>
-        <td>{{ item.deliveryTime }}</td>
-        <td>{{ item.costEstimate }}</td>
-        <td>{{ item.taxRate }}</td>
-        <td>{{ item.unitPrice }}</td>
-        <td>{{ item.salePrice }}</td>
-        <td>{{ item.tnved }}</td>
-        <td>{{ item.isMarked }}</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
+<ng-template #emptyCatalog>
+  <div class="catalog-empty">
+    <app-empty
+      class="mt-6 block"
+      title="Каталог пока пуст"
+      subtitle="Добавьте первый продукт, чтобы начать работу с каталогом."
+    ></app-empty>
+    <button type="button" class="catalog-empty__action" (click)="openNewProductPopup()">
+      + Новый товар
+    </button>
+  </div>
+</ng-template>
 
-<!-- TODO: toggle by data -->
-<app-empty
-  class="mt-6 block"
-  title="Каталог пока пуст"
-  subtitle="Добавьте первый продукт, чтобы начать работу с каталогом."
-  ctaText="+ Новый продукт"
-></app-empty>
+<app-catalog-new-product-popup
+  *ngIf="showNewProductPopup"
+  [errorMessage]="createErrorMessage"
+  (cancel)="closeNewProductPopup()"
+  (save)="addProduct($event)"
+></app-catalog-new-product-popup>

--- a/feedme.client/src/app/components/catalog/catalog.component.ts
+++ b/feedme.client/src/app/components/catalog/catalog.component.ts
@@ -8,6 +8,7 @@ import { FilterPipe } from '../../pipes/filter.pipe';
 import { NewProductFormValues } from '../catalog-new-product-popup/catalog-new-product-popup.component';
 import { CatalogItem, CatalogService } from '../../services/catalog.service';
 import { EmptyStateComponent } from '../../warehouse/ui/empty-state.component';
+import { CatalogNewProductPopupComponent } from '../catalog-new-product-popup/catalog-new-product-popup.component';
 
 @Pipe({
   name: 'booleanLabel',
@@ -26,7 +27,14 @@ export class BooleanLabelPipe implements PipeTransform {
 @Component({
   selector: 'app-catalog',
   standalone: true,
-  imports: [CommonModule, FormsModule, FilterPipe, BooleanLabelPipe, EmptyStateComponent],
+  imports: [
+    CommonModule,
+    FormsModule,
+    FilterPipe,
+    BooleanLabelPipe,
+    EmptyStateComponent,
+    CatalogNewProductPopupComponent,
+  ],
   templateUrl: './catalog.component.html',
   styleUrls: ['./catalog.component.css']
 })
@@ -35,6 +43,9 @@ export class CatalogComponent implements OnInit {
 
   activeTab: 'info' | 'logistics' = 'info';
   filter = '';
+
+  showNewProductPopup = false;
+  createErrorMessage: string | null = null;
 
   private readonly catalogDataSubject = new BehaviorSubject<CatalogItem[]>([]);
   readonly catalogData$ = this.catalogDataSubject.asObservable();
@@ -54,6 +65,18 @@ export class CatalogComponent implements OnInit {
 
   }
 
+  /** Открывает модальное окно создания товара */
+  openNewProductPopup(): void {
+    this.createErrorMessage = null;
+    this.showNewProductPopup = true;
+  }
+
+  /** Закрывает модальное окно создания товара */
+  closeNewProductPopup(): void {
+    this.showNewProductPopup = false;
+    this.createErrorMessage = null;
+  }
+
   /** Добавляет новый товар в каталог */
   addProduct(item: NewProductFormValues): void {
     this.catalogService
@@ -65,8 +88,10 @@ export class CatalogComponent implements OnInit {
           this.catalogDataSubject.next(updated);
 
           this.errorMessage = null;
+          this.createErrorMessage = null;
+          this.showNewProductPopup = false;
         }),
-        catchError(() => this.handleError('Не удалось сохранить товар. Попробуйте ещё раз.'))
+        catchError(() => this.handleCreateError('Не удалось сохранить товар. Попробуйте ещё раз.'))
       )
       .subscribe();
   }
@@ -75,5 +100,10 @@ export class CatalogComponent implements OnInit {
     this.errorMessage = message;
     return EMPTY;
 
+  }
+
+  private handleCreateError(message: string) {
+    this.createErrorMessage = message;
+    return EMPTY;
   }
 }

--- a/feedme.client/src/app/components/supply-controls/supply-controls.component.html
+++ b/feedme.client/src/app/components/supply-controls/supply-controls.component.html
@@ -17,8 +17,13 @@
     <button type="button" class="btn btn-secondary">
       Экспорт
     </button>
-    <button type="button" class="btn btn-primary" (click)="onCreateSupply()">
-      + Новая поставка
+    <button
+      type="button"
+      class="btn btn-primary"
+      (click)="onPrimaryAction()"
+      [attr.aria-label]="primaryActionAriaLabel"
+    >
+      {{ primaryActionLabel }}
     </button>
   </div>
 </div>

--- a/feedme.client/src/app/components/supply-controls/supply-controls.component.ts
+++ b/feedme.client/src/app/components/supply-controls/supply-controls.component.ts
@@ -19,7 +19,7 @@ type SupplyTab = {
 export class SupplyControlsComponent {
   @Input() activeTab: SupplySection = 'supplies';
   @Output() activeTabChange = new EventEmitter<SupplySection>();
-  @Output() createSupply = new EventEmitter<void>();
+  @Output() primaryAction = new EventEmitter<void>();
 
   readonly tabs: ReadonlyArray<SupplyTab> = [
     { key: 'supplies', label: 'Поставки' },
@@ -27,6 +27,13 @@ export class SupplyControlsComponent {
     { key: 'catalog', label: 'Каталог' },
     { key: 'inventory', label: 'Инвентаризация' },
   ];
+
+  private readonly actionLabels: Record<SupplySection, { label: string; aria: string }> = {
+    supplies: { label: '+ Новая поставка', aria: 'Создать новую поставку' },
+    stock: { label: '+ Новая поставка', aria: 'Создать новую поставку' },
+    catalog: { label: '+ Новый товар', aria: 'Добавить новый товар в каталог' },
+    inventory: { label: '+ Новая поставка', aria: 'Создать новую поставку' },
+  };
 
   onSelect(tab: SupplySection): void {
     if (this.activeTab === tab) {
@@ -36,8 +43,16 @@ export class SupplyControlsComponent {
     this.activeTabChange.emit(tab);
   }
 
-  onCreateSupply(): void {
-    this.createSupply.emit();
+  onPrimaryAction(): void {
+    this.primaryAction.emit();
+  }
+
+  get primaryActionLabel(): string {
+    return this.actionLabels[this.activeTab]?.label ?? this.actionLabels.supplies.label;
+  }
+
+  get primaryActionAriaLabel(): string {
+    return this.actionLabels[this.activeTab]?.aria ?? this.actionLabels.supplies.aria;
   }
 
   trackByTab = (_: number, tab: SupplyTab) => tab.key;

--- a/feedme.client/src/app/warehouse/warehouse-page.component.html
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.html
@@ -79,7 +79,7 @@
       <app-supply-controls
         [activeTab]="activeTab()"
         (activeTabChange)="selectTab($event)"
-        (createSupply)="openCreateDialog()"
+        (primaryAction)="handlePrimaryAction()"
       ></app-supply-controls>
     </section>
 
@@ -327,8 +327,8 @@
       <section *ngIf="activeTab() === 'stock'" class="warehouse-page__empty">
         <app-empty title="Остатки" subtitle="Выберите склад и примените фильтры"></app-empty>
       </section>
-      <section *ngIf="activeTab() === 'catalog'" class="warehouse-page__empty">
-        <app-empty title="Каталог" subtitle="Импортируйте CSV или создайте первую позицию"></app-empty>
+      <section *ngIf="activeTab() === 'catalog'" class="warehouse-page__tab-panel">
+        <app-catalog></app-catalog>
       </section>
       <section *ngIf="activeTab() === 'inventory'" class="warehouse-page__empty">
         <app-empty title="Инвентаризация" subtitle="Создайте обход или запустите экспресс-пересчёт"></app-empty>

--- a/feedme.client/src/app/warehouse/warehouse-page.component.ts
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.ts
@@ -3,6 +3,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   HostListener,
+  ViewChild,
   computed,
   effect,
   inject,
@@ -21,6 +22,7 @@ import { FieldComponent } from './ui/field.component';
 import { StatusBadgeClassPipe } from '../pipes/status-badge-class.pipe';
 import { StatusBadgeLabelPipe } from '../pipes/status-badge-label.pipe';
 import { SupplyControlsComponent } from '../components/supply-controls/supply-controls.component';
+import { CatalogComponent as LegacyCatalogComponent } from '../components/catalog/catalog.component';
 
 const RUB_FORMATTER = new Intl.NumberFormat('ru-RU', {
   style: 'currency',
@@ -51,6 +53,7 @@ type SupplyHistoryEntry = {
     StatusBadgeClassPipe,
     StatusBadgeLabelPipe,
     SupplyControlsComponent,
+    LegacyCatalogComponent,
   ],
   templateUrl: './warehouse-page.component.html',
   styleUrl: './warehouse-page.component.css',
@@ -59,6 +62,9 @@ type SupplyHistoryEntry = {
 export class WarehousePageComponent {
   private readonly warehouseService = inject(WarehouseService);
   private readonly fb = inject(NonNullableFormBuilder);
+
+  @ViewChild(LegacyCatalogComponent)
+  private catalogComponent?: LegacyCatalogComponent;
 
 
   readonly activeTab = signal<'supplies' | 'stock' | 'catalog' | 'inventory'>('supplies');
@@ -231,6 +237,19 @@ export class WarehousePageComponent {
 
   selectTab(tab: WarehouseTab): void {
     this.activeTab.set(tab);
+  }
+
+  handlePrimaryAction(): void {
+    const active = this.activeTab();
+
+    if (active === 'supplies' || active === 'stock' || active === 'inventory') {
+      this.openCreateDialog();
+      return;
+    }
+
+    if (active === 'catalog') {
+      this.catalogComponent?.openNewProductPopup();
+    }
   }
 
   updateStatus(value: string): void {


### PR DESCRIPTION
## Summary
- restore the legacy catalog table component inside the warehouse page catalog tab
- expose the catalog creation modal and wire it to the new warehouse navigation controls
- update supply controls to emit a generic primary action with context-aware labeling

## Testing
- npm test *(fails: ChromeHeadless missing libatk-1.0.so.0 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dad44107848323b6f7c8768f9ab4bc