### PR TITLE
Remove redundant catalog search input and update tab styles

### DIFF
--- a/feedme.client/src/app/components/catalog/catalog.component.css
+++ b/feedme.client/src/app/components/catalog/catalog.component.css
@@ -37,6 +37,8 @@
   cursor: pointer;
   font-weight: 500;
   font-size: 16px;
+  color: #111827;
+  transition: color 0.2s ease-in-out;
 }
 .tabs button:focus-visible {
   outline: 2px solid rgba(37, 99, 235, 0.8);
@@ -45,8 +47,8 @@
   border-radius: 6px;
 }
 .tabs button.active {
-  border-bottom: 2px solid #007bff;
-  color: #007bff;
+  border-bottom: 2px solid #fa4b00;
+  color: #fa4b00;
 }
 .error-message {
   color: #dc3545;

--- a/feedme.client/src/app/components/catalog/catalog.component.html
+++ b/feedme.client/src/app/components/catalog/catalog.component.html
@@ -1,5 +1,4 @@
 <div class="catalog-header">
-  <input type="text" placeholder="Поиск…" [(ngModel)]="filter" />
   <div class="tabs">
     <button type="button" (click)="activeTab='info'" [class.active]="activeTab==='info'">Основная информация</button>
     <button type="button" (click)="activeTab='logistics'" [class.active]="activeTab==='logistics'">Закупка и логистика</button>
@@ -27,7 +26,7 @@
           </tr>
         </thead>
         <tbody>
-          <tr *ngFor="let item of catalogData | filter:filter">
+          <tr *ngFor="let item of catalogData">
             <td>{{ item.name }}</td>
             <td>{{ item.type }}</td>
             <td>{{ item.code }}</td>
@@ -58,7 +57,7 @@
           </tr>
         </thead>
         <tbody>
-          <tr *ngFor="let item of catalogData | filter:filter">
+          <tr *ngFor="let item of catalogData">
             <td>{{ item.supplier }}</td>
             <td>{{ item.costEstimate }}</td>
             <td>{{ item.taxRate }}</td>

--- a/feedme.client/src/app/components/catalog/catalog.component.ts
+++ b/feedme.client/src/app/components/catalog/catalog.component.ts
@@ -8,11 +8,9 @@ import {
   signal,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { FormsModule } from '@angular/forms';
 
 import { BehaviorSubject, EMPTY, catchError, take, tap } from 'rxjs';
 
-import { FilterPipe } from '../../pipes/filter.pipe';
 import { NewProductFormValues } from '../catalog-new-product-popup/catalog-new-product-popup.component';
 import { CatalogItem, CatalogService } from '../../services/catalog.service';
 import { EmptyStateComponent } from '../../warehouse/ui/empty-state.component';
@@ -37,8 +35,6 @@ export class BooleanLabelPipe implements PipeTransform {
   standalone: true,
   imports: [
     CommonModule,
-    FormsModule,
-    FilterPipe,
     BooleanLabelPipe,
     EmptyStateComponent,
     CatalogNewProductPopupComponent,
@@ -51,8 +47,6 @@ export class CatalogComponent implements OnInit {
   private readonly catalogService = inject(CatalogService);
 
   activeTab: 'info' | 'logistics' = 'info';
-  filter = '';
-
   private readonly newProductPopupOpen = signal(false);
   private readonly newProductError = signal<string | null>(null);
   private readonly loadError = signal<string | null>(null);


### PR DESCRIPTION
## Summary
- remove the local catalog search input to avoid duplicating global search controls
- simplify the catalog table bindings now that filtering is handled elsewhere
- update the catalog tab styles to use dark text by default and orange when active

## Testing
- npm run lint *(fails: Angular project does not define a lint target)*

------
https://chatgpt.com/codex/tasks/task_e_68e2f1e27dac83238d05f1c724238f91