### PR TITLE
Improve configurable CORS policy and add coverage

### DIFF
--- a/feedme.Server.Tests/CorsTests.cs
+++ b/feedme.Server.Tests/CorsTests.cs
@@ -1,0 +1,66 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using feedme.Server.Configuration;
+using Xunit;
+
+namespace feedme.Server.Tests;
+
+public class CorsTests
+{
+    [Fact]
+    public async Task PreflightRequest_ReturnsCorsHeadersForConfiguredOrigin()
+    {
+        await using var factory = new FeedmeApplicationFactory()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureAppConfiguration((_, configuration) =>
+                {
+                    configuration.AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        [$"{CorsSettings.SectionName}:{nameof(CorsSettings.AllowedOrigins)}:0"] = "http://localhost:4200"
+                    });
+                });
+            });
+
+        using var client = factory.CreateClient();
+        using var request = new HttpRequestMessage(HttpMethod.Options, "/api/receipts");
+        request.Headers.Add("Origin", "http://localhost:4200");
+        request.Headers.Add("Access-Control-Request-Method", "GET");
+
+        using var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        Assert.True(response.Headers.TryGetValues("Access-Control-Allow-Origin", out var origins));
+        Assert.Contains("http://localhost:4200", origins);
+        Assert.True(response.Headers.TryGetValues("Access-Control-Allow-Methods", out var methods));
+        Assert.Contains(methods, value => !string.IsNullOrWhiteSpace(value));
+    }
+
+    [Fact]
+    public async Task GetRequest_IncludesCorsHeaderForConfiguredOrigin()
+    {
+        await using var factory = new FeedmeApplicationFactory()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureAppConfiguration((_, configuration) =>
+                {
+                    configuration.AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        [$"{CorsSettings.SectionName}:{nameof(CorsSettings.AllowedOrigins)}:0"] = "http://localhost:4200"
+                    });
+                });
+            });
+
+        using var client = factory.CreateClient();
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/api/receipts");
+        request.Headers.Add("Origin", "http://localhost:4200");
+
+        using var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.True(response.Headers.TryGetValues("Access-Control-Allow-Origin", out var origins));
+        Assert.Contains("http://localhost:4200", origins);
+    }
+}

--- a/feedme.Server/Configuration/CorsPolicyConfigurator.cs
+++ b/feedme.Server/Configuration/CorsPolicyConfigurator.cs
@@ -1,0 +1,44 @@
+using System;
+using Microsoft.AspNetCore.Cors.Infrastructure;
+using Microsoft.Extensions.Options;
+
+namespace feedme.Server.Configuration;
+
+public sealed class CorsPolicyConfigurator : IConfigureNamedOptions<CorsOptions>
+{
+    private readonly CorsSettings _settings;
+
+    public CorsPolicyConfigurator(IOptions<CorsSettings> corsOptions)
+    {
+        ArgumentNullException.ThrowIfNull(corsOptions);
+        _settings = corsOptions.Value;
+    }
+
+    public void Configure(string? name, CorsOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var policyBuilder = new CorsPolicyBuilder();
+        var allowedOrigins = _settings.GetSanitizedOrigins();
+
+        if (allowedOrigins.Count > 0)
+        {
+            policyBuilder.WithOrigins(allowedOrigins.ToArray());
+        }
+        else
+        {
+            policyBuilder.AllowAnyOrigin();
+        }
+
+        policyBuilder
+            .AllowAnyHeader()
+            .AllowAnyMethod();
+
+        options.AddPolicy(CorsSettings.PolicyName, policyBuilder.Build());
+    }
+
+    public void Configure(CorsOptions options)
+    {
+        Configure(null, options);
+    }
+}

--- a/feedme.Server/Program.cs
+++ b/feedme.Server/Program.cs
@@ -5,6 +5,7 @@ using feedme.Server.Configuration;
 using feedme.Server.Data;
 using feedme.Server.Extensions;
 using feedme.Server.Repositories;
+using Microsoft.AspNetCore.Cors.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -30,6 +31,9 @@ public class Program
         builder.Services
             .AddOptions<CorsSettings>()
             .Bind(builder.Configuration.GetSection(CorsSettings.SectionName));
+
+        builder.Services.AddCors();
+        builder.Services.AddSingleton<IConfigureOptions<CorsOptions>, CorsPolicyConfigurator>();
 
         builder.Services.AddDbContext<AppDbContext>((serviceProvider, options) =>
         {
@@ -72,34 +76,6 @@ public class Program
 
         builder.Services.AddHealthChecks()
             .AddDbContextCheck<AppDbContext>();
-
-        builder.Services.AddCors(options =>
-        {
-            var corsSettings = builder.Configuration
-                .GetSection(CorsSettings.SectionName)
-                .Get<CorsSettings>() ?? new CorsSettings();
-
-            var allowedOrigins = corsSettings.GetSanitizedOrigins();
-
-            options.AddPolicy(
-                CorsSettings.PolicyName,
-                policy =>
-                {
-                    if (allowedOrigins.Count > 0)
-                    {
-                        policy
-                            .WithOrigins(allowedOrigins.ToArray())
-                            .AllowAnyHeader()
-                            .AllowAnyMethod();
-                        return;
-                    }
-
-                    policy
-                        .AllowAnyOrigin()
-                        .AllowAnyHeader()
-                        .AllowAnyMethod();
-                });
-        });
 
         var app = builder.Build();
 


### PR DESCRIPTION
## Summary
- centralize the CORS policy definition in a dedicated options configurator
- register the configurator during startup and remove the inline policy setup
- add integration tests that verify CORS headers for allowed origins

## Testing
- dotnet test *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e050bd8b588323887c9ced7821bd8f