### PR TITLE
Fix development CORS errors by using proxy fallback

### DIFF
--- a/feedme.client/src/environments/environment.ts
+++ b/feedme.client/src/environments/environment.ts
@@ -1,11 +1,11 @@
 // src/environments/environment.ts
 //
-// Локальная сборка обращается напрямую к удалённому backend.
-// Это гарантирует, что разработка ведётся в тех же условиях, что и production,
-// и запросы не будут направляться на несуществующий локальный сервер.
+// Локальная сборка использует dev-server proxy, чтобы обращаться к backend
+// через тот же origin (http://localhost:4200). Это избавляет от проблем с CORS,
+// а также позволяет прозрачно подменять целевой сервер (локальный или удалённый)
+// через конфигурацию proxy.conf.js без переписывания клиентского кода.
 import type { EnvironmentConfig } from './environment.model';
 
 export const environment: EnvironmentConfig = {
-  production: false,
-  apiBaseUrl: 'http://185.251.90.40:8080'
+  production: false
 };

--- a/feedme.client/src/proxy.conf.js
+++ b/feedme.client/src/proxy.conf.js
@@ -7,7 +7,9 @@ const FALLBACK_ENDPOINTS = [
   'https://localhost:8081',
   'https://localhost:7221',
   'http://localhost:8080',
-  'http://localhost:5016'
+  'http://localhost:5016',
+  // Обращение к удалённому стенду, используемому в production.
+  'http://185.251.90.40:8080'
 ];
 
 const { endpoint: target, attemptedEndpoints } = resolveFirstReachableEndpoint([


### PR DESCRIPTION
## Summary
- route development API calls through the Angular CLI proxy instead of hitting the remote server directly
- add the production backend to the proxy fallback list so the dev server can forward requests when no local backend is running

## Testing
- npm test *(fails: ChromeHeadless cannot start because libatk-1.0.so.0 is missing in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dffb9a9adc83238dc69707b902a00f