### PR TITLE
Add diagnostics for receipt API failures

### DIFF
--- a/feedme.client/src/app/services/api-error-parser.service.ts
+++ b/feedme.client/src/app/services/api-error-parser.service.ts
@@ -1,0 +1,260 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+
+import { ApiRequestError, ApiRequestContext } from './api-request-error';
+
+export interface CreateApiErrorParams {
+  readonly method: string;
+  readonly url: string;
+  readonly payload?: unknown;
+  readonly error: unknown;
+}
+
+@Injectable({ providedIn: 'root' })
+export class ApiErrorParserService {
+  create(params: CreateApiErrorParams): ApiRequestError {
+    if (params.error instanceof ApiRequestError) {
+      return params.error;
+    }
+
+    const context: ApiRequestContext = {
+      method: this.normalizeMethod(params.method),
+      url: this.normalizeUrl(params.url),
+      payloadPreview: this.formatPayload(params.payload),
+    };
+
+    if (params.error instanceof HttpErrorResponse) {
+      return this.fromHttpError(context, params.error);
+    }
+
+    if (params.error instanceof Error) {
+      const details = this.buildBaseDetails(context);
+      details.push(`Причина: ${params.error.message}`);
+
+      return new ApiRequestError(
+        context,
+        null,
+        null,
+        'Не удалось выполнить запрос к API.',
+        details,
+        params.error,
+      );
+    }
+
+    return new ApiRequestError(
+      context,
+      null,
+      null,
+      'Не удалось выполнить запрос к API.',
+      this.buildBaseDetails(context),
+      params.error,
+    );
+  }
+
+  private fromHttpError(context: ApiRequestContext, error: HttpErrorResponse): ApiRequestError {
+    const status = Number.isFinite(error.status) ? error.status : null;
+    const statusText = error.statusText?.trim() ? error.statusText.trim() : null;
+
+    const details = this.buildBaseDetails(context);
+    if (status !== null) {
+      const suffix = statusText ? ` (${statusText})` : '';
+      details.push(`Код статуса: ${status}${suffix}`);
+    } else {
+      details.push('Код статуса: не определён');
+    }
+
+    const serverMessage = this.extractServerMessage(error.error);
+    if (serverMessage) {
+      details.push(`Сообщение сервера: ${serverMessage}`);
+    }
+
+    const responsePreview = this.formatPayload(error.error);
+    if (responsePreview && responsePreview !== serverMessage) {
+      details.push(`Ответ сервера (сырые данные): ${responsePreview}`);
+    }
+
+    const networkHints = this.describeNetworkHints(error);
+    details.push(...networkHints);
+
+    const userMessage = this.composeUserMessage(status, statusText, serverMessage, networkHints);
+
+    return new ApiRequestError(context, status, statusText, userMessage, details, error);
+  }
+
+  private composeUserMessage(
+    status: number | null,
+    statusText: string | null,
+    serverMessage: string | null,
+    networkHints: readonly string[],
+  ): string {
+    if (status === 0) {
+      return 'Браузер заблокировал запрос к API. Проверьте настройки CORS и доступность сервера.';
+    }
+
+    if (status !== null && status >= 500) {
+      const suffix = statusText ? ` (${statusText})` : '';
+      return `Сервер вернул внутреннюю ошибку${suffix ? suffix : ''}.`;
+    }
+
+    if (status !== null && status >= 400) {
+      const suffix = statusText ? ` (${statusText})` : '';
+      return `Сервер отклонил запрос${suffix ? suffix : ''}.`;
+    }
+
+    if (serverMessage) {
+      return `Сервер вернул ошибку: ${serverMessage}`;
+    }
+
+    if (networkHints.length > 0) {
+      return 'Не удалось выполнить запрос из-за сетевых ограничений.';
+    }
+
+    return 'Не удалось выполнить запрос к API.';
+  }
+
+  private buildBaseDetails(context: ApiRequestContext): string[] {
+    const details = [`Метод: ${context.method}`, `URL: ${context.url}`];
+
+    if (context.payloadPreview) {
+      details.push(`Тело запроса: ${context.payloadPreview}`);
+    }
+
+    return details;
+  }
+
+  private describeNetworkHints(error: HttpErrorResponse): string[] {
+    const hints: string[] = [];
+
+    if (error.status === 0) {
+      hints.push('Подсказка: статус 0 указывает на сетевую ошибку или блокировку CORS.');
+    }
+
+    if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+      hints.push('Подсказка: браузер сообщает об отсутствии подключения к интернету.');
+    }
+
+    if (error.url && error.url.startsWith('http://') && typeof window !== 'undefined') {
+      const currentProtocol = window.location?.protocol ?? '';
+      if (currentProtocol === 'https:') {
+        hints.push('Подсказка: смешанный контент (https страница и http API) может блокироваться браузером.');
+      }
+    }
+
+    return hints;
+  }
+
+  private extractServerMessage(payload: unknown): string | null {
+    if (payload == null) {
+      return null;
+    }
+
+    if (typeof payload === 'string') {
+      const normalized = payload.trim();
+      return normalized.length > 0 ? normalized : null;
+    }
+
+    if (typeof payload === 'object') {
+      const message = this.tryExtractString(payload as Record<string, unknown>, [
+        'message',
+        'title',
+        'error',
+        'detail',
+      ]);
+
+      if (message) {
+        return message;
+      }
+
+      if ('errors' in (payload as Record<string, unknown>)) {
+        const errors = (payload as Record<string, unknown>)['errors'];
+        if (errors && typeof errors === 'object') {
+          const entries = Object.entries(errors as Record<string, unknown>);
+          if (entries.length > 0) {
+            return entries
+              .map(([field, value]) => {
+                if (Array.isArray(value)) {
+                  return `${field}: ${value.filter(Boolean).join(', ')}`;
+                }
+
+                if (value && typeof value === 'object') {
+                  return `${field}: ${this.formatPayload(value) ?? '[объект]'}`;
+                }
+
+                return `${field}: ${String(value)}`;
+              })
+              .join('; ');
+          }
+        }
+      }
+    }
+
+    return null;
+  }
+
+  private tryExtractString(source: Record<string, unknown>, keys: readonly string[]): string | null {
+    for (const key of keys) {
+      const value = source[key];
+      if (typeof value === 'string' && value.trim().length > 0) {
+        return value.trim();
+      }
+    }
+
+    return null;
+  }
+
+  private formatPayload(payload: unknown): string | null {
+    if (payload == null) {
+      return null;
+    }
+
+    if (typeof payload === 'string') {
+      const trimmed = payload.trim();
+      if (trimmed.length === 0) {
+        return null;
+      }
+
+      return this.truncate(trimmed);
+    }
+
+    try {
+      const serialized = JSON.stringify(payload);
+      if (!serialized || serialized === '""') {
+        return null;
+      }
+
+      return this.truncate(serialized);
+    } catch {
+      return null;
+    }
+  }
+
+  private truncate(value: string, max = 280): string {
+    if (value.length <= max) {
+      return value;
+    }
+
+    return `${value.slice(0, max - 1)}…`;
+  }
+
+  private normalizeMethod(method: string): string {
+    if (typeof method === 'string') {
+      const normalized = method.trim().toUpperCase();
+      if (normalized.length > 0) {
+        return normalized;
+      }
+    }
+
+    return 'GET';
+  }
+
+  private normalizeUrl(url: string): string {
+    if (typeof url === 'string') {
+      const normalized = url.trim();
+      if (normalized.length > 0) {
+        return normalized;
+      }
+    }
+
+    return 'не указан';
+  }
+}

--- a/feedme.client/src/app/services/api-request-error.ts
+++ b/feedme.client/src/app/services/api-request-error.ts
@@ -1,0 +1,29 @@
+export interface ApiRequestContext {
+  readonly method: string;
+  readonly url: string;
+  readonly payloadPreview: string | null;
+}
+
+export class ApiRequestError extends Error {
+  readonly details: readonly string[];
+
+  constructor(
+    public readonly context: ApiRequestContext,
+    public readonly status: number | null,
+    public readonly statusText: string | null,
+    message: string,
+    details: readonly string[],
+    cause: unknown,
+  ) {
+    super(message);
+    this.name = 'ApiRequestError';
+    this.details = Object.freeze([...details]);
+    if (cause !== undefined) {
+      (this as { cause?: unknown }).cause = cause;
+    }
+  }
+
+  get userMessage(): string {
+    return this.message;
+  }
+}

--- a/feedme.client/src/app/warehouse/supplies/supplies.component.html
+++ b/feedme.client/src/app/warehouse/supplies/supplies.component.html
@@ -162,9 +162,12 @@
       </header>
 
       <div class="supplies-dialog__body">
-        <p class="supplies-dialog__alert" *ngIf="submissionError() as error" role="alert">
-          {{ error }}
-        </p>
+        <div class="supplies-dialog__alert" *ngIf="submissionError() as error" role="alert">
+          <span class="supplies-dialog__alert-title">{{ error.title }}</span>
+          <ul class="supplies-dialog__alert-details" *ngIf="error.details.length > 0">
+            <li *ngFor="let detail of error.details">{{ detail }}</li>
+          </ul>
+        </div>
         <section class="supplies-dialog__section">
           <h3 class="supplies-dialog__section-title">Детали документа</h3>
           <div class="supplies-dialog__grid">

--- a/feedme.client/src/app/warehouse/supplies/supplies.component.scss
+++ b/feedme.client/src/app/warehouse/supplies/supplies.component.scss
@@ -471,6 +471,24 @@
   font-size: 0.875rem;
 }
 
+.supplies-dialog__alert-title {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.supplies-dialog__alert-details {
+  margin: 0.5rem 0 0;
+  padding-left: 1.25rem;
+  display: grid;
+  gap: 0.25rem;
+  list-style: disc;
+}
+
+.supplies-dialog__alert-details li {
+  margin: 0;
+}
+
 .supplies-dialog__section-title {
   margin: 0 0 1rem;
   font-size: 1rem;


### PR DESCRIPTION
## Summary
- add reusable `ApiRequestError` model and `ApiErrorParserService` to collect HTTP diagnostics for API calls
- wrap all receipt service requests with structured error handling to include method, URL, and payload context
- surface detailed submission errors in the supplies dialog with richer UI feedback for debugging

## Testing
- npm run lint *(fails: project has no configured lint target)*
- npm run test *(fails: ChromeHeadless cannot start because libatk-1.0.so.0 is missing in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e10f5c1b148323aabecf95634d05d7