### PR TITLE
Configure development API to use remote Postgres

### DIFF
--- a/feedme.Server/appsettings.Development.json
+++ b/feedme.Server/appsettings.Development.json
@@ -5,7 +5,15 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "Database": {
+    "Provider": "Postgres",
+    "Host": "185.251.90.40",
+    "Port": "5432",
+    "Name": "feedme",
+    "Username": "feedme",
+    "Password": "feedme"
+  },
   "ConnectionStrings": {
-    "WarehouseDb": "Host=localhost;Port=5432;Database=feedme_dev;Username=postgres;Password=postgres"
+    "WarehouseDb": "Host=185.251.90.40;Port=5432;Database=feedme;Username=feedme;Password=feedme"
   }
 }


### PR DESCRIPTION
## Summary
- point the development connection string at the remote Postgres host 185.251.90.40
- configure the development environment to select the Postgres provider and supply the remote credentials via Database options

## Testing
- not run (runtime dependencies for backend tests are unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68e2f16817088323918c155e4244a85f