### PR TITLE
feat: restyle warehouse header and filters

### DIFF
--- a/feedme.client/src/app/warehouse/warehouse-page.component.css
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.css
@@ -5,6 +5,13 @@
 
 :root {
   --brand: #ff6a00;
+  --panel: #ffffff;
+  --line: #e2e8f0;
+  --shadow: 0 16px 32px rgba(15, 23, 42, 0.08);
+  --muted: #6b7280;
+  --text: #111827;
+  --blue: #2563eb;
+  --orange: #f97316;
 }
 
 .warehouse-page {
@@ -82,105 +89,276 @@
 }
 
 .warehouse-page__overview {
-  position: sticky;
-  top: 0;
-  z-index: 15;
   display: flex;
   flex-direction: column;
-  gap: 24px;
-  padding: 28px 32px 32px;
-  background: rgba(248, 250, 252, 0.95);
-  border-bottom: 1px solid #e2e8f0;
-  backdrop-filter: blur(12px);
-  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.04);
+  gap: 14px;
+  padding: 28px 32px 0;
 }
 
-.warehouse-page__header {
+.header-crumbs {
   display: flex;
-  flex-wrap: wrap;
-  align-items: flex-end;
+  align-items: center;
   justify-content: space-between;
-  gap: 24px;
+  padding: 14px 16px;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  box-shadow: var(--shadow);
 }
 
-.warehouse-page__header-context {
-  display: flex;
-  flex-direction: column;
+.breadcrumbs {
+  display: inline-flex;
+  align-items: center;
   gap: 6px;
-}
-
-.warehouse-page__title {
-  margin: 0;
-  font-size: 1.75rem;
   font-weight: 700;
-  color: #0f172a;
+  color: var(--text);
 }
 
-.warehouse-page__subtitle {
-  margin: 0;
+.breadcrumbs .sep {
+  color: var(--muted);
+  font-weight: 400;
+}
+
+.warehouse {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  color: var(--muted);
+}
+
+.warehouse .select {
+  height: 36px;
+  min-width: 220px;
+  padding: 0 0.75rem;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #fff;
+  color: #111827;
+}
+
+.warehouse .select:focus {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
+}
+
+.warehouse .add {
+  margin-left: 6px;
+  color: #c2410c;
+  font-weight: 700;
+  background: none;
+  border: none;
+  cursor: pointer;
   font-size: 0.9375rem;
-  color: #64748b;
 }
 
-.warehouse-page__warehouse-picker {
+.warehouse .add:hover,
+.warehouse .add:focus-visible {
+  text-decoration: underline;
+  outline: none;
+}
+
+.kpi {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 14px;
+  margin-top: 10px;
+}
+
+.kpi .card {
+  background: #fff;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  box-shadow: var(--shadow);
+  padding: 16px;
   display: flex;
   flex-direction: column;
   gap: 8px;
-  font-size: 0.75rem;
+}
+
+.kpi .title {
+  color: var(--muted);
+  font-size: 12px;
+  margin: 0;
   text-transform: uppercase;
-  color: #64748b;
-}
-
-.warehouse-page__warehouse-picker-label {
   letter-spacing: 0.04em;
-  font-weight: 600;
 }
 
-.warehouse-page__warehouse-picker-control {
-  position: relative;
+.kpi .value {
+  font-size: 28px;
+  font-weight: 800;
+  color: var(--text);
+  margin: 0;
 }
 
-.warehouse-page__warehouse-select {
-  appearance: none;
-  width: min(260px, 100%);
-  padding: 12px 42px 12px 16px;
-  border-radius: 12px;
-  border: 1px solid #d0d5dd;
-  background-color: #ffffff;
-  font-size: 0.9375rem;
-  font-weight: 600;
-  color: #0f172a;
-  line-height: 1.4;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
-  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' stroke='%2364748b' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'%3e%3cpath d='M4 6l4 4 4-4'/%3e%3c/svg%3e");
-  background-repeat: no-repeat;
-  background-position: right 14px center;
-  background-size: 16px;
-  cursor: pointer;
+.kpi .value.neg {
+  color: #b91c1c;
 }
 
-.warehouse-page__warehouse-select:focus {
-  outline: none;
-  border-color: rgba(59, 130, 246, 0.6);
-  box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.15);
-}
-
-.warehouse-page__snapshot {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
-  gap: 16px;
-}
-
-.warehouse-page__metric-card {
+.toolbar {
   display: flex;
-  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
   gap: 12px;
-  padding: 20px 24px;
-  border-radius: 16px;
-  border: 1px solid #e2e8f0;
-  background: #ffffff;
-  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.06);
-  min-height: 120px;
+  margin: 14px 32px 0;
+  padding: 12px;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  box-shadow: var(--shadow);
+  position: sticky;
+  top: 16px;
+  z-index: 10;
+}
+
+.filters {
+  display: grid;
+  gap: 10px;
+  flex: 1;
+  grid-template-columns: 1.2fr 0.6fr 0.6fr auto;
+  align-items: center;
+}
+
+@media (max-width: 960px) {
+  .filters {
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  }
+}
+
+.input,
+.picker,
+.toolbar select {
+  height: 36px;
+  padding: 0 0.75rem;
+  background: #fff;
+  color: var(--text);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  font-size: 0.9375rem;
+}
+
+.input::placeholder {
+  color: #9aa3af;
+}
+
+.actions {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.actions .btn {
+  white-space: nowrap;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.55rem 0.95rem;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  font-weight: 700;
+  font-size: 0.875rem;
+  line-height: 1.2;
+  background: #f3f4f6;
+  color: var(--text);
+  cursor: pointer;
+  user-select: none;
+  transition: background-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.btn:hover:not(:disabled),
+.btn:focus-visible:not(:disabled) {
+  background: #e2e8f0;
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.12);
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
+}
+
+.btn:focus {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(31, 59, 100, 0.18);
+}
+
+.btn-outline {
+  background: #fff;
+  border-color: #ffb892;
+  color: #c2410c;
+}
+
+.btn-outline:hover:not(:disabled),
+.btn-outline:focus-visible:not(:disabled) {
+  background: #fff7ed;
+  border-color: #f97316;
+}
+
+.btn-blue {
+  background: var(--blue);
+  color: #fff;
+  box-shadow: 0 10px 20px rgba(37, 99, 235, 0.22);
+}
+
+.btn-blue:hover:not(:disabled),
+.btn-blue:focus-visible:not(:disabled) {
+  background: #1e3a8a;
+}
+
+.btn-orange {
+  background: var(--orange);
+  color: #fff;
+  box-shadow: 0 10px 20px rgba(249, 115, 22, 0.25);
+}
+
+.btn-orange:hover:not(:disabled),
+.btn-orange:focus-visible:not(:disabled) {
+  background: #ea580c;
+}
+
+.btn-danger {
+  background: #dc2626;
+  color: #fff;
+}
+
+.btn-danger:hover:not(:disabled),
+.btn-danger:focus-visible:not(:disabled) {
+  background: #b91c1c;
+}
+
+.btn-ghost {
+  background: transparent;
+  color: var(--muted);
+}
+
+.btn-ghost:hover:not(:disabled),
+.btn-ghost:focus-visible:not(:disabled) {
+  background: #f1f5f9;
+  color: var(--text);
+}
+
+.btn-sm {
+  padding: 0.35rem 0.75rem;
+  font-size: 0.8125rem;
+}
+
+.toolbar .btn {
+  height: 36px;
+}
+
+.filters button.btn {
+  justify-self: start;
+}
+
+.warehouse-page__tabs {
+  display: block;
+  margin: 18px 32px 0;
 }
 
 .sr-only {
@@ -196,42 +374,6 @@
 
 }
 
-.warehouse-page__metric-label {
-  font-size: 0.875rem;
-  line-height: 1.4;
-  font-weight: 500;
-  color: var(--muted-foreground, #6b7280);
-}
-
-.warehouse-page__metric-value {
-  font-size: 1.75rem;
-  line-height: 1.25;
-  font-weight: 700;
-  color: #0f172a;
-}
-
-.warehouse-page__metric-value--currency {
-  font-variant-numeric: tabular-nums;
-}
-
-.warehouse-page__metric-badge {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 48px;
-  padding: 6px 12px;
-  border-radius: 9999px;
-  background-color: #fee2e2;
-  color: #b91c1c;
-  font-size: 1rem;
-  font-weight: 600;
-  line-height: 1;
-}
-
-.warehouse-page__metric-card--expired .warehouse-page__metric-value {
-  color: #b91c1c;
-}
-
 .warehouse-page__tab-panel {
   display: flex;
   flex-direction: column;
@@ -244,98 +386,6 @@
   border-radius: 12px;
   background-color: #ffffff;
   box-shadow: 0 8px 24px rgba(15, 23, 42, 0.04);
-}
-
-.card__content {
-  width: 100%;
-  box-sizing: border-box;
-}
-
-.p-4 {
-  padding: 16px;
-}
-
-.flex {
-  display: flex;
-}
-
-.flex-wrap {
-  flex-wrap: wrap;
-}
-
-.items-center {
-  align-items: center;
-}
-
-.gap-3 {
-  gap: 12px;
-}
-
-.warehouse-page__filters {
-  width: 100%;
-}
-
-.warehouse-page__filters-control {
-  display: flex;
-  flex-direction: column;
-}
-
-.warehouse-page__filters-field {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.warehouse-page__filters-label {
-  font-size: 0.75rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  color: #64748b;
-  letter-spacing: 0.04em;
-}
-
-
-.warehouse-page__filters-control--date {
-  flex: 0 0 auto;
-}
-
-.warehouse-page__filters-control--date .input {
-  width: 160px;
-}
-
-.warehouse-page__filters-control--select {
-  flex: 0 1 200px;
-  min-width: 180px;
-}
-
-.warehouse-page__filters .btn {
-  height: 44px;
-  white-space: nowrap;
-}
-
-.warehouse-page__filters .btn-brand-outline {
-  background: transparent;
-  color: var(--brand-600);
-  border: 1px solid var(--brand-600);
-  box-shadow: none;
-}
-
-.warehouse-page__filters .btn-brand-outline:hover:not(:disabled) {
-  background: color-mix(in srgb, var(--brand-600) 12%, #ffffff);
-  border-color: color-mix(in srgb, var(--brand-600) 90%, #000000 10%);
-}
-
-.ml-auto {
-  margin-left: auto;
-}
-
-.w-\[320px\] {
-  flex: 1 1 320px;
-  min-width: min(320px, 100%);
-}
-
-.w-\[160px\] {
-  flex: 0 0 160px;
 }
 
 .warehouse-page__bulk {

--- a/feedme.client/src/app/warehouse/warehouse-page.component.html
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.html
@@ -23,139 +23,106 @@
 
   <main class="warehouse-page__content">
     <section class="warehouse-page__overview" aria-label="Обзор склада">
-      <div class="warehouse-page__header">
-        <div class="warehouse-page__header-context">
-          <h1 class="warehouse-page__title">Поставки</h1>
-          <p class="warehouse-page__subtitle">Контролируйте движение товаров и запасы</p>
+      <header class="header-crumbs">
+        <nav class="breadcrumbs" aria-label="Хлебные крошки">
+          <span>Поставки</span>
+          <span class="sep" aria-hidden="true">/</span>
+          <span>{{ selectedWarehouse() || 'Все склады' }}</span>
+        </nav>
+        <div class="warehouse">
+          <label class="sr-only" for="warehouse-select">Выбор склада</label>
+          <select
+            #activeWarehouse
+            id="warehouse-select"
+            class="select"
+            [value]="selectedWarehouse()"
+            (change)="selectWarehouse(activeWarehouse.value)"
+            aria-label="Выбор активного склада"
+          >
+            <option *ngFor="let warehouseName of warehouses()" [value]="warehouseName">
+              {{ warehouseName }}
+            </option>
+          </select>
+          <button type="button" class="add" (click)="openCreateDialog()">+ Добавить поставку</button>
         </div>
-        <label class="warehouse-page__warehouse-picker">
-          <span class="warehouse-page__warehouse-picker-label">Склад</span>
-          <div class="warehouse-page__warehouse-picker-control">
-            <select
-              #activeWarehouse
-              class="warehouse-page__warehouse-select"
-              [value]="selectedWarehouse()"
-              (change)="selectWarehouse(activeWarehouse.value)"
-              aria-label="Выбор активного склада"
-            >
-              <option *ngFor="let warehouseName of warehouses()" [value]="warehouseName">
-                {{ warehouseName }}
-              </option>
-            </select>
-          </div>
-        </label>
-      </div>
+      </header>
 
-      <section
-        *ngIf="overviewMetrics() as snapshot"
-        class="warehouse-page__snapshot"
-        aria-label="Ключевые показатели склада"
-      >
-        <article class="warehouse-page__metric-card" aria-live="polite">
-          <p class="warehouse-page__metric-label">Поставок за 7 дней</p>
-          <p class="warehouse-page__metric-value">{{ snapshot.suppliesLastWeek }}</p>
+      <section *ngIf="overviewMetrics() as snapshot" class="kpi" aria-label="Ключевые показатели склада">
+        <article class="card" aria-live="polite">
+          <p class="title">Поставок за 7 дней</p>
+          <p class="value">{{ snapshot.suppliesLastWeek }}</p>
         </article>
 
-        <article class="warehouse-page__metric-card" aria-live="polite">
-          <p class="warehouse-page__metric-label">Сумма закупок / 7 дн.</p>
-          <p class="warehouse-page__metric-value warehouse-page__metric-value--currency">
-            {{ formatCurrency(snapshot.purchaseAmountLastWeek) }}
-          </p>
+        <article class="card" aria-live="polite">
+          <p class="title">Сумма закупок / 7 дн.</p>
+          <p class="value">{{ formatCurrency(snapshot.purchaseAmountLastWeek) }}</p>
         </article>
 
-        <article class="warehouse-page__metric-card" aria-live="polite">
-          <p class="warehouse-page__metric-label">Позиций на складе</p>
-          <p class="warehouse-page__metric-value">{{ snapshot.positions }}</p>
+        <article class="card" aria-live="polite">
+          <p class="title">Позиций на складе</p>
+          <p class="value">{{ snapshot.positions }}</p>
         </article>
 
-        <article class="warehouse-page__metric-card warehouse-page__metric-card--expired" aria-live="polite">
-          <p class="warehouse-page__metric-label">Просрочено</p>
-          <p class="warehouse-page__metric-value">
-            <span class="warehouse-page__metric-badge">{{ snapshot.expired }}</span>
-          </p>
+        <article class="card" aria-live="polite">
+          <p class="title">Просрочено</p>
+          <p class="value" [ngClass]="{ neg: snapshot.expired > 0 }">{{ snapshot.expired }}</p>
         </article>
       </section>
-
-      <app-supply-controls
-        [activeTab]="activeTab()"
-        (activeTabChange)="selectTab($event)"
-
-      ></app-supply-controls>
     </section>
 
-    <section *ngIf="activeTab() === 'supplies'" class="warehouse-page__tab-panel">
-        <div class="card warehouse-page__filters-card">
-          <form
-            class="warehouse-page__filters card__content p-4 flex flex-wrap items-center gap-3"
-            (submit)="$event.preventDefault()"
-          >
-            <div class="warehouse-page__filters-control warehouse-page__filters-control--select">
-              <label class="warehouse-page__filters-field">
-                <span class="warehouse-page__filters-label">Статус</span>
-                <select
-                  #statusSelect
-                  class="select"
-                  [value]="status()"
-                  (change)="updateStatus(statusSelect.value)"
-                  aria-label="Фильтр по статусу"
-                >
-                  <option value="">Все статусы</option>
-                  <option *ngFor="let statusOption of statuses" [value]="statusOption">
-                    {{ statusOption | statusBadgeLabel }}
-                  </option>
-                </select>
-              </label>
-            </div>
-            <div class="warehouse-page__filters-control warehouse-page__filters-control--select">
-              <label class="warehouse-page__filters-field">
-                <span class="warehouse-page__filters-label">Поставщик</span>
-                <select
-                  #supplierSelect
-                  class="select"
-                  [value]="supplier()"
-                  (change)="updateSupplier(supplierSelect.value)"
-                  aria-label="Фильтр по поставщику"
-                >
-                  <option value="">Все поставщики</option>
-                  <option *ngFor="let supplierName of suppliers()" [value]="supplierName">
-                    {{ supplierName }}
-                  </option>
-                </select>
-              </label>
-            </div>
-            <div class="warehouse-page__filters-control warehouse-page__filters-control--date w-[160px]">
-              <label class="warehouse-page__filters-field">
-                <span class="warehouse-page__filters-label">Приход от</span>
-                <input
-                  #dateFromInput
-                  class="input"
-                  type="date"
-                  aria-label="Дата прихода от"
-                  [value]="dateFrom()"
-                  (change)="updateDateFrom(dateFromInput.value)"
-                />
-              </label>
-            </div>
-            <div class="warehouse-page__filters-control warehouse-page__filters-control--date w-[160px]">
-              <label class="warehouse-page__filters-field">
-                <span class="warehouse-page__filters-label">Приход до</span>
-                <input
-                  #dateToInput
-                  class="input"
-                  type="date"
-                  aria-label="Дата прихода до"
-                  [value]="dateTo()"
-                  (change)="updateDateTo(dateToInput.value)"
-                />
-              </label>
-            </div>
-            <button type="button" class="btn btn-outline" (click)="clearFilters()">Сброс</button>
-            <button type="button" class="btn btn-brand-outline">Импорт</button>
-            <button type="button" class="btn btn-secondary">Экспорт</button>
-            <button type="button" class="btn ml-auto" (click)="openCreateDialog()">+ Новая поставка</button>
-          </form>
-        </div>
+    <section class="toolbar" aria-label="Фильтры и действия по поставкам">
+      <form class="filters" (submit)="$event.preventDefault()">
+        <label class="sr-only" for="supply-search">Поиск по поставкам</label>
+        <input
+          #searchInput
+          id="supply-search"
+          class="input"
+          type="search"
+          placeholder="Поиск по документу, SKU или названию"
+          [value]="search()"
+          (input)="updateSearch(searchInput.value)"
+          aria-label="Поиск по документу, SKU или названию"
+        />
 
+        <label class="sr-only" for="arrival-from">Дата прихода от</label>
+        <input
+          #dateFromInput
+          id="arrival-from"
+          class="picker"
+          type="date"
+          aria-label="Дата прихода от"
+          [value]="dateFrom()"
+          (change)="updateDateFrom(dateFromInput.value)"
+        />
+
+        <label class="sr-only" for="arrival-to">Дата прихода до</label>
+        <input
+          #dateToInput
+          id="arrival-to"
+          class="picker"
+          type="date"
+          aria-label="Дата прихода до"
+          [value]="dateTo()"
+          (change)="updateDateTo(dateToInput.value)"
+        />
+
+        <button type="button" class="btn btn-outline" (click)="clearFilters()">Сброс</button>
+      </form>
+
+      <div class="actions">
+        <button type="button" class="btn btn-outline">Импорт</button>
+        <button type="button" class="btn btn-blue">Экспорт</button>
+        <button type="button" class="btn btn-orange" (click)="openCreateDialog()">+ Новая поставка</button>
+      </div>
+    </section>
+
+    <app-supply-controls
+      class="warehouse-page__tabs"
+      [activeTab]="activeTab()"
+      (activeTabChange)="selectTab($event)"
+    ></app-supply-controls>
+
+    <section *ngIf="activeTab() === 'supplies'" class="warehouse-page__tab-panel">
         <section class="warehouse-page__bulk" *ngIf="hasSelection()" aria-live="polite">
           <span class="warehouse-page__bulk-count">Выбрано: {{ checkedIds().length }}</span>
           <div class="warehouse-page__bulk-actions">


### PR DESCRIPTION
## Summary
- redesign the warehouse overview with the new breadcrumb header, KPI layout, and sticky toolbar actions
- replace status and supplier filters with text/date filters while keeping supply creation workflows intact
- refresh component styling with shared color tokens and updated button variants for the new UI

## Testing
- npm run lint *(fails: Angular workspace does not define a lint target)*
- npm run test *(fails: ChromeHeadless cannot start because libatk-1.0.so.0 is missing in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dbaee0c7bc8323a79f5b32895a6e6b