### PR TITLE
Remove bulk action hint from warehouse tab

### DIFF
--- a/feedme.client/src/app/warehouse/warehouse-page.component.css
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.css
@@ -356,11 +356,6 @@
   font-weight: 500;
 }
 
-.warehouse-page__bulk-hint {
-  font-size: 0.875rem;
-  color: #94a3b8;
-}
-
 .warehouse-page__table-card {
   border: 1px solid #e2e8f0;
   border-radius: 12px;

--- a/feedme.client/src/app/warehouse/warehouse-page.component.html
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.html
@@ -156,7 +156,7 @@
           </form>
         </div>
 
-        <section class="warehouse-page__bulk" *ngIf="hasSelection(); else bulkHint" aria-live="polite">
+        <section class="warehouse-page__bulk" *ngIf="hasSelection()" aria-live="polite">
           <span class="warehouse-page__bulk-count">Выбрано: {{ checkedIds().length }}</span>
           <div class="warehouse-page__bulk-actions">
             <button type="button" class="btn btn-outline btn-sm">Списать</button>
@@ -165,9 +165,6 @@
             <button type="button" class="btn btn-danger btn-sm" (click)="openDeleteDialogForSelection()">Удалить</button>
           </div>
         </section>
-        <ng-template #bulkHint>
-          <p class="warehouse-page__bulk-hint">Выберите строки для массовых действий</p>
-        </ng-template>
 
         <section class="warehouse-page__table-card">
           <header class="warehouse-page__table-header">Последние поставки</header>


### PR DESCRIPTION
## Summary
- remove the bulk-action hint paragraph from the warehouse deliveries view so the message no longer appears
- delete the now-unused CSS hook for the removed hint element

## Testing
- npm run lint *(fails: lint target is not configured for this Angular project)*
- npm run test *(fails: ChromeHeadless cannot start because libatk-1.0.so.0 is missing in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68db3596f4148323904b2e13055d5d9c