### PR TITLE
Fix CORS policy when only wildcard origins configured

### DIFF
--- a/feedme.Server/Configuration/CorsPolicyConfigurator.cs
+++ b/feedme.Server/Configuration/CorsPolicyConfigurator.cs
@@ -67,10 +67,7 @@ public sealed class CorsPolicyConfigurator : IConfigureNamedOptions<CorsOptions>
 
             rules.Add(rule);
 
-            if (!rule.AllowsAnyPort)
-            {
-                allowedOrigins.Add(rule.NormalizedOrigin);
-            }
+            allowedOrigins.Add(rule.NormalizedOrigin);
         }
 
         return new CorsOriginRuleSet(rules, allowedOrigins);


### PR DESCRIPTION
## Summary
- ensure CORS policies include normalized origins even when only wildcard port entries are configured
- guarantee Access-Control-Allow-Origin headers are emitted for wildcard origins to unblock Angular clients

## Testing
- `dotnet test` *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0f7550648832386f8a442e2aec358