### PR TITLE
Improve CORS origin matching for host-only entries

### DIFF
--- a/feedme.Server.Tests/Configuration/CorsOriginMatcherTests.cs
+++ b/feedme.Server.Tests/Configuration/CorsOriginMatcherTests.cs
@@ -1,0 +1,36 @@
+using feedme.Server.Configuration;
+using Xunit;
+
+namespace feedme.Server.Tests.Configuration;
+
+public class CorsOriginMatcherTests
+{
+    [Fact]
+    public void TryCreate_ReturnsNull_ForInvalidOrigin()
+    {
+        var matcher = CorsOriginMatcher.TryCreate("not-a-valid-origin");
+
+        Assert.Null(matcher);
+    }
+
+    [Fact]
+    public void Matches_ReturnsTrue_ForExactOrigin()
+    {
+        var matcher = CorsOriginMatcher.TryCreate("http://localhost:4200");
+
+        Assert.NotNull(matcher);
+        Assert.True(matcher!.Matches("http://localhost:4200"));
+        Assert.False(matcher.Matches("http://localhost:4201"));
+    }
+
+    [Fact]
+    public void Matches_IgnoresPort_WhenOriginDoesNotSpecifyPort()
+    {
+        var matcher = CorsOriginMatcher.TryCreate("http://localhost");
+
+        Assert.NotNull(matcher);
+        Assert.True(matcher!.Matches("http://localhost:4200"));
+        Assert.True(matcher.Matches("http://localhost:3000"));
+        Assert.False(matcher.Matches("http://example.com:4200"));
+    }
+}

--- a/feedme.Server/Configuration/CorsOriginMatcher.cs
+++ b/feedme.Server/Configuration/CorsOriginMatcher.cs
@@ -1,0 +1,72 @@
+using System;
+
+namespace feedme.Server.Configuration;
+
+internal sealed class CorsOriginMatcher
+{
+    private readonly string _original;
+    private readonly string _scheme;
+    private readonly string _host;
+    private readonly int? _port;
+
+    private CorsOriginMatcher(string original, string scheme, string host, int? port)
+    {
+        _original = original;
+        _scheme = scheme;
+        _host = host;
+        _port = port;
+    }
+
+    public static CorsOriginMatcher? TryCreate(string origin)
+    {
+        if (string.IsNullOrWhiteSpace(origin))
+        {
+            return null;
+        }
+
+        if (!Uri.TryCreate(origin, UriKind.Absolute, out var parsedOrigin))
+        {
+            return null;
+        }
+
+        var normalizedOrigin = parsedOrigin.GetLeftPart(UriPartial.Authority);
+        int? port = parsedOrigin.IsDefaultPort ? null : parsedOrigin.Port;
+
+        return new CorsOriginMatcher(normalizedOrigin, parsedOrigin.Scheme, parsedOrigin.Host, port);
+    }
+
+    public bool Matches(string? origin)
+    {
+        if (string.IsNullOrWhiteSpace(origin))
+        {
+            return false;
+        }
+
+        if (string.Equals(origin, _original, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (!Uri.TryCreate(origin, UriKind.Absolute, out var candidate))
+        {
+            return false;
+        }
+
+        if (!string.Equals(candidate.Scheme, _scheme, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (!string.Equals(candidate.Host, _host, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (_port.HasValue)
+        {
+            return candidate.Port == _port.Value;
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable `CorsOriginMatcher` that treats host-only origins as port-agnostic matches
- update the CORS policy configurator to use the matcher while preserving fallback behaviour
- cover the new matcher and host-only configuration with focused unit and integration tests

## Testing
- `dotnet test feedme.Server.Tests/feedme.Server.Tests.csproj --logger "console;verbosity=minimal"` *(fails: System.Runtime TypeLoadException when loading appsettings via WebApplicationFactory on the preview .NET SDK available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0ec81572483239651f5b57068a67e