### PR TITLE
Fix catalog popup bindings and expose popup API

### DIFF
--- a/feedme.client/src/app/components/catalog/catalog.component.html
+++ b/feedme.client/src/app/components/catalog/catalog.component.html
@@ -8,7 +8,7 @@
     + Новый товар
   </button>
 </div>
-<div class="error-message" *ngIf="errorMessage">{{ errorMessage }}</div>
+<div class="error-message" *ngIf="loadErrorMessage() as errorMessage">{{ errorMessage }}</div>
 
 <ng-container *ngIf="catalogData$ | async as catalogData">
   <ng-container *ngIf="catalogData.length; else emptyCatalog">
@@ -91,8 +91,8 @@
 </ng-template>
 
 <app-catalog-new-product-popup
-  *ngIf="showNewProductPopup"
-  [errorMessage]="createErrorMessage"
+  *ngIf="isNewProductPopupVisible()"
+  [errorMessage]="creationErrorMessage()"
   (cancel)="closeNewProductPopup()"
   (save)="addProduct($event)"
 ></app-catalog-new-product-popup>

--- a/feedme.client/src/app/warehouse/catalog/catalog.component.ts
+++ b/feedme.client/src/app/warehouse/catalog/catalog.component.ts
@@ -133,6 +133,14 @@ export class CatalogComponent {
     this.resetForm();
   }
 
+  openNewProductPopup(): void {
+    this.openDialog();
+  }
+
+  closeNewProductPopup(): void {
+    this.closeDialog();
+  }
+
   async submit(): Promise<void> {
     if (this.productForm.invalid) {
       this.productForm.markAllAsTouched();


### PR DESCRIPTION
## Summary
- refactor the legacy catalog component to manage popup visibility and errors with signals under OnPush change detection
- update the catalog template bindings to use the new signal-based state helpers
- add popup open/close aliases to the warehouse catalog component for API parity

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dad98c193c8323a9db8f39dbb4e711