### PR TITLE
feat: persist warehouse supplies using backend receipts

### DIFF
--- a/feedme.client/src/app/warehouse/shared/models.ts
+++ b/feedme.client/src/app/warehouse/shared/models.ts
@@ -23,6 +23,7 @@ export interface SupplyProduct {
   sku: string;
   name: string;
   unit: string;
+  category: string;
   supplier?: string;
   purchasePrice: number | null;
 }

--- a/feedme.client/src/app/warehouse/supplies/supplies.component.html
+++ b/feedme.client/src/app/warehouse/supplies/supplies.component.html
@@ -162,6 +162,9 @@
       </header>
 
       <div class="supplies-dialog__body">
+        <p class="supplies-dialog__alert" *ngIf="submissionError() as error" role="alert">
+          {{ error }}
+        </p>
         <section class="supplies-dialog__section">
           <h3 class="supplies-dialog__section-title">Детали документа</h3>
           <div class="supplies-dialog__grid">
@@ -250,7 +253,9 @@
 
       <footer class="supplies-dialog__footer">
         <button type="button" class="btn btn-outline" (click)="closeDialog()">Отмена</button>
-        <button type="submit" class="btn btn-primary">Сохранить</button>
+        <button type="submit" class="btn btn-primary" [disabled]="isSubmitting()">
+          {{ isSubmitting() ? 'Сохранение…' : 'Сохранить' }}
+        </button>
       </footer>
     </form>
   </div>

--- a/feedme.client/src/app/warehouse/supplies/supplies.component.scss
+++ b/feedme.client/src/app/warehouse/supplies/supplies.component.scss
@@ -303,6 +303,14 @@
   filter: brightness(0.96);
 }
 
+.btn:disabled,
+.btn[disabled] {
+  cursor: not-allowed;
+  opacity: 0.6;
+  filter: none;
+  pointer-events: none;
+}
+
 .btn-primary {
   background: var(--supplies-orange);
   color: #ffffff;
@@ -451,6 +459,16 @@
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+}
+
+.supplies-dialog__alert {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  background: rgba(185, 28, 28, 0.08);
+  color: #991b1b;
+  border: 1px solid rgba(185, 28, 28, 0.3);
+  font-size: 0.875rem;
 }
 
 .supplies-dialog__section-title {

--- a/feedme.client/src/app/warehouse/supplies/supplies.component.spec.ts
+++ b/feedme.client/src/app/warehouse/supplies/supplies.component.spec.ts
@@ -12,6 +12,7 @@ class MockSuppliesService {
       sku: 'MEAT-001',
       name: 'Курица охлаждённая',
       unit: 'кг',
+      category: 'Мясо',
       supplier: 'ООО Куры Дуры',
       purchasePrice: 210,
     },

--- a/feedme.client/src/app/warehouse/supplies/supplies.service.ts
+++ b/feedme.client/src/app/warehouse/supplies/supplies.service.ts
@@ -1,43 +1,39 @@
 import { Injectable, inject } from '@angular/core';
-import { BehaviorSubject, Observable, of } from 'rxjs';
-import { take } from 'rxjs/operators';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { map, take, tap } from 'rxjs/operators';
 
 import { Product, SupplyProduct, SupplyRow } from '../shared/models';
 import { computeExpiryStatus } from '../shared/status.util';
 import { WarehouseCatalogService } from '../catalog/catalog.service';
+import { CreateReceipt, Receipt, ReceiptService } from '../../services/receipt.service';
 
 @Injectable({ providedIn: 'root' })
 export class SuppliesService {
   private readonly catalogService = inject(WarehouseCatalogService);
+  private readonly receiptService = inject(ReceiptService);
 
   private readonly productsSubject = new BehaviorSubject<SupplyProduct[]>([]);
   private readonly rowsSubject = new BehaviorSubject<SupplyRow[]>([]);
   private productMap = new Map<string, SupplyProduct>();
-  private rowsInitialized = false;
-  private idCounter = 0;
 
   constructor() {
     this.catalogService.getAll().subscribe(products => {
-      const mapped = products.map(product => this.toSupplyProduct(product));
-      this.productMap = new Map(mapped.map(product => [product.id, product]));
-      this.productsSubject.next(mapped);
-
-      if (!this.rowsInitialized) {
-        const initialRows = this.createInitialRows(mapped);
-        this.rowsSubject.next(initialRows);
-        this.idCounter = initialRows.length;
-        this.rowsInitialized = true;
-      }
+      this.updateProducts(products);
     });
 
     this.catalogService
       .refresh()
       .pipe(take(1))
       .subscribe({
+        next: products => {
+          this.updateProducts(products);
+        },
         error: () => {
           this.productsSubject.next([]);
         },
       });
+
+    this.loadRowsFromServer();
   }
 
   getAll(): Observable<SupplyRow[]> {
@@ -56,88 +52,41 @@ export class SuppliesService {
   add(row: Omit<SupplyRow, 'id'>): Observable<SupplyRow>;
   add(row: SupplyRow | Omit<SupplyRow, 'id'>): Observable<SupplyRow> {
     const payload = { ...row } as SupplyRow;
-    const record: SupplyRow = {
-      ...payload,
-      id: typeof payload.id === 'string' && payload.id ? payload.id : this.generateId(),
+    const normalized: Omit<SupplyRow, 'id'> = {
+      docNo: payload.docNo.trim(),
+      arrivalDate: payload.arrivalDate,
+      warehouse: payload.warehouse.trim(),
+      responsible: payload.responsible?.trim() || undefined,
+      productId: payload.productId,
+      sku: payload.sku,
+      name: payload.name,
+      qty: payload.qty,
+      unit: payload.unit,
+      expiryDate: payload.expiryDate,
+      supplier: payload.supplier?.trim() || undefined,
       status: computeExpiryStatus(payload.expiryDate, payload.arrivalDate),
-    };
+    } satisfies Omit<SupplyRow, 'id'>;
 
-    this.rowsSubject.next([record, ...this.rowsSubject.value]);
-    return of(record);
-  }
+    const request = this.toReceiptPayload(normalized);
 
-  private generateId(): string {
-    if (typeof crypto !== 'undefined' && 'randomUUID' in crypto && typeof crypto.randomUUID === 'function') {
-      return crypto.randomUUID();
-    }
+    return this.receiptService.saveReceipt(request).pipe(
+      map(receipt => {
+        const created = this.mapReceiptToRow(receipt);
+        if (!created) {
+          throw new Error('Ответ сервера не содержит данных о поставке.');
+        }
 
-    this.idCounter += 1;
-    return `supply-${this.idCounter}`;
-  }
-
-  private createInitialRows(products: SupplyProduct[]): SupplyRow[] {
-    if (products.length === 0) {
-      return [];
-    }
-
-    const today = new Date();
-
-    const formatISO = (source: Date): string => {
-      const year = source.getFullYear();
-      const month = String(source.getMonth() + 1).padStart(2, '0');
-      const day = String(source.getDate()).padStart(2, '0');
-      return `${year}-${month}-${day}`;
-    };
-
-    const addDays = (source: Date, offset: number): Date => {
-      const result = new Date(source);
-      result.setDate(result.getDate() + offset);
-      return result;
-    };
-
-    const bySku = new Map(products.map(product => [product.sku, product]));
-
-    const buildRow = (
-      sku: string,
-      docNo: string,
-      arrivalOffset: number,
-      expiryOffset: number,
-      quantity: number,
-      warehouse: string,
-      responsible: string
-    ): SupplyRow | null => {
-      const product = bySku.get(sku);
-      if (!product) {
-        return null;
-      }
-
-      const arrivalDate = formatISO(addDays(today, arrivalOffset));
-      const expiryDate = formatISO(addDays(today, expiryOffset));
-
-      return {
-        id: this.generateId(),
-        docNo,
-        arrivalDate,
-        warehouse,
-        responsible,
-        productId: product.id,
-        sku: product.sku,
-        name: product.name,
-        qty: quantity,
-        unit: product.unit,
-        expiryDate,
-        supplier: product.supplier,
-        status: computeExpiryStatus(expiryDate, arrivalDate),
-      } satisfies SupplyRow;
-    };
-
-    const rows = [
-      buildRow('MEAT-001', 'PO-000851', 0, 30, 120, 'Главный склад', 'Иванов И.'),
-      buildRow('MEAT-002', 'PO-000852', -2, 7, 16, 'Кухня', 'Петров П.'),
-      buildRow('DAIRY-004', 'PO-000853', -5, -1, 12, 'Бар', 'Сидоров С.'),
-    ].filter((row): row is SupplyRow => row !== null);
-
-    return rows;
+        return created;
+      }),
+      tap(created => {
+        this.rowsSubject.next(
+          this.sortRows([
+            created,
+            ...this.rowsSubject.value.filter(existing => existing.id !== created.id),
+          ]),
+        );
+      }),
+    );
   }
 
   private toSupplyProduct(product: Product): SupplyProduct {
@@ -146,8 +95,157 @@ export class SuppliesService {
       sku: product.sku,
       name: product.name,
       unit: product.unit,
+      category: product.category,
       supplier: product.supplierMain ?? undefined,
       purchasePrice: product.purchasePrice,
     } satisfies SupplyProduct;
+  }
+
+  private updateProducts(products: readonly Product[]): void {
+    const mapped = products.map(product => this.toSupplyProduct(product));
+    this.productMap = new Map(mapped.map(product => [product.id, product]));
+    this.productsSubject.next(mapped);
+  }
+
+  private loadRowsFromServer(): void {
+    this.receiptService
+      .getAll()
+      .pipe(
+        take(1),
+        map(receipts =>
+          receipts
+            .map(receipt => this.mapReceiptToRow(receipt))
+            .filter((row): row is SupplyRow => row !== null),
+        ),
+      )
+      .subscribe({
+        next: rows => {
+          this.rowsSubject.next(this.sortRows(rows));
+        },
+        error: () => {
+          this.rowsSubject.next([]);
+        },
+      });
+  }
+
+  private mapReceiptToRow(receipt: Receipt): SupplyRow | null {
+    if (!receipt) {
+      return null;
+    }
+
+    const [line] = receipt.items ?? [];
+    if (!line) {
+      return null;
+    }
+
+    return {
+      id: receipt.id,
+      docNo: this.normalizeText(receipt.number),
+      arrivalDate: this.normalizeDateString(receipt.receivedAt),
+      warehouse: this.normalizeText(receipt.warehouse, 'Главный склад'),
+      responsible: this.normalizeOptionalText(receipt.responsible),
+      productId: this.normalizeText(line.catalogItemId),
+      sku: this.normalizeText(line.sku),
+      name: this.normalizeText(line.itemName, 'Без названия'),
+      qty: Number(line.quantity ?? 0),
+      unit: this.normalizeText(line.unit, 'шт'),
+      expiryDate: line.expiryDate ? this.normalizeDateString(line.expiryDate) : '',
+      supplier: this.normalizeOptionalText(receipt.supplier),
+      status: this.normalizeStatus(line.status, receipt.receivedAt, line.expiryDate),
+    } satisfies SupplyRow;
+  }
+
+  private normalizeText(value: string | null | undefined, fallback = ''): string {
+    const normalized = (value ?? '').trim();
+    return normalized || fallback;
+  }
+
+  private normalizeOptionalText(value: string | null | undefined): string | undefined {
+    const normalized = this.normalizeText(value);
+    return normalized || undefined;
+  }
+
+  private normalizeDateString(value: string | Date | null | undefined): string {
+    if (!value) {
+      return '';
+    }
+
+    const date = value instanceof Date ? value : new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return '';
+    }
+
+    const year = date.getUTCFullYear();
+    const month = `${date.getUTCMonth() + 1}`.padStart(2, '0');
+    const day = `${date.getUTCDate()}`.padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  }
+
+  private normalizeStatus(
+    status: string | null | undefined,
+    arrival: string | Date | null | undefined,
+    expiry: string | Date | null | undefined,
+  ): SupplyRow['status'] {
+    const normalized = (status ?? '').trim().toLowerCase();
+    if (normalized === 'ok' || normalized === 'warning' || normalized === 'expired') {
+      return normalized;
+    }
+
+    return computeExpiryStatus(expiry, arrival);
+  }
+
+  private sortRows(rows: readonly SupplyRow[]): SupplyRow[] {
+    return [...rows].sort((left, right) => {
+      const dateCompare = right.arrivalDate.localeCompare(left.arrivalDate);
+      if (dateCompare !== 0) {
+        return dateCompare;
+      }
+
+      return right.docNo.localeCompare(left.docNo);
+    });
+  }
+
+  private toReceiptPayload(row: Omit<SupplyRow, 'id'>): CreateReceipt {
+    const product = this.productMap.get(row.productId);
+    const unitPrice = this.normalizeNumber(product?.purchasePrice);
+
+    return {
+      number: row.docNo,
+      supplier: row.supplier ?? product?.supplier ?? '',
+      warehouse: row.warehouse,
+      responsible: row.responsible ?? '',
+      receivedAt: this.toUtcIsoString(row.arrivalDate),
+      items: [
+        {
+          catalogItemId: row.productId,
+          sku: row.sku,
+          itemName: row.name,
+          category: product?.category ?? 'Без категории',
+          quantity: row.qty,
+          unit: row.unit,
+          unitPrice,
+          expiryDate: row.expiryDate ? this.toUtcIsoString(row.expiryDate) : null,
+          status: row.status,
+        },
+      ],
+    } satisfies CreateReceipt;
+  }
+
+  private toUtcIsoString(value: string): string {
+    if (!value) {
+      throw new Error('Дата должна быть указана.');
+    }
+
+    const [year, month, day] = value.split('-').map(part => Number.parseInt(part, 10));
+    if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) {
+      throw new Error(`Некорректная дата: ${value}`);
+    }
+
+    const utcDate = new Date(Date.UTC(year, month - 1, day));
+    return utcDate.toISOString();
+  }
+
+  private normalizeNumber(value: number | null | undefined): number {
+    return Number.isFinite(value) && value !== null ? value : 0;
   }
 }


### PR DESCRIPTION
## Summary
- load and normalize supply rows from the receipts API so the supplies table reflects persisted data
- extend supply product metadata with category information required for receipt creation
- improve the new supply dialog with submission state handling and user-facing errors

## Testing
- `npm test` *(fails: ChromeHeadless missing libatk-1.0.so.0 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd28d91da08323a57c478e490de370