### PR TITLE
Restyle new supply popup to match new design

### DIFF
--- a/feedme.client/src/app/components/add-receipt-popup/add-receipt-popup.component.css
+++ b/feedme.client/src/app/components/add-receipt-popup/add-receipt-popup.component.css
@@ -1,38 +1,230 @@
-.popup-backdrop {
-  /* затемнённый фон */
+:host {
+  display: contents;
 }
-.popup-content {
-  width: 480px;
+
+/* ===== Modal (Новая поставка) — nd- namespace ===== */
+.nd-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(17, 24, 39, 0.35);
+  backdrop-filter: blur(2px);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  z-index: 1000;
+}
+
+.nd-backdrop.is-open {
+  display: flex;
+}
+
+.nd-modal {
+  position: relative;
+  inset: auto 50% 10% 50%;
+  transform: translate(-50%, 0);
+  width: 560px;
+  max-width: calc(100% - 32px);
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04), 0 12px 30px rgba(0, 0, 0, 0.14);
+  display: none;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.nd-modal.is-open {
+  display: flex;
+}
+
+.nd-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  padding: 18px 20px 8px;
+}
+
+.nd-title {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 800;
+  color: var(--text);
+}
+
+.nd-sub {
+  margin: 6px 0 0;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+.nd-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 0.95rem;
+  border-radius: 12px;
+  border: 1px solid transparent;
   background: #fff;
-  border-radius: 8px;
-  padding: 24px;
+  cursor: pointer;
+  font-weight: 700;
+  font-size: 14px;
+  transition: background-color 0.15s ease, filter 0.15s ease;
 }
-.popup-content h2 {
-  margin-bottom: 16px;
-  text-align: center;
+
+.nd-btn:focus {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(43, 113, 211, 0.18);
 }
-label {
+
+.nd-btn-quiet {
+  background: transparent;
+  border-color: transparent;
+  padding: 0.25rem 0.5rem;
+}
+
+.nd-btn-outline {
+  border-color: #ffb892;
+  color: #c2410c;
+  background: #fff;
+}
+
+.nd-btn-outline:hover {
+  background: #fff8f3;
+}
+
+.nd-btn-primary {
+  background: var(--orange);
+  color: #fff;
+}
+
+.nd-btn-primary:hover {
+  filter: brightness(0.98);
+}
+
+.nd-body {
+  padding: 6px 20px 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.nd-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.nd-label {
   display: block;
-  margin-top: 12px;
-  font-weight: 500;
+  font-size: 11px;
+  letter-spacing: 0.02em;
+  color: var(--muted);
+  text-transform: uppercase;
 }
-input,
-select {
+
+.nd-input-wrap {
+  position: relative;
+}
+
+.nd-input {
   width: 100%;
-  padding: 8px;
-  margin-top: 4px;
-  box-sizing: border-box;
+  height: 42px;
+  padding: 0 42px 0 14px;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: #fff;
+  color: var(--text);
+  font-size: 15px;
+  transition: box-shadow 0.15s ease, border-color 0.15s ease;
+  appearance: none;
 }
-.popup-buttons {
+
+.nd-input::placeholder {
+  color: #9aa3af;
+}
+
+.nd-input:focus {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(43, 113, 211, 0.18);
+  border-color: rgba(43, 113, 211, 0.32);
+}
+
+.nd-input:disabled {
+  background: #f9fafb;
+  color: #6b7280;
+  cursor: not-allowed;
+}
+
+.nd-grid-2 {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: 1fr 1fr;
+}
+
+.nd-with-icon .nd-input {
+  padding-right: 44px;
+}
+
+.nd-with-icon .nd-ico {
+  position: absolute;
+  right: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 18px;
+  height: 18px;
+  opacity: 0.6;
+}
+
+.nd-ico-search {
+  mask: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="%23000" d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/></svg>') center/contain no-repeat;
+  background: #6b7280;
+}
+
+.nd-ico-calendar {
+  mask: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="%23000" d="M7 2h2v2h6V2h2v2h3v18H4V4h3V2zm13 6H6v12h14V8z"/></svg>') center/contain no-repeat;
+  background: #6b7280;
+}
+
+.nd-ico-close {
+  mask: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="%23000" d="M18.3 5.71 12 12l6.3 6.29-1.41 1.42L10.59 13.4 4.3 19.71 2.89 18.3 9.17 12 2.89 5.71 4.3 4.29l6.29 6.3 6.3-6.3z"/></svg>') center/contain no-repeat;
+  background: #6b7280;
+  width: 18px;
+  height: 18px;
+}
+
+.nd-meta-grid {
+  margin-top: 4px;
+}
+
+.nd-foot {
   display: flex;
   justify-content: flex-end;
-  gap: 12px;
-  margin-top: 24px;
+  gap: 10px;
+  padding: 14px 20px 18px;
+  border-top: 1px solid var(--line);
+  margin-top: 8px;
 }
-.cancel-btn {
-  background: #ccc;
-}
-.save-btn {
-  background: #007bff;
-  color: #fff;
+
+@media (max-width: 600px) {
+  .nd-modal {
+    width: 100%;
+    inset: auto;
+    transform: none;
+  }
+
+  .nd-grid-2 {
+    grid-template-columns: 1fr;
+  }
+
+  .nd-foot {
+    flex-direction: column-reverse;
+    align-items: stretch;
+  }
+
+  .nd-btn {
+    justify-content: center;
+    width: 100%;
+  }
 }

--- a/feedme.client/src/app/components/add-receipt-popup/add-receipt-popup.component.html
+++ b/feedme.client/src/app/components/add-receipt-popup/add-receipt-popup.component.html
@@ -1,55 +1,219 @@
-<div class="popup-backdrop">
-  <div class="popup-content">
-    <h2>Новая поставка</h2>
-    <form [formGroup]="form" (ngSubmit)="onSubmit()">
+<div class="nd-backdrop is-open" (click)="onClose()">
+  <div
+    class="nd-modal is-open"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="add-receipt-title"
+    aria-describedby="add-receipt-description"
+    (click)="$event.stopPropagation()"
+  >
+    <div class="nd-head">
+      <div>
+        <h2 id="add-receipt-title" class="nd-title">Новая поставка</h2>
+        <p id="add-receipt-description" class="nd-sub">
+          Выберите товар из каталога, укажите количество и даты поставки.
+        </p>
+      </div>
+      <button
+        type="button"
+        class="nd-btn nd-btn-quiet"
+        aria-label="Закрыть диалог"
+        (click)="onClose()"
+      >
+        <span aria-hidden="true" class="nd-ico nd-ico-close"></span>
+      </button>
+    </div>
 
-      <label>Товар</label>
-      <select formControlName="productId">
-        <option value="">— Выберите —</option>
-        <option *ngFor="let p of catalog" [value]="p.id">{{ p.name }}</option>
-      </select>
+    <form class="nd-body" [formGroup]="form" (ngSubmit)="onSubmit()">
+      <div class="nd-field nd-with-icon">
+        <label class="nd-label" for="add-receipt-product">Товар</label>
+        <div class="nd-input-wrap">
+          <select id="add-receipt-product" class="nd-input" formControlName="productId">
+            <option value="">Начните вводить название или SKU</option>
+            <option *ngFor="let item of catalog" [value]="item.id">
+              {{ item.name }} · {{ item.code }}
+            </option>
+          </select>
+          <span aria-hidden="true" class="nd-ico nd-ico-search"></span>
+        </div>
+      </div>
 
-      <label>Поставщик</label>
-      <input formControlName="supplier" disabled />
+      <div class="nd-grid-2">
+        <div class="nd-field">
+          <label class="nd-label" for="add-receipt-quantity">Количество</label>
+          <div class="nd-input-wrap">
+            <input
+              id="add-receipt-quantity"
+              type="number"
+              class="nd-input"
+              formControlName="quantity"
+              min="0"
+              step="0.01"
+              inputmode="decimal"
+            />
+          </div>
+        </div>
+        <div class="nd-field nd-with-icon">
+          <label class="nd-label" for="add-receipt-received-at">Дата прихода</label>
+          <div class="nd-input-wrap">
+            <input
+              id="add-receipt-received-at"
+              type="date"
+              class="nd-input"
+              formControlName="receivedAt"
+            />
+            <span aria-hidden="true" class="nd-ico nd-ico-calendar"></span>
+          </div>
+        </div>
+      </div>
 
-      <label>Код ТН ВЭД</label>
-      <input formControlName="tnvedCode" disabled />
+      <div class="nd-grid-2">
+        <div class="nd-field">
+          <label class="nd-label" for="add-receipt-warehouse">Склад</label>
+          <div class="nd-input-wrap">
+            <input
+              id="add-receipt-warehouse"
+              type="text"
+              class="nd-input"
+              formControlName="warehouse"
+              autocomplete="off"
+            />
+          </div>
+        </div>
+        <div class="nd-field">
+          <label class="nd-label" for="add-receipt-number">Номер документа</label>
+          <div class="nd-input-wrap">
+            <input
+              id="add-receipt-number"
+              type="text"
+              class="nd-input"
+              formControlName="number"
+              autocomplete="off"
+            />
+          </div>
+        </div>
+      </div>
 
-      <label>Метод списания</label>
-      <input formControlName="writeoffMethod" disabled />
+      <div class="nd-grid-2">
+        <div class="nd-field">
+          <label class="nd-label" for="add-receipt-unit">Единица измерения</label>
+          <div class="nd-input-wrap">
+            <select id="add-receipt-unit" class="nd-input" formControlName="unit">
+              <option *ngFor="let u of units" [value]="u">{{ u }}</option>
+            </select>
+          </div>
+        </div>
+        <div class="nd-field nd-with-icon">
+          <label class="nd-label" for="add-receipt-expiry">Срок годности</label>
+          <div class="nd-input-wrap">
+            <input
+              id="add-receipt-expiry"
+              type="date"
+              class="nd-input"
+              formControlName="expiryDate"
+            />
+            <span aria-hidden="true" class="nd-ico nd-ico-calendar"></span>
+          </div>
+        </div>
+      </div>
 
-      <label>Цена закупки за единицу</label>
-      <input formControlName="unitPrice" disabled />
+      <div class="nd-grid-2 nd-meta-grid">
+        <div class="nd-field">
+          <label class="nd-label" for="add-receipt-supplier">Поставщик</label>
+          <div class="nd-input-wrap">
+            <input
+              id="add-receipt-supplier"
+              type="text"
+              class="nd-input"
+              formControlName="supplier"
+              disabled
+              tabindex="-1"
+            />
+          </div>
+        </div>
+        <div class="nd-field">
+          <label class="nd-label" for="add-receipt-tnved">Код ТН ВЭД</label>
+          <div class="nd-input-wrap">
+            <input
+              id="add-receipt-tnved"
+              type="text"
+              class="nd-input"
+              formControlName="tnvedCode"
+              disabled
+              tabindex="-1"
+            />
+          </div>
+        </div>
+      </div>
 
-      <label>Склад</label>
-      <input type="text" formControlName="warehouse" />
+      <div class="nd-grid-2 nd-meta-grid">
+        <div class="nd-field">
+          <label class="nd-label" for="add-receipt-writeoff">Метод списания</label>
+          <div class="nd-input-wrap">
+            <input
+              id="add-receipt-writeoff"
+              type="text"
+              class="nd-input"
+              formControlName="writeoffMethod"
+              disabled
+              tabindex="-1"
+            />
+          </div>
+        </div>
+        <div class="nd-field">
+          <label class="nd-label" for="add-receipt-unit-price">Цена закупки за единицу</label>
+          <div class="nd-input-wrap">
+            <input
+              id="add-receipt-unit-price"
+              type="number"
+              class="nd-input"
+              formControlName="unitPrice"
+              disabled
+              tabindex="-1"
+            />
+          </div>
+        </div>
+      </div>
 
-      <label>Дата приёмки</label>
-      <input type="date" formControlName="receivedAt" />
+      <div class="nd-field">
+        <label class="nd-label" for="add-receipt-total-cost">Общая сумма</label>
+        <div class="nd-input-wrap">
+          <input
+            id="add-receipt-total-cost"
+            type="number"
+            class="nd-input"
+            formControlName="totalCost"
+            disabled
+            tabindex="-1"
+          />
+        </div>
+      </div>
 
-      <label>Номер документа</label>
-      <input type="text" formControlName="number" />
+      <div class="nd-field">
+        <label class="nd-label" for="add-receipt-batch">Номер партии</label>
+        <div class="nd-input-wrap">
+          <input
+            id="add-receipt-batch"
+            type="text"
+            class="nd-input"
+            formControlName="batchCode"
+            autocomplete="off"
+          />
+        </div>
+      </div>
 
-      <label>Количество</label>
-      <input type="number" formControlName="quantity" />
-
-      <label>Ед. изм.</label>
-      <select formControlName="unit">
-        <option *ngFor="let u of units" [value]="u">{{ u }}</option>
-      </select>
-
-      <label>Общая сумма</label>
-      <input formControlName="totalCost" disabled />
-
-      <label>Срок годности</label>
-      <input type="date" formControlName="expiryDate" />
-
-      <label>Номер партии</label>
-      <input type="text" formControlName="batchCode" />
-
-      <div class="popup-buttons">
-        <button type="button" class="cancel-btn" (click)="onClose()">Отмена</button>
-        <button type="submit" class="save-btn" [disabled]="form.invalid">Сохранить</button>
+      <div class="nd-foot">
+        <button
+          type="button"
+          class="nd-btn nd-btn-outline"
+          data-testid="cancel-button"
+          (click)="onClose()"
+        >
+          Отмена
+        </button>
+        <button type="submit" class="nd-btn nd-btn-primary" [disabled]="form.invalid">
+          Добавить
+        </button>
       </div>
     </form>
   </div>

--- a/feedme.client/src/app/components/add-receipt-popup/add-receipt-popup.component.spec.ts
+++ b/feedme.client/src/app/components/add-receipt-popup/add-receipt-popup.component.spec.ts
@@ -89,7 +89,7 @@ describe('AddReceiptPopupComponent', () => {
   it('should emit close on onClose', () => {
     runInContext(() => {
       spyOn(component.close, 'emit');
-      const btn = fixture.debugElement.query(By.css('.cancel-btn'));
+      const btn = fixture.debugElement.query(By.css('[data-testid="cancel-button"]'));
       btn.nativeElement.click();
       expect(component.close.emit).toHaveBeenCalled();
     });


### PR DESCRIPTION
## Summary
- rebuild the add-receipt popup markup to follow the new modal layout with structured form fields and accessibility helpers
- replace legacy popup styles with the provided nd-* design system rules including icon buttons and responsive grids
- update unit tests to target the new cancel button selector used in the redesigned template

## Testing
- npm run lint *(fails: Angular workspace has no lint target configured)*
- npm run test *(fails: ChromeHeadless cannot start because system libraries such as libatk-1.0.so.0 are missing in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dbae27cbec8323ae18213a0c58ca93