### PR TITLE
Add Angular CLI dev proxy for remote backend

### DIFF
--- a/feedme.client/package.json
+++ b/feedme.client/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "prebuild": "node ./scripts/prepare-build-folders.mjs",
     "pretest": "npm ci || npm i",
-    "start": "npx ng serve --open",
+    "start": "npx ng serve --open --proxy-config proxy.conf.cjs",
     "build": "npx ng build",
     "test": "npx ng test --watch=false --browsers=ChromeHeadlessNoSandbox",
     "lint": "npx ng lint"

--- a/feedme.client/proxy.conf.cjs
+++ b/feedme.client/proxy.conf.cjs
@@ -1,0 +1,42 @@
+const { readFileSync } = require('node:fs');
+const { resolve } = require('node:path');
+
+const REMOTE_CONFIG_PATH = resolve(__dirname, 'src', 'environments', 'remote-backend.config.json');
+const DEFAULT_API_PATH = '/api';
+
+function loadRemoteBackendConfig() {
+  const raw = readFileSync(REMOTE_CONFIG_PATH, 'utf-8');
+  return JSON.parse(raw);
+}
+
+function normalizeBaseUrl(baseUrl) {
+  if (typeof baseUrl !== 'string' || !baseUrl.trim()) {
+    throw new Error('Remote backend baseUrl must be defined in remote-backend.config.json.');
+  }
+
+  return baseUrl.trim().replace(/\/+$/, '');
+}
+
+function normalizeApiPath(apiPath) {
+  const value = typeof apiPath === 'string' ? apiPath : DEFAULT_API_PATH;
+  const trimmed = value.trim();
+
+  if (!trimmed) {
+    throw new Error('Remote backend apiPath cannot be empty when configuring the development proxy.');
+  }
+
+  return trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+}
+
+const remoteBackendConfig = loadRemoteBackendConfig();
+const target = normalizeBaseUrl(remoteBackendConfig.baseUrl);
+const apiPath = normalizeApiPath(remoteBackendConfig.apiPath);
+
+module.exports = {
+  [apiPath]: {
+    target,
+    secure: false,
+    changeOrigin: true,
+    logLevel: 'warn'
+  }
+};

--- a/feedme.client/src/environments/api-base-url.builder.ts
+++ b/feedme.client/src/environments/api-base-url.builder.ts
@@ -1,6 +1,6 @@
 import type { EnvironmentConfig } from './environment.model';
 
-type RemoteBackendConfig = {
+export type RemoteBackendConfig = {
   baseUrl?: string;
   apiPath?: string;
 };
@@ -15,7 +15,7 @@ const DEFAULT_API_PATH = '/api';
  */
 export function buildEnvironmentConfig(
   config: RemoteBackendConfig,
-  overrides?: Partial<Pick<EnvironmentConfig, 'production'>>
+  overrides?: Partial<EnvironmentConfig>
 ): EnvironmentConfig {
   const apiBaseUrl = composeApiBaseUrl(config);
 
@@ -24,6 +24,10 @@ export function buildEnvironmentConfig(
     apiBaseUrl,
     ...overrides
   };
+}
+
+export function resolveApiPath(config: RemoteBackendConfig): string {
+  return normalizeApiPath(config.apiPath ?? DEFAULT_API_PATH);
 }
 
 function composeApiBaseUrl(config: RemoteBackendConfig): string {

--- a/feedme.client/src/environments/environment.prod.ts
+++ b/feedme.client/src/environments/environment.prod.ts
@@ -5,9 +5,15 @@
 // но явно включает флаг production.
 
 import type { EnvironmentConfig } from './environment.model';
-import { buildEnvironmentConfig } from './api-base-url.builder';
-import remoteBackendConfig from './remote-backend.config.json';
+import {
+  buildEnvironmentConfig,
+  type RemoteBackendConfig
+} from './api-base-url.builder';
+import remoteBackendConfigJson from './remote-backend.config.json';
 
+const remoteBackendConfig = remoteBackendConfigJson satisfies RemoteBackendConfig;
 
-export const environment: EnvironmentConfig = buildEnvironmentConfig(remoteBackendConfig, { production: true });
+export const environment: EnvironmentConfig = buildEnvironmentConfig(remoteBackendConfig, {
+  production: true
+});
 

--- a/feedme.client/src/environments/environment.ts
+++ b/feedme.client/src/environments/environment.ts
@@ -1,14 +1,24 @@
 // src/environments/environment.ts
 //
 
-// Dev-окружение тоже обращается к удалённому серверу.
-// Это исключает любые обращения к localhost и позволяет тестировать приложение
-// на том же API, что и в продакшене.
+// Dev-окружение использует прокси Angular CLI, чтобы перенаправлять запросы
+// к удалённому серверу через тот же origin. Это избавляет от проблем с CORS,
+// сохраняя работу с тем же API, что и в продакшене.
 
 import type { EnvironmentConfig } from './environment.model';
-import { buildEnvironmentConfig } from './api-base-url.builder';
-import remoteBackendConfig from './remote-backend.config.json';
+import {
+  buildEnvironmentConfig,
+  resolveApiPath,
+  type RemoteBackendConfig
+} from './api-base-url.builder';
+import remoteBackendConfigJson from './remote-backend.config.json';
 
+const remoteBackendConfig = remoteBackendConfigJson satisfies RemoteBackendConfig;
+const remoteEnvironment = buildEnvironmentConfig(remoteBackendConfig);
+const proxyAwareApiBaseUrl = resolveApiPath(remoteBackendConfig) || '/';
 
-export const environment: EnvironmentConfig = buildEnvironmentConfig(remoteBackendConfig);
+export const environment: EnvironmentConfig = {
+  ...remoteEnvironment,
+  apiBaseUrl: proxyAwareApiBaseUrl
+};
 


### PR DESCRIPTION
## Summary
- add an Angular CLI proxy configuration that forwards API requests to the configured remote backend
- reuse the remote backend configuration typing to share normalization helpers across environments and set the dev API base to a relative path
- update the development start script to enable the proxy and keep production settings intact

## Testing
- npm run test --prefix feedme.client *(fails: ChromeHeadless cannot start because libatk-1.0.so.0 is missing in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2e390c6608323bdf64036656bf16e