### PR TITLE
Fix CORS origin parsing nullability

### DIFF
--- a/feedme.Server/Configuration/CorsOriginRule.cs
+++ b/feedme.Server/Configuration/CorsOriginRule.cs
@@ -56,7 +56,7 @@ public sealed class CorsOriginRule
             return false;
         }
 
-        var port = uri.IsDefaultPort ? null : uri.Port;
+        int? port = uri.IsDefaultPort ? null : uri.Port;
 
         rule = new CorsOriginRule(originValue, uri.Scheme, uri.Host, port, allowsAnyPort);
         return true;

--- a/feedme.Server/Configuration/CorsPolicyConfigurator.cs
+++ b/feedme.Server/Configuration/CorsPolicyConfigurator.cs
@@ -60,7 +60,7 @@ public sealed class CorsPolicyConfigurator : IConfigureNamedOptions<CorsOptions>
 
         foreach (var origin in configuredOrigins)
         {
-            if (!CorsOriginRule.TryCreate(origin, out var rule))
+            if (!CorsOriginRule.TryCreate(origin, out var rule) || rule is null)
             {
                 continue;
             }


### PR DESCRIPTION
## Summary
- ensure CORS origin parsing uses nullable-aware port handling
- guard against null rules when building the configured CORS origin list

## Testing
- dotnet build feedme.sln *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68e0fb584f388323812e8f5408f58d87