### PR TITLE
feat: restore catalog supply popup

### DIFF
--- a/feedme.client/src/app/warehouse/ui/create-supply-dialog.component.css
+++ b/feedme.client/src/app/warehouse/ui/create-supply-dialog.component.css
@@ -1,0 +1,176 @@
+:host {
+  display: block;
+  width: min(560px, 100%);
+  border-radius: 16px;
+  background-color: #ffffff;
+  border: 1px solid #e2e8f0;
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.25);
+  padding: 24px;
+}
+
+.create-supply-dialog {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.create-supply-dialog__header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.create-supply-dialog__header h2 {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.create-supply-dialog__subtitle {
+  margin: 0;
+  font-size: 0.9375rem;
+  color: #64748b;
+}
+
+.create-supply-dialog__form {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.create-supply-dialog__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px;
+}
+
+.create-supply-dialog__field {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.create-supply-dialog__label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #94a3b8;
+  font-weight: 600;
+}
+
+.create-supply-dialog__input {
+  width: 100%;
+  padding: 12px;
+  border-radius: 10px;
+  border: 1px solid #d0d5dd;
+  font-size: 0.9375rem;
+  color: #0f172a;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.create-supply-dialog__input:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.1);
+}
+
+.create-supply-dialog__suggestions {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  z-index: 10;
+  margin: 0;
+  padding: 8px 0;
+  list-style: none;
+  background-color: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.15);
+  max-height: 240px;
+  overflow-y: auto;
+  margin-top: 4px;
+}
+
+.create-supply-dialog__suggestions li button {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  width: 100%;
+  padding: 10px 16px;
+  border: none;
+  background: transparent;
+  text-align: left;
+  font-size: 0.9375rem;
+  color: #0f172a;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.create-supply-dialog__suggestions li button:hover,
+.create-supply-dialog__suggestions li button:focus-visible {
+  background-color: #f1f5f9;
+}
+
+.create-supply-dialog__suggestion-name {
+  font-weight: 600;
+}
+
+.create-supply-dialog__suggestion-meta {
+  font-size: 0.8125rem;
+  color: #64748b;
+}
+
+.create-supply-dialog__product {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+  padding: 16px;
+  border-radius: 12px;
+  background-color: #f8fafc;
+  border: 1px solid #e2e8f0;
+}
+
+.create-supply-dialog__product-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.create-supply-dialog__product-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #94a3b8;
+  font-weight: 600;
+}
+
+.create-supply-dialog__product-value {
+  font-size: 0.9375rem;
+  color: #0f172a;
+}
+
+.create-supply-dialog__error {
+  margin: 0;
+  font-size: 0.75rem;
+  color: #dc2626;
+}
+
+.create-supply-dialog__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+@media (max-width: 640px) {
+  :host {
+    padding: 20px;
+  }
+
+  .create-supply-dialog__suggestions {
+    position: static;
+    max-height: none;
+  }
+}

--- a/feedme.client/src/app/warehouse/ui/create-supply-dialog.component.html
+++ b/feedme.client/src/app/warehouse/ui/create-supply-dialog.component.html
@@ -1,0 +1,96 @@
+<section
+  class="create-supply-dialog"
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby="create-supply-title"
+>
+  <header class="create-supply-dialog__header">
+    <h2 id="create-supply-title">Новая поставка</h2>
+    <p class="create-supply-dialog__subtitle">
+      Выберите товар из каталога, укажите количество и даты поставки.
+    </p>
+  </header>
+
+  <form class="create-supply-dialog__form" [formGroup]="form" (ngSubmit)="submit()">
+    <div class="create-supply-dialog__field">
+      <label class="create-supply-dialog__label" for="create-supply-product">Товар</label>
+      <input
+        id="create-supply-product"
+        type="search"
+        class="create-supply-dialog__input"
+        formControlName="productQuery"
+        autocomplete="off"
+        placeholder="Начните вводить название или SKU"
+      />
+      <ul
+        class="create-supply-dialog__suggestions"
+        *ngIf="suggestions().length > 0"
+      >
+        <li *ngFor="let product of suggestions(); trackBy: trackByProduct">
+          <button type="button" (click)="selectProduct(product)">
+            <span class="create-supply-dialog__suggestion-name">{{ product.name }}</span>
+            <span class="create-supply-dialog__suggestion-meta">SKU {{ product.sku }}</span>
+          </button>
+        </li>
+      </ul>
+      <p class="create-supply-dialog__error" *ngIf="form.controls.productId.invalid && form.controls.productId.touched">
+        Выберите товар из списка.
+      </p>
+    </div>
+
+    <div class="create-supply-dialog__product" *ngIf="selectedProduct() as product">
+      <div class="create-supply-dialog__product-row">
+        <span class="create-supply-dialog__product-label">Поставщик</span>
+        <span class="create-supply-dialog__product-value">{{ product.supplierMain || 'Не указан' }}</span>
+      </div>
+      <div class="create-supply-dialog__product-row">
+        <span class="create-supply-dialog__product-label">Категория</span>
+        <span class="create-supply-dialog__product-value">{{ product.category }}</span>
+      </div>
+      <div class="create-supply-dialog__product-row">
+        <span class="create-supply-dialog__product-label">Ед. изм.</span>
+        <span class="create-supply-dialog__product-value">{{ product.unit }}</span>
+      </div>
+    </div>
+
+    <div class="create-supply-dialog__grid">
+      <label class="create-supply-dialog__field">
+        <span class="create-supply-dialog__label">Количество</span>
+        <input
+          type="number"
+          min="0"
+          step="0.001"
+          formControlName="quantity"
+          class="create-supply-dialog__input"
+        />
+        <p class="create-supply-dialog__error" *ngIf="form.controls.quantity.invalid && form.controls.quantity.touched">
+          Укажите количество больше нуля.
+        </p>
+      </label>
+
+      <label class="create-supply-dialog__field">
+        <span class="create-supply-dialog__label">Дата прихода</span>
+        <input type="date" formControlName="arrivalDate" class="create-supply-dialog__input" />
+        <p class="create-supply-dialog__error" *ngIf="form.controls.arrivalDate.invalid && form.controls.arrivalDate.touched">
+          Укажите дату прихода.
+        </p>
+      </label>
+
+      <label class="create-supply-dialog__field">
+        <span class="create-supply-dialog__label">Срок годности</span>
+        <input type="date" formControlName="expiryDate" class="create-supply-dialog__input" />
+        <p class="create-supply-dialog__error" *ngIf="form.controls.expiryDate.errors?.['dateOrder']">
+          Срок годности не может быть раньше даты прихода.
+        </p>
+        <p class="create-supply-dialog__error" *ngIf="form.controls.expiryDate.invalid && !form.controls.expiryDate.errors?.['dateOrder'] && form.controls.expiryDate.touched">
+          Укажите срок годности.
+        </p>
+      </label>
+    </div>
+
+    <footer class="create-supply-dialog__actions">
+      <button type="button" class="btn btn-outline" (click)="close()">Отмена</button>
+      <button type="submit" class="btn" [disabled]="form.invalid">Добавить</button>
+    </footer>
+  </form>
+</section>

--- a/feedme.client/src/app/warehouse/ui/create-supply-dialog.component.ts
+++ b/feedme.client/src/app/warehouse/ui/create-supply-dialog.component.ts
@@ -1,0 +1,185 @@
+import { CommonModule } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Output,
+  computed,
+  inject,
+} from '@angular/core';
+import {
+  NonNullableFormBuilder,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
+import { startWith } from 'rxjs';
+
+import { WarehouseCatalogService } from '../catalog/catalog.service';
+import { Product } from '../shared/models';
+
+export interface CreateSupplyDialogResult {
+  readonly product: Product;
+  readonly quantity: number;
+  readonly arrivalDate: string;
+  readonly expiryDate: string;
+}
+
+@Component({
+  selector: 'app-create-supply-dialog',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  templateUrl: './create-supply-dialog.component.html',
+  styleUrl: './create-supply-dialog.component.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CreateSupplyDialogComponent {
+  @Output() cancel = new EventEmitter<void>();
+  @Output() create = new EventEmitter<CreateSupplyDialogResult>();
+
+  private readonly catalogService = inject(WarehouseCatalogService);
+  private readonly fb = inject(NonNullableFormBuilder);
+
+  private static readonly maxSuggestions = 8;
+
+  readonly form = this.fb.group({
+    productQuery: this.fb.control('', { validators: [Validators.required] }),
+    productId: this.fb.control('', { validators: [Validators.required] }),
+    quantity: this.fb.control(1, {
+      validators: [Validators.required, Validators.min(0.001)],
+    }),
+    arrivalDate: this.fb.control(this.formatDate(new Date()), {
+      validators: [Validators.required],
+    }),
+    expiryDate: this.fb.control('', { validators: [Validators.required] }),
+  });
+
+  readonly products = toSignal(this.catalogService.getAll(), {
+    initialValue: [] as Product[],
+  });
+
+  private readonly productQuery = toSignal(
+    this.form.controls.productQuery.valueChanges.pipe(
+      startWith(this.form.controls.productQuery.value),
+    ),
+    { initialValue: this.form.controls.productQuery.value },
+  );
+
+  private readonly selectedProductId = toSignal(
+    this.form.controls.productId.valueChanges.pipe(
+      startWith(this.form.controls.productId.value),
+    ),
+    { initialValue: this.form.controls.productId.value },
+  );
+
+  readonly selectedProduct = computed<Product | null>(() => {
+    const id = this.selectedProductId();
+    if (!id) {
+      return null;
+    }
+
+    return this.products().find((item) => item.id === id) ?? null;
+  });
+
+  readonly suggestions = computed(() => {
+    const query = this.normalizeQuery(this.productQuery());
+    if (!query) {
+      return [] as Product[];
+    }
+
+    const selected = this.selectedProduct();
+    const all = this.products();
+
+    return all
+      .filter((product) =>
+        this.matchesQuery(product, query) &&
+        (!selected || selected.id !== product.id || query !== selected.name.toLowerCase()),
+      )
+      .slice(0, CreateSupplyDialogComponent.maxSuggestions);
+  });
+
+  constructor() {
+    this.form.controls.productQuery.valueChanges
+      .pipe(takeUntilDestroyed())
+      .subscribe((value: string) => {
+        const selected = this.selectedProduct();
+        if (!selected) {
+          return;
+        }
+
+        const query = this.normalizeQuery(value);
+        if (!query || query !== selected.name.toLowerCase()) {
+          this.form.controls.productId.setValue('', { emitEvent: false });
+        }
+      });
+  }
+
+  selectProduct(product: Product): void {
+    this.form.controls.productId.setValue(product.id);
+    this.form.controls.productQuery.setValue(product.name);
+  }
+
+  submit(): void {
+    this.form.markAllAsTouched();
+
+    const selected = this.selectedProduct();
+    if (!selected) {
+      this.form.controls.productId.setErrors({ required: true });
+      return;
+    }
+
+    const arrival = this.form.controls.arrivalDate.value;
+    const expiry = this.form.controls.expiryDate.value;
+
+    if (arrival && expiry && arrival > expiry) {
+      this.form.controls.expiryDate.setErrors({ dateOrder: true });
+      return;
+    }
+
+    if (this.form.invalid) {
+      return;
+    }
+
+    const quantity = Number(this.form.controls.quantity.value);
+    if (!Number.isFinite(quantity) || quantity <= 0) {
+      this.form.controls.quantity.setErrors({ min: true });
+      return;
+    }
+
+    this.create.emit({
+      product: selected,
+      quantity,
+      arrivalDate: arrival!,
+      expiryDate: expiry!,
+    });
+  }
+
+  close(): void {
+    this.cancel.emit();
+  }
+
+  trackByProduct = (_: number, product: Product) => product.id;
+
+  private normalizeQuery(value: string | null): string {
+    return (value ?? '').trim().toLowerCase();
+  }
+
+  private matchesQuery(product: Product, query: string): boolean {
+    if (!query) {
+      return false;
+    }
+
+    const haystack = `${product.name} ${product.sku} ${product.category}`.toLowerCase();
+    return query
+      .split(/\s+/)
+      .filter(Boolean)
+      .every((token) => haystack.includes(token));
+  }
+
+  private formatDate(date: Date): string {
+    const year = date.getFullYear();
+    const month = `${date.getMonth() + 1}`.padStart(2, '0');
+    const day = `${date.getDate()}`.padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  }
+}

--- a/feedme.client/src/app/warehouse/warehouse-page.component.html
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.html
@@ -366,6 +366,13 @@
     </section>
   </aside>
 
+  <div class="warehouse-page__dialog-backdrop" *ngIf="createDialogOpen()">
+    <app-create-supply-dialog
+      (cancel)="closeCreateDialog()"
+      (create)="handleCreateSupply($event)"
+    ></app-create-supply-dialog>
+  </div>
+
   <div class="warehouse-page__dialog-backdrop" *ngIf="editDialogOpen()">
     <section class="warehouse-page__dialog" role="dialog" aria-modal="true" aria-labelledby="edit-supply-title">
       <header class="warehouse-page__dialog-header" id="edit-supply-title">


### PR DESCRIPTION
## Summary
- add a standalone create-supply dialog that searches the catalog and collects quantity and dates only
- wire the warehouse page to open the legacy-style popup, generate document numbers, and map expiry-based statuses
- extend warehouse page specs with catalog stubs and new popup behaviour coverage

## Testing
- npm test *(fails: ChromeHeadless cannot start because libatk-1.0.so.0 is missing in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68db378569ec8323b1ea1bf045a53138