### PR TITLE
Fix missing form binding in supply dialog

### DIFF
--- a/feedme.client/src/app/warehouse/supplies/supplies.component.html
+++ b/feedme.client/src/app/warehouse/supplies/supplies.component.html
@@ -156,7 +156,7 @@
     aria-labelledby="supplies-dialog-title"
     (click)="$event.stopPropagation()"
   >
-    <form class="supplies-dialog__form" (ngSubmit)="submit()" novalidate>
+    <form class="supplies-dialog__form" [formGroup]="form" (ngSubmit)="submit()" novalidate>
       <header class="supplies-dialog__header">
         <h2 id="supplies-dialog-title">Новая поставка</h2>
       </header>


### PR DESCRIPTION
## Summary
- bind the new supply dialog form element to its reactive form group so the submit handler runs correctly

## Testing
- npx --yes @angular/cli@19.2.8 lint *(fails: workspace has no lint target)*

------
https://chatgpt.com/codex/tasks/task_e_68dfe0922e0c8323a0ae52b9f9fda2b8