### PR TITLE
Configure configurable CORS policy

### DIFF
--- a/feedme.Server/Configuration/CorsSettings.cs
+++ b/feedme.Server/Configuration/CorsSettings.cs
@@ -1,0 +1,30 @@
+using System.Collections.Immutable;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace feedme.Server.Configuration;
+
+public sealed class CorsSettings
+{
+    public const string SectionName = "Cors";
+    public const string PolicyName = "ConfiguredOrigins";
+
+    public string[] AllowedOrigins { get; set; } = Array.Empty<string>();
+
+    public IReadOnlyCollection<string> GetSanitizedOrigins()
+    {
+        if (AllowedOrigins.Length == 0)
+        {
+            return Array.Empty<string>();
+        }
+
+        var sanitizedOrigins = AllowedOrigins
+            .Where(origin => !string.IsNullOrWhiteSpace(origin))
+            .Select(origin => origin.Trim().TrimEnd('/'))
+            .Where(origin => !string.IsNullOrWhiteSpace(origin))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToImmutableArray();
+
+        return sanitizedOrigins;
+    }
+}

--- a/feedme.Server/appsettings.json
+++ b/feedme.Server/appsettings.json
@@ -8,5 +8,11 @@
   "AllowedHosts": "*",
   "ConnectionStrings": {
     "WarehouseDb": "Host=localhost;Port=5432;Database=feedme;Username=postgres;Password=postgres"
+  },
+  "Cors": {
+    "AllowedOrigins": [
+      "http://localhost:4200",
+      "http://185.251.90.40"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- add strongly typed configuration to manage allowed CORS origins
- register a configurable CORS policy and ensure routing executes before controllers
- define default allowed origins in appsettings for local and remote clients

## Testing
- dotnet test *(fails: `dotnet` CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e03560254c832384c2d018d5758d7a