### PR TITLE
Fix dev proxy fallback when backend endpoint is unreachable

### DIFF
--- a/feedme.client/src/proxy.conf.js
+++ b/feedme.client/src/proxy.conf.js
@@ -14,7 +14,10 @@ const FALLBACK_ENDPOINTS = [
   'http://localhost:5016'
 ];
 
-const { endpoint: target, attemptedEndpoints } = resolveFirstReachableEndpoint([
+const {
+  endpoint: target,
+  attemptedEndpoints
+} = resolveFirstReachableEndpoint([
   () => resolvePreferredEndpoint([
     'services__feedme-server__https__0',
     'services__feedme-server__http__0'
@@ -31,6 +34,7 @@ if (!target) {
 
 function resolveFirstReachableEndpoint(resolvers) {
   const attemptedEndpoints = [];
+  let firstCandidate;
 
   for (const resolveCandidate of resolvers) {
     const value = resolveCandidate();
@@ -52,6 +56,10 @@ function resolveFirstReachableEndpoint(resolvers) {
         continue;
       }
 
+      if (!firstCandidate) {
+        firstCandidate = normalized;
+      }
+
       if (isEndpointReachable(normalized)) {
         attemptedEndpoints.push(normalized);
 
@@ -66,7 +74,7 @@ function resolveFirstReachableEndpoint(resolvers) {
   }
 
   return {
-    endpoint: undefined,
+    endpoint: firstCandidate,
     attemptedEndpoints
   };
 }


### PR DESCRIPTION
## Summary
- prevent the Angular dev proxy from aborting when none of the probed backend endpoints respond
- keep the first resolved endpoint as a graceful fallback so the frontend can start without a running backend

## Testing
- npm run build -- --progress=false
- npm run lint *(fails: workspace does not define a lint target)*

------
https://chatgpt.com/codex/tasks/task_e_68e137af951c832399a20250b3568a73