### PR TITLE
Fix supply creation to persist within current warehouse view

### DIFF
--- a/feedme.client/src/app/components/content/content.component.html
+++ b/feedme.client/src/app/components/content/content.component.html
@@ -1,9 +1,10 @@
 <div class="content">
-  <app-warehouse-tabs [selectedTab]="selectedTab"
-                      (selectedTabChange)="setSelectedTab($event)">
+  <app-warehouse-tabs [selectedWarehouse]="selectedWarehouse"
+                      (selectedWarehouseChange)="setSelectedWarehouse($event)">
   </app-warehouse-tabs>
 
-  <app-supply-controls [(selectedSupply)]="selectedSupply"
+  <app-supply-controls [selectedSupply]="selectedSupply"
+                       (selectedSupplyChange)="onSupplyChange($event)"
                        (openPopup)="openPopup()"
                        (goToCatalog)="goToCatalog()">
   </app-supply-controls>

--- a/feedme.client/src/app/components/content/content.component.ts
+++ b/feedme.client/src/app/components/content/content.component.ts
@@ -8,6 +8,8 @@ import { InfoCardsWrapperComponent } from '../info-cards-wrapper/info-cards-wrap
 import { CatalogComponent } from '../catalog/catalog.component';
 import { WarehouseTableComponent } from '../warehouse-table/warehouse-table.component';
 import { PopupComponent } from '../popup/popup.component';
+import { SupplyItem } from '../../models/supply-item.model';
+import { SupplyView, WarehouseSuppliesService } from '../../services/warehouse-supplies.service';
 
 @Component({
   selector: 'app-content',
@@ -26,28 +28,35 @@ import { PopupComponent } from '../popup/popup.component';
   styleUrls: ['./content.component.css']
 })
 export class ContentComponent implements OnInit {
-  selectedTab: string = 'Главный склад';
-  selectedSupply: string = 'supplies';
-  tableData: any[] = [];
-  selectedItem: any = null;
+  selectedWarehouse: string = 'Главный склад';
+  selectedSupply: SupplyView = 'supplies';
+  tableData: SupplyItem[] = [];
+  selectedItem: SupplyItem | null = null;
   showPopup: boolean = false;
 
-  ngOnInit() {
-    const initialData = localStorage.getItem(`warehouseData_${this.selectedTab}`);
-    this.tableData = initialData ? JSON.parse(initialData) : [];
-  }
+  constructor(private readonly warehouseSuppliesService: WarehouseSuppliesService) {}
 
-  setSelectedTab(tab: string) {
-    this.selectedTab = tab;
+  ngOnInit() {
     this.loadTableData();
   }
 
-  loadTableData() {
-    const data = localStorage.getItem(`warehouseData_${this.selectedTab}`);
-    this.tableData = data ? JSON.parse(data) : [];
+  setSelectedWarehouse(warehouse: string) {
+    this.selectedWarehouse = warehouse;
+    this.loadTableData();
   }
 
-  handleSettingsClick(item: any) {
+  onSupplyChange(view: SupplyView) {
+    this.selectedSupply = view;
+    if (view !== 'catalog') {
+      this.loadTableData();
+    }
+  }
+
+  private loadTableData() {
+    this.tableData = this.warehouseSuppliesService.loadSupplies(this.selectedWarehouse);
+  }
+
+  handleSettingsClick(item: SupplyItem) {
     this.selectedItem = item;
   }
 
@@ -60,20 +69,15 @@ export class ContentComponent implements OnInit {
   }
 
   goToCatalog() {
-    this.selectedTab = 'Каталог';
+    this.onSupplyChange('catalog');
   }
 
   closeInfoCards() {
     this.selectedItem = null;
   }
 
-  onAddItem(item: any) {
-    const updatedData = [...this.tableData, item];
-    this.tableData = updatedData;
-    localStorage.setItem(
-      `warehouseData_${this.selectedTab}`,
-      JSON.stringify(updatedData)
-    );
+  onAddItem(item: SupplyItem) {
+    this.tableData = this.warehouseSuppliesService.addSupply(this.selectedWarehouse, item);
     this.closePopup();
   }
 }

--- a/feedme.client/src/app/components/popup/popup.component.ts
+++ b/feedme.client/src/app/components/popup/popup.component.ts
@@ -2,6 +2,7 @@ import { Component, Output, EventEmitter, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { CatalogItem } from '../../models/catalog-item.model';
+import { SupplyItem } from '../../models/supply-item.model';
 import { normalizeCatalogItem, sanitizeNumericValue } from '../../utils/catalog.utils';
 
 @Component({
@@ -13,7 +14,7 @@ import { normalizeCatalogItem, sanitizeNumericValue } from '../../utils/catalog.
 })
 export class PopupComponent implements OnInit {
   @Output() onClose = new EventEmitter<void>();
-  @Output() onAddItem = new EventEmitter<any>();
+  @Output() onAddItem = new EventEmitter<SupplyItem>();
 
   name = '';
   category = '';
@@ -80,7 +81,7 @@ export class PopupComponent implements OnInit {
 
     const id = Date.now().toString();
 
-    const newItem = {
+    const newItem: SupplyItem = {
       id,
       name: this.name,
       category: this.category,

--- a/feedme.client/src/app/components/supply-controls/supply-controls.component.html
+++ b/feedme.client/src/app/components/supply-controls/supply-controls.component.html
@@ -15,7 +15,9 @@
     <span>Добавить товар</span>
   </button>
 
-  <div class="item catalog-button" (click)="handleGoToCatalog()">
+  <div class="item catalog-button"
+       [class.selected]="selectedSupply === 'catalog'"
+       (click)="handleGoToCatalog()">
     <img src="assets/catalog.svg" alt="Каталог" class="item-icon">
     <span>Каталог</span>
   </div>

--- a/feedme.client/src/app/components/supply-controls/supply-controls.component.ts
+++ b/feedme.client/src/app/components/supply-controls/supply-controls.component.ts
@@ -1,6 +1,8 @@
 import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
+import { SupplyView } from '../../services/warehouse-supplies.service';
+
 @Component({
   selector: 'app-supply-controls',
   standalone: true,
@@ -9,13 +11,13 @@ import { CommonModule } from '@angular/common';
   styleUrls: ['./supply-controls.component.css']
 })
 export class SupplyControlsComponent {
-  @Input() selectedSupply: string = 'supplies';
-  @Output() selectedSupplyChange = new EventEmitter<string>();
+  @Input() selectedSupply: SupplyView = 'supplies';
+  @Output() selectedSupplyChange = new EventEmitter<SupplyView>();
 
   @Output() openPopup = new EventEmitter<void>();
   @Output() goToCatalog = new EventEmitter<void>();
 
-  setSupplyType(type: string) {
+  setSupplyType(type: SupplyView) {
     this.selectedSupply = type;
     this.selectedSupplyChange.emit(this.selectedSupply);
   }
@@ -25,6 +27,8 @@ export class SupplyControlsComponent {
   }
 
   handleGoToCatalog() {
+    this.selectedSupply = 'catalog';
+    this.selectedSupplyChange.emit(this.selectedSupply);
     this.goToCatalog.emit();
   }
 }

--- a/feedme.client/src/app/components/warehouse-table/warehouse-table.component.ts
+++ b/feedme.client/src/app/components/warehouse-table/warehouse-table.component.ts
@@ -1,6 +1,8 @@
 import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
+import { SupplyItem } from '../../models/supply-item.model';
+
 @Component({
   selector: 'app-warehouse-table',
   standalone: true,
@@ -9,12 +11,12 @@ import { CommonModule } from '@angular/common';
   styleUrls: ['./warehouse-table.component.css']
 })
 export class WarehouseTableComponent {
-  @Input() data: any[] = [];
+  @Input() data: SupplyItem[] = [];
 
-  @Output() onSettingsClick = new EventEmitter<any>();
-  @Output() onEditStockClick = new EventEmitter<{ index: number, stock: number }>();
+  @Output() onSettingsClick = new EventEmitter<SupplyItem>();
+  @Output() onEditStockClick = new EventEmitter<{ index: number; stock: number }>();
 
-  handleSettingsClick(item: any, event: MouseEvent) {
+  handleSettingsClick(item: SupplyItem, event: MouseEvent) {
     event.stopPropagation();
     this.onSettingsClick.emit(item);
   }

--- a/feedme.client/src/app/components/warehouse-tabs/warehouse-tabs.component.html
+++ b/feedme.client/src/app/components/warehouse-tabs/warehouse-tabs.component.html
@@ -1,7 +1,7 @@
 <div class="container warehouse-tabs">
   <div *ngFor="let warehouse of warehouses"
        class="item"
-       [class.selected]="selectedTab === warehouse"
+       [class.selected]="selectedWarehouse === warehouse"
        (click)="selectTab(warehouse)">
     <img src="assets/sklad.svg" alt="{{ warehouse }}">
     <span>{{ warehouse }}</span>

--- a/feedme.client/src/app/components/warehouse-tabs/warehouse-tabs.component.ts
+++ b/feedme.client/src/app/components/warehouse-tabs/warehouse-tabs.component.ts
@@ -14,8 +14,8 @@ export class WarehouseTabsComponent implements OnInit {
   showNewWarehousePopup = false;
   newWarehouseName = '';
 
-  @Input() selectedTab: string = 'Главный склад';
-  @Output() selectedTabChange = new EventEmitter<string>();
+  @Input() selectedWarehouse: string = 'Главный склад';
+  @Output() selectedWarehouseChange = new EventEmitter<string>();
 
   ngOnInit() {
     const savedWarehouses = localStorage.getItem('warehouses');
@@ -23,8 +23,8 @@ export class WarehouseTabsComponent implements OnInit {
   }
 
   selectTab(tab: string) {
-    this.selectedTab = tab;
-    this.selectedTabChange.emit(this.selectedTab);
+    this.selectedWarehouse = tab;
+    this.selectedWarehouseChange.emit(this.selectedWarehouse);
   }
 
   handleAddWarehouse() {
@@ -60,7 +60,7 @@ export class WarehouseTabsComponent implements OnInit {
       localStorage.setItem('warehouses', JSON.stringify(this.warehouses));
       localStorage.removeItem(`warehouseData_${name}`);
 
-      if (this.selectedTab === name) {
+      if (this.selectedWarehouse === name) {
         this.selectTab('Главный склад');
       }
     }

--- a/feedme.client/src/app/models/supply-item.model.ts
+++ b/feedme.client/src/app/models/supply-item.model.ts
@@ -1,0 +1,10 @@
+export interface SupplyItem {
+  id: string;
+  name: string;
+  category: string;
+  stock: number;
+  unitPrice: number;
+  expiryDate: string;
+  supplyDate: string;
+  totalCost: number;
+}

--- a/feedme.client/src/app/services/warehouse-supplies.service.ts
+++ b/feedme.client/src/app/services/warehouse-supplies.service.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@angular/core';
+
+import { SupplyItem } from '../models/supply-item.model';
+
+export type SupplyView = 'supplies' | 'stock' | 'catalog';
+
+@Injectable({ providedIn: 'root' })
+export class WarehouseSuppliesService {
+  private readonly storagePrefix = 'warehouseData_';
+
+  loadSupplies(warehouse: string): SupplyItem[] {
+    const raw = localStorage.getItem(this.composeKey(warehouse));
+    if (!raw) {
+      return [];
+    }
+
+    try {
+      const parsed: SupplyItem[] = JSON.parse(raw);
+      return parsed.map(item => ({ ...item }));
+    } catch {
+      return [];
+    }
+  }
+
+  addSupply(warehouse: string, supply: SupplyItem): SupplyItem[] {
+    const current = this.loadSupplies(warehouse);
+    const updated = [supply, ...current];
+    this.persist(warehouse, updated);
+    return updated;
+  }
+
+  persist(warehouse: string, supplies: SupplyItem[]): void {
+    localStorage.setItem(this.composeKey(warehouse), JSON.stringify(supplies));
+  }
+
+  private composeKey(warehouse: string): string {
+    return `${this.storagePrefix}${warehouse}`;
+  }
+}


### PR DESCRIPTION
## Summary
- introduce a typed supply model and WarehouseSuppliesService to manage warehouse scoped deliveries
- update the content flow to track the active warehouse separately from the catalog view and reload supplies via the service
- adjust supply controls and warehouse table components to use the new types and highlight the active catalog view

## Testing
- CI=true npm run build
- npm run lint *(fails: lint target not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68dba593f7088323be212d96d898db6f