### PR TITLE
style: refresh new supply dialog layout

### DIFF
--- a/feedme.client/src/app/warehouse/ui/create-supply-dialog.component.css
+++ b/feedme.client/src/app/warehouse/ui/create-supply-dialog.component.css
@@ -41,8 +41,9 @@
 
 .create-supply-dialog__grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 16px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  column-gap: 24px;
+  row-gap: 16px;
 }
 
 .create-supply-dialog__field {
@@ -50,6 +51,16 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
+}
+
+.create-supply-dialog__field--full {
+  grid-column: 1 / -1;
+}
+
+.create-supply-dialog__control {
+  position: relative;
+  display: flex;
+  align-items: center;
 }
 
 .create-supply-dialog__label {
@@ -62,12 +73,36 @@
 
 .create-supply-dialog__input {
   width: 100%;
-  padding: 12px;
+  padding: 12px 14px;
   border-radius: 10px;
   border: 1px solid #d0d5dd;
   font-size: 0.9375rem;
   color: #0f172a;
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.create-supply-dialog__field--with-icon .create-supply-dialog__input {
+  padding-right: 46px;
+}
+
+.create-supply-dialog__icon {
+  position: absolute;
+  right: 16px;
+  width: 18px;
+  height: 18px;
+  opacity: 0.6;
+  background-color: #64748b;
+  pointer-events: none;
+}
+
+.create-supply-dialog__icon--search {
+  mask: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="%23000" d="M15.5 14h-.79l-.28-.27A6.5 6.5 0 1 0 9.5 16a6.47 6.47 0 0 0 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/></svg>')
+    center/contain no-repeat;
+}
+
+.create-supply-dialog__icon--calendar {
+  mask: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="%23000" d="M7 2h2v2h6V2h2v2h3v18H4V4h3V2zm12 6H6v12h13V8z"/></svg>')
+    center/contain no-repeat;
 }
 
 .create-supply-dialog__input:focus {
@@ -78,7 +113,7 @@
 
 .create-supply-dialog__suggestions {
   position: absolute;
-  top: 100%;
+  top: calc(100% + 8px);
   left: 0;
   right: 0;
   z-index: 10;
@@ -172,5 +207,10 @@
   .create-supply-dialog__suggestions {
     position: static;
     max-height: none;
+  }
+
+  .create-supply-dialog__grid {
+    grid-template-columns: 1fr;
+    row-gap: 12px;
   }
 }

--- a/feedme.client/src/app/warehouse/ui/create-supply-dialog.component.html
+++ b/feedme.client/src/app/warehouse/ui/create-supply-dialog.component.html
@@ -12,16 +12,19 @@
   </header>
 
   <form class="create-supply-dialog__form" [formGroup]="form" (ngSubmit)="submit()">
-    <div class="create-supply-dialog__field">
+    <div class="create-supply-dialog__field create-supply-dialog__field--with-icon">
       <label class="create-supply-dialog__label" for="create-supply-product">Товар</label>
-      <input
-        id="create-supply-product"
-        type="search"
-        class="create-supply-dialog__input"
-        formControlName="productQuery"
-        autocomplete="off"
-        placeholder="Начните вводить название или SKU"
-      />
+      <div class="create-supply-dialog__control">
+        <input
+          id="create-supply-product"
+          type="search"
+          class="create-supply-dialog__input"
+          formControlName="productQuery"
+          autocomplete="off"
+          placeholder="Начните вводить название или SKU"
+        />
+        <span aria-hidden="true" class="create-supply-dialog__icon create-supply-dialog__icon--search"></span>
+      </div>
       <ul
         class="create-supply-dialog__suggestions"
         *ngIf="suggestions().length > 0"
@@ -56,29 +59,37 @@
     <div class="create-supply-dialog__grid">
       <label class="create-supply-dialog__field">
         <span class="create-supply-dialog__label">Количество</span>
-        <input
-          type="number"
-          min="0"
-          step="0.001"
-          formControlName="quantity"
-          class="create-supply-dialog__input"
-        />
+        <div class="create-supply-dialog__control">
+          <input
+            type="number"
+            min="0"
+            step="0.001"
+            formControlName="quantity"
+            class="create-supply-dialog__input"
+          />
+        </div>
         <p class="create-supply-dialog__error" *ngIf="form.controls.quantity.invalid && form.controls.quantity.touched">
           Укажите количество больше нуля.
         </p>
       </label>
 
-      <label class="create-supply-dialog__field">
+      <label class="create-supply-dialog__field create-supply-dialog__field--with-icon">
         <span class="create-supply-dialog__label">Дата прихода</span>
-        <input type="date" formControlName="arrivalDate" class="create-supply-dialog__input" />
+        <div class="create-supply-dialog__control">
+          <input type="date" formControlName="arrivalDate" class="create-supply-dialog__input" />
+          <span aria-hidden="true" class="create-supply-dialog__icon create-supply-dialog__icon--calendar"></span>
+        </div>
         <p class="create-supply-dialog__error" *ngIf="form.controls.arrivalDate.invalid && form.controls.arrivalDate.touched">
           Укажите дату прихода.
         </p>
       </label>
 
-      <label class="create-supply-dialog__field">
+      <label class="create-supply-dialog__field create-supply-dialog__field--with-icon create-supply-dialog__field--full">
         <span class="create-supply-dialog__label">Срок годности</span>
-        <input type="date" formControlName="expiryDate" class="create-supply-dialog__input" />
+        <div class="create-supply-dialog__control">
+          <input type="date" formControlName="expiryDate" class="create-supply-dialog__input" />
+          <span aria-hidden="true" class="create-supply-dialog__icon create-supply-dialog__icon--calendar"></span>
+        </div>
         <p class="create-supply-dialog__error" *ngIf="form.controls.expiryDate.errors?.['dateOrder']">
           Срок годности не может быть раньше даты прихода.
         </p>


### PR DESCRIPTION
## Summary
- wrap the product lookup in the new supply dialog with an iconized control for the search affordance
- restructure the quantity/date grid with a dedicated spacer and stretch the expiry date field across the dialog width
- extend the dialog styling to support control wrappers, icons, and responsive column handling

## Testing
- npm run lint *(fails: Angular workspace has no lint target configured)*
- npm run test *(fails: ChromeHeadless cannot start because libatk-1.0.so.0 is missing in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dbb4dd3a38832382203bc0745905c2