### PR TITLE
Allow configuring CORS origins with wildcard ports

### DIFF
--- a/feedme.Server.Tests/Configuration/CorsOriginRuleTests.cs
+++ b/feedme.Server.Tests/Configuration/CorsOriginRuleTests.cs
@@ -1,0 +1,34 @@
+using System;
+using feedme.Server.Configuration;
+using Xunit;
+
+namespace feedme.Server.Tests.Configuration;
+
+public class CorsOriginRuleTests
+{
+    [Fact]
+    public void TryCreate_WithWildcardPort_AllowsAnyPort()
+    {
+        var created = CorsOriginRule.TryCreate("http://example.com:*", out var rule);
+
+        Assert.True(created);
+        Assert.NotNull(rule);
+        Assert.True(rule!.AllowsAnyPort);
+        Assert.Equal("http://example.com", rule.NormalizedOrigin);
+        Assert.True(rule.Matches(new Uri("http://example.com:8080")));
+        Assert.True(rule.Matches(new Uri("http://example.com:5000")));
+    }
+
+    [Fact]
+    public void TryCreate_WithExplicitPort_MatchesOnlyThatPort()
+    {
+        var created = CorsOriginRule.TryCreate("http://localhost:4200", out var rule);
+
+        Assert.True(created);
+        Assert.NotNull(rule);
+        Assert.False(rule!.AllowsAnyPort);
+        Assert.Equal("http://localhost:4200", rule.NormalizedOrigin);
+        Assert.True(rule.Matches(new Uri("http://localhost:4200")));
+        Assert.False(rule.Matches(new Uri("http://localhost:4300")));
+    }
+}

--- a/feedme.Server.Tests/CorsTests.cs
+++ b/feedme.Server.Tests/CorsTests.cs
@@ -63,4 +63,31 @@ public class CorsTests
         Assert.True(response.Headers.TryGetValues("Access-Control-Allow-Origin", out var origins));
         Assert.Contains("http://localhost:4200", origins);
     }
+
+    [Fact]
+    public async Task PreflightRequest_ReturnsCorsHeadersForWildcardPortOrigin()
+    {
+        await using var factory = new FeedmeApplicationFactory()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureAppConfiguration((_, configuration) =>
+                {
+                    configuration.AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        [$"{CorsSettings.SectionName}:{nameof(CorsSettings.AllowedOrigins)}:0"] = "http://example.com:*"
+                    });
+                });
+            });
+
+        using var client = factory.CreateClient();
+        using var request = new HttpRequestMessage(HttpMethod.Options, "/api/receipts");
+        request.Headers.Add("Origin", "http://example.com:8080");
+        request.Headers.Add("Access-Control-Request-Method", "GET");
+
+        using var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        Assert.True(response.Headers.TryGetValues("Access-Control-Allow-Origin", out var origins));
+        Assert.Contains("http://example.com:8080", origins);
+    }
 }

--- a/feedme.Server/Configuration/CorsOriginRule.cs
+++ b/feedme.Server/Configuration/CorsOriginRule.cs
@@ -1,0 +1,99 @@
+using System;
+
+namespace feedme.Server.Configuration;
+
+public sealed class CorsOriginRule
+{
+    private CorsOriginRule(
+        string originalValue,
+        string scheme,
+        string host,
+        int? port,
+        bool allowsAnyPort)
+    {
+        OriginalValue = originalValue;
+        Scheme = scheme;
+        Host = host;
+        Port = port;
+        AllowsAnyPort = allowsAnyPort;
+        NormalizedOrigin = CreateNormalizedOrigin(scheme, host, port);
+    }
+
+    public string OriginalValue { get; }
+
+    public string Scheme { get; }
+
+    public string Host { get; }
+
+    public int? Port { get; }
+
+    public bool AllowsAnyPort { get; }
+
+    public string NormalizedOrigin { get; }
+
+    public static bool TryCreate(string value, out CorsOriginRule? rule)
+    {
+        rule = null;
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        var originValue = value.Trim();
+        var allowsAnyPort = originValue.EndsWith(":*", StringComparison.Ordinal);
+        var valueWithoutWildcard = allowsAnyPort
+            ? originValue[..^2]
+            : originValue;
+
+        if (!Uri.TryCreate(valueWithoutWildcard, UriKind.Absolute, out var uri))
+        {
+            return false;
+        }
+
+        if (!string.IsNullOrEmpty(uri.PathAndQuery) && uri.PathAndQuery != "/")
+        {
+            return false;
+        }
+
+        var port = uri.IsDefaultPort ? null : uri.Port;
+
+        rule = new CorsOriginRule(originValue, uri.Scheme, uri.Host, port, allowsAnyPort);
+        return true;
+    }
+
+    public bool Matches(Uri origin)
+    {
+        if (!string.Equals(origin.Scheme, Scheme, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (!string.Equals(origin.Host, Host, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (AllowsAnyPort)
+        {
+            return true;
+        }
+
+        if (Port is null)
+        {
+            return origin.IsDefaultPort;
+        }
+
+        return origin.Port == Port.Value;
+    }
+
+    private static string CreateNormalizedOrigin(string scheme, string host, int? port)
+    {
+        if (port is null)
+        {
+            return $"{scheme}://{host}";
+        }
+
+        return $"{scheme}://{host}:{port.Value}";
+    }
+}

--- a/feedme.Server/Configuration/CorsPolicyConfigurator.cs
+++ b/feedme.Server/Configuration/CorsPolicyConfigurator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Cors.Infrastructure;
 using Microsoft.Extensions.Options;
 
@@ -21,16 +22,26 @@ public sealed class CorsPolicyConfigurator : IConfigureNamedOptions<CorsOptions>
         var policyBuilder = new CorsPolicyBuilder();
         var allowedOrigins = _settings.GetSanitizedOrigins();
 
-        if (allowedOrigins.Count > 0)
-        {
-            policyBuilder.WithOrigins(allowedOrigins.ToArray());
-        }
-        else
+        if (allowedOrigins.Count == 0)
         {
             policyBuilder.AllowAnyOrigin();
+            policyBuilder
+                .AllowAnyHeader()
+                .AllowAnyMethod();
+
+            options.AddPolicy(CorsSettings.PolicyName, policyBuilder.Build());
+            return;
+        }
+
+        var originRules = CreateOriginRules(allowedOrigins);
+
+        if (originRules.AllowedOrigins.Count > 0)
+        {
+            policyBuilder.WithOrigins(originRules.AllowedOrigins.ToArray());
         }
 
         policyBuilder
+            .SetIsOriginAllowed(origin => originRules.IsAllowed(origin))
             .AllowAnyHeader()
             .AllowAnyMethod();
 
@@ -40,5 +51,72 @@ public sealed class CorsPolicyConfigurator : IConfigureNamedOptions<CorsOptions>
     public void Configure(CorsOptions options)
     {
         Configure(null, options);
+    }
+
+    private static CorsOriginRuleSet CreateOriginRules(IReadOnlyCollection<string> configuredOrigins)
+    {
+        var rules = new List<CorsOriginRule>();
+        var allowedOrigins = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var origin in configuredOrigins)
+        {
+            if (!CorsOriginRule.TryCreate(origin, out var rule))
+            {
+                continue;
+            }
+
+            rules.Add(rule);
+
+            if (!rule.AllowsAnyPort)
+            {
+                allowedOrigins.Add(rule.NormalizedOrigin);
+            }
+        }
+
+        return new CorsOriginRuleSet(rules, allowedOrigins);
+    }
+
+    private sealed class CorsOriginRuleSet
+    {
+        private readonly IReadOnlyCollection<CorsOriginRule> _rules;
+        private readonly HashSet<string> _allowedOrigins;
+
+        public CorsOriginRuleSet(
+            IReadOnlyCollection<CorsOriginRule> rules,
+            HashSet<string> allowedOrigins)
+        {
+            _rules = rules;
+            _allowedOrigins = allowedOrigins;
+        }
+
+        public IReadOnlyCollection<string> AllowedOrigins => _allowedOrigins;
+
+        public bool IsAllowed(string origin)
+        {
+            if (_allowedOrigins.Contains(origin))
+            {
+                return true;
+            }
+
+            if (_rules.Count == 0)
+            {
+                return false;
+            }
+
+            if (!Uri.TryCreate(origin, UriKind.Absolute, out var parsedOrigin))
+            {
+                return false;
+            }
+
+            foreach (var rule in _rules)
+            {
+                if (rule.Matches(parsedOrigin))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
     }
 }

--- a/feedme.Server/appsettings.json
+++ b/feedme.Server/appsettings.json
@@ -12,7 +12,7 @@
   "Cors": {
     "AllowedOrigins": [
       "http://localhost:4200",
-      "http://185.251.90.40"
+      "http://185.251.90.40:*"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- add a `CorsOriginRule` helper to parse configured origins and support wildcard port matching
- update the CORS policy configurator to honour wildcard ports and keep existing exact origin handling
- add unit and integration coverage for the new behaviour and update the default configuration to allow the API host on any port

## Testing
- dotnet test *(fails: `dotnet`: command not found in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0ec7ecf908323bfdfbbb2b5a0f6d5