### PR TITLE
fix: point dev environment to remote api host

### DIFF
--- a/feedme.client/src/environments/environment.ts
+++ b/feedme.client/src/environments/environment.ts
@@ -1,10 +1,11 @@
 // src/environments/environment.ts
 //
-// Локальная сборка использует относительный путь к backend (`/api`).
-// Angular dev-server автоматически проксирует такие запросы на ASP.NET API,
-// поэтому не возникает проблем с CORS и не нужно открывать удалённый порт.
+// Локальная сборка обращается напрямую к удалённому backend.
+// Это гарантирует, что разработка ведётся в тех же условиях, что и production,
+// и запросы не будут направляться на несуществующий локальный сервер.
 import type { EnvironmentConfig } from './environment.model';
 
 export const environment: EnvironmentConfig = {
-  production: false
+  production: false,
+  apiBaseUrl: 'http://185.251.90.40:8080'
 };


### PR DESCRIPTION
## Summary
- update the development environment configuration to use the remote API host instead of localhost
- document in comments that development now mirrors production by calling the remote backend directly

## Testing
- npm test *(fails: ChromeHeadless cannot start because libatk-1.0.so.0 is missing in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dff4db083c8323bd995e7431981bec