### PR TITLE
Ensure newest supplies appear first in last supplies table

### DIFF
--- a/feedme.client/src/app/warehouse/warehouse-page.component.spec.ts
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.spec.ts
@@ -291,6 +291,10 @@ describe('WarehousePageComponent', () => {
     expect(created.warehouse).toBe('Главный склад');
     expect(created.status).toBe('ok');
     expect(component.createDialogOpen()).toBe(false);
+
+    fixture.detectChanges();
+    const tableRows = getTableRows(fixture.nativeElement);
+    expect(tableRows[0].textContent).toContain('PO-000856');
   });
 
   it('shows row sum calculated from qty and price', () => {


### PR DESCRIPTION
## Summary
- sort filtered warehouse supplies by arrival date and document number so freshly added deliveries surface in the "Последние поставки" table
- extend the warehouse page unit test to confirm a created delivery is rendered at the top of the list

## Testing
- npm test -- --watch=false *(fails: ChromeHeadless cannot start because libatk-1.0.so.0 is missing in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dba72ebddc83239d3fe3127a612aee