### PR TITLE
Fix supply quantity display in warehouse table

### DIFF
--- a/feedme.client/src/app/components/warehouse-table/warehouse-table.component.html
+++ b/feedme.client/src/app/components/warehouse-table/warehouse-table.component.html
@@ -20,7 +20,7 @@
       <div>{{ item.totalCost }}</div>
       <div>{{ item.unitPrice }}</div>
       <div>{{ item.stock }}</div>
-      <div>{{ item.stock }}</div>
+      <div>{{ getSupplyQuantity(item) }}</div>
       <div>{{ item.expiryDate }}</div>
       <div class="actions">
         <div class="icons-container">

--- a/feedme.client/src/app/components/warehouse-table/warehouse-table.component.ts
+++ b/feedme.client/src/app/components/warehouse-table/warehouse-table.component.ts
@@ -1,29 +1,54 @@
-import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+
+export interface WarehouseTableRow {
+  supplyDate?: string;
+  name?: string;
+  category?: string;
+  totalCost?: number | string;
+  unitPrice?: number | string;
+  stock?: number | string;
+  supplyQuantity?: number | string;
+  receivedQuantity?: number | string;
+  quantity?: number | string;
+  qty?: number | string;
+  incomingQuantity?: number | string;
+  expiryDate?: string;
+}
 
 @Component({
   selector: 'app-warehouse-table',
   standalone: true,
   imports: [CommonModule],
   templateUrl: './warehouse-table.component.html',
-  styleUrls: ['./warehouse-table.component.css']
+  styleUrls: ['./warehouse-table.component.css'],
 })
 export class WarehouseTableComponent {
-  @Input() data: any[] = [];
+  private static readonly quantityKeys: (keyof WarehouseTableRow)[] = [
+    'supplyQuantity',
+    'receivedQuantity',
+    'quantity',
+    'qty',
+    'incomingQuantity',
+  ];
 
-  @Output() onSettingsClick = new EventEmitter<any>();
-  @Output() onEditStockClick = new EventEmitter<{ index: number, stock: number }>();
+  private static readonly numberFormatter = new Intl.NumberFormat('ru-RU');
 
-  handleSettingsClick(item: any, event: MouseEvent) {
+  @Input() data: WarehouseTableRow[] = [];
+
+  @Output() readonly onSettingsClick = new EventEmitter<WarehouseTableRow>();
+  @Output() readonly onEditStockClick = new EventEmitter<{ index: number; stock: number | string }>();
+
+  handleSettingsClick(item: WarehouseTableRow, event: MouseEvent): void {
     event.stopPropagation();
     this.onSettingsClick.emit(item);
   }
 
-  handleEditStockClick(index: number, stock: number) {
+  handleEditStockClick(index: number, stock: number | string): void {
     this.onEditStockClick.emit({ index, stock });
   }
 
-  getCategoryIcon(category: string): string {
+  getCategoryIcon(category: string | undefined): string {
     switch (category) {
       case 'Заготовка':
         return 'assets/Zagotovka.svg';
@@ -32,8 +57,50 @@ export class WarehouseTableComponent {
       case 'Добавка':
         return 'assets/Toping.svg';
       case 'Товар':
+        return 'assets/default.svg';
       default:
         return 'assets/default.svg';
     }
+  }
+
+  getSupplyQuantity(row: WarehouseTableRow): string {
+    const explicitValue = WarehouseTableComponent.quantityKeys
+      .map((key) => row[key])
+      .find((value) => this.isPresent(value));
+
+    if (this.isPresent(explicitValue)) {
+      return this.formatQuantity(explicitValue);
+    }
+
+    if (this.isPresent(row.stock)) {
+      return this.formatQuantity(row.stock);
+    }
+
+    return '—';
+  }
+
+  private isPresent(value: unknown): value is string | number {
+    if (value === null || value === undefined) {
+      return false;
+    }
+
+    if (typeof value === 'string') {
+      return value.trim().length > 0;
+    }
+
+    return true;
+  }
+
+  private formatQuantity(value: string | number): string {
+    if (typeof value === 'number') {
+      return WarehouseTableComponent.numberFormatter.format(value);
+    }
+
+    const numericValue = Number(value);
+    if (!Number.isNaN(numericValue)) {
+      return WarehouseTableComponent.numberFormatter.format(numericValue);
+    }
+
+    return value;
   }
 }


### PR DESCRIPTION
## Summary
- introduce a typed warehouse table row model and helper that resolves the received quantity from multiple possible payload fields
- render the "Кол-во товара в поставке" column through the helper so newly added supplies surface their quantity values

## Testing
- npm run lint *(fails: workspace has no configured lint target)*

------
https://chatgpt.com/codex/tasks/task_e_68dbb4a6637c8323a1dfad9c05268239