### PR TITLE
Ensure new supplies list shows newly created entries

### DIFF
--- a/feedme.client/src/app/warehouse/warehouse-page.component.ts
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.ts
@@ -350,29 +350,34 @@ export class WarehousePageComponent {
       this.selectedWarehouse() || this.warehouses()[0] || 'Главный склад',
     );
     const responsible = 'Не назначен';
-    const supplier = (product.supplierMain ?? '').trim() || 'Не указан';
-    const category = product.category?.trim() || 'Без категории';
-    const unit = product.unit?.trim() || 'шт';
+    const supplier = this.normalizeText(product.supplierMain, 'Не указан');
+    const category = this.normalizeText(product.category, 'Без категории');
+    const unit = this.normalizeUnit(product.unit);
     const price = Number(product.purchasePrice ?? 0);
     const status = this.mapExpiryStatus(result.arrivalDate, result.expiryDate);
+    const arrivalDate = result.arrivalDate.trim();
+    const expiryDate = result.expiryDate.trim();
+    const name = this.normalizeText(product.name, 'Без названия');
+    const sku = this.normalizeText(product.sku, '—');
 
     const payload: Omit<SupplyRow, 'id'> = {
       docNo,
-      arrivalDate: result.arrivalDate,
+      arrivalDate,
       warehouse,
       responsible,
-      sku: product.sku,
-      name: product.name,
+      sku,
+      name,
       category,
-      qty: result.quantity,
+      qty: Number(result.quantity),
       unit,
       price,
-      expiry: result.expiryDate,
+      expiry: expiryDate,
       supplier,
       status,
     };
 
-    this.warehouseService.addRow(payload);
+    const created = this.warehouseService.addRow(payload);
+    this.selectedWarehouse.set(created.warehouse);
     this.createDialogOpen.set(false);
   }
 
@@ -406,6 +411,15 @@ export class WarehousePageComponent {
       return 'warning';
     }
     return 'ok';
+  }
+
+  private normalizeText(value: string | null | undefined, fallback: string): string {
+    const normalized = value?.trim();
+    return normalized && normalized.length > 0 ? normalized : fallback;
+  }
+
+  private normalizeUnit(unit: string | null | undefined): string {
+    return this.normalizeText(unit, 'шт');
   }
 
   startEdit(row: SupplyRow): void {

--- a/feedme.client/src/app/warehouse/warehouse.service.ts
+++ b/feedme.client/src/app/warehouse/warehouse.service.ts
@@ -111,11 +111,16 @@ export class WarehouseService {
     return this.computeMetrics(rows.filter((row) => row.warehouse === warehouse));
   }
 
-  addRow(row: Omit<SupplyRow, 'id'>): void {
+  addRow(row: Omit<SupplyRow, 'id'>): SupplyRow {
+    let created: SupplyRow | null = null;
+
     this.rowsSignal.update((rows) => {
       const nextId = rows.reduce((max, current) => Math.max(max, current.id), 0) + 1;
-      return [...rows, { id: nextId, ...row }];
+      created = { id: nextId, ...row } satisfies SupplyRow;
+      return [created, ...rows];
     });
+
+    return created!;
   }
 
   updateRow(updatedRow: SupplyRow): void {


### PR DESCRIPTION
## Summary
- update the warehouse service to prepend newly created supplies and return the created record
- normalise supply payload fields and keep the last created warehouse selected so the new row is visible
- extend the warehouse page spec to verify the "Последние поставки" table shows the new supply details

## Testing
- npm test -- --watch=false *(fails: ChromeHeadless cannot start because libatk-1.0.so.0 is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68dbae4e3a1483238b9b1dd19b9dc786