### PR TITLE
Fix dev CORS by routing API calls through proxy

### DIFF
--- a/feedme.client/src/environments/environment.prod.ts
+++ b/feedme.client/src/environments/environment.prod.ts
@@ -1,11 +1,10 @@
 // src/environments/environment.prod.ts
 //
-// Продакшен-сборка сразу направляет запросы на внешний backend без прокси.
-// Это гарантирует, что опубликованный фронтенд и backend взаимодействуют
-// через один и тот же домен 185.251.90.40:8080.
+// Продакшен-сборка также использует origin, на котором размещено приложение.
+// Это позволяет без дополнительных настроек деплоить фронтенд вместе с backend
+// на один домен и избегать лишних CORS-настроек.
 import type { EnvironmentConfig } from './environment.model';
 
 export const environment: EnvironmentConfig = {
-  production: true,
-  apiBaseUrl: 'http://185.251.90.40:8080'
+  production: true
 };

--- a/feedme.client/src/environments/environment.ts
+++ b/feedme.client/src/environments/environment.ts
@@ -1,11 +1,10 @@
 // src/environments/environment.ts
 //
-// Локальная сборка обращается напрямую к удалённому backend.
-// Это гарантирует, что разработка ведётся в тех же условиях, что и production,
-// и запросы не будут направляться на несуществующий локальный сервер.
+// Локальная сборка использует origin приложения и проксируется до нужного backend
+// через `proxy.conf.js`. Благодаря этому браузер всегда обращается к API с того же
+// домена, что и фронтенд, и проблемы с CORS не возникают даже при разработке.
 import type { EnvironmentConfig } from './environment.model';
 
 export const environment: EnvironmentConfig = {
-  production: false,
-  apiBaseUrl: 'http://185.251.90.40:8080'
+  production: false
 };

--- a/feedme.client/src/proxy.conf.js
+++ b/feedme.client/src/proxy.conf.js
@@ -2,12 +2,16 @@ const net = require('node:net');
 const { URL } = require('node:url');
 const { env } = require('process');
 
+const CUSTOM_ENDPOINTS = resolveFromUrlsVariable('FEEDME_DEV_BACKEND');
+
 const FALLBACK_ENDPOINTS = [
   // HTTPS ports are listed first so that secure endpoints take precedence.
   'https://localhost:8081',
   'https://localhost:7221',
   'http://localhost:8080',
-  'http://localhost:5016'
+  'http://localhost:5016',
+  'https://185.251.90.40:8081',
+  'http://185.251.90.40:8080'
 ];
 
 const { endpoint: target, attemptedEndpoints } = resolveFirstReachableEndpoint([
@@ -18,6 +22,7 @@ const { endpoint: target, attemptedEndpoints } = resolveFirstReachableEndpoint([
   () => resolveFromUrlsVariable('ASPNETCORE_URLS'),
   () => resolveFromPorts('ASPNETCORE_HTTPS_PORTS', 'https'),
   () => resolveFromPorts('ASPNETCORE_HTTP_PORTS', 'http'),
+  () => CUSTOM_ENDPOINTS,
   () => FALLBACK_ENDPOINTS
 ]);
 


### PR DESCRIPTION
## Summary
- use the application origin in Angular environment configs so requests always go through the configured proxy
- extend the proxy configuration with a configurable endpoint and remote fallbacks to reach the deployed backend when no local service is running

## Testing
- npm run lint *(fails: Angular project has no lint target configured)*

------
https://chatgpt.com/codex/tasks/task_e_68dffb9a9adc83238dc69707b902a00f