### PR TITLE
Configure production database to remote server

### DIFF
--- a/feedme.Server/appsettings.json
+++ b/feedme.Server/appsettings.json
@@ -6,8 +6,16 @@
     }
   },
   "AllowedHosts": "*",
+  "Database": {
+    "Provider": "Postgres",
+    "Host": "185.251.90.40",
+    "Port": "5432",
+    "Name": "feedme",
+    "Username": "feedme",
+    "Password": "feedme"
+  },
   "ConnectionStrings": {
-    "WarehouseDb": "Host=localhost;Port=5432;Database=feedme;Username=postgres;Password=postgres"
+    "WarehouseDb": "Host=185.251.90.40;Port=5432;Database=feedme;Username=feedme;Password=feedme"
   },
   "Cors": {
     "AllowedOrigins": [


### PR DESCRIPTION
## Summary
- configure the production appsettings to use the remote Postgres instance by default
- expose the connection details through both the strongly typed database options and the main connection string

## Testing
- dotnet test *(fails: dotnet command is unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2f61ebfb883238f71a7afa1e3d021