### PR TITLE
Fix CORS origin rule null handling

### DIFF
--- a/feedme.Server/Configuration/CorsOriginRule.cs
+++ b/feedme.Server/Configuration/CorsOriginRule.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace feedme.Server.Configuration;
 
@@ -31,7 +32,7 @@ public sealed class CorsOriginRule
 
     public string NormalizedOrigin { get; }
 
-    public static bool TryCreate(string value, out CorsOriginRule? rule)
+    public static bool TryCreate(string value, [NotNullWhen(true)] out CorsOriginRule? rule)
     {
         rule = null;
 
@@ -56,7 +57,7 @@ public sealed class CorsOriginRule
             return false;
         }
 
-        var port = uri.IsDefaultPort ? null : uri.Port;
+        int? port = uri.IsDefaultPort ? null : uri.Port;
 
         rule = new CorsOriginRule(originValue, uri.Scheme, uri.Host, port, allowsAnyPort);
         return true;


### PR DESCRIPTION
## Summary
- explicitly treat parsed port values as nullable to avoid ambiguous conditional types
- annotate CORS origin creation helper so successful parsing always returns a non-null rule

## Testing
- dotnet build feedme.Server/feedme.Server.csproj *(fails: `dotnet` command is not available in the current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0fb584f388323812e8f5408f58d87