### PR TITLE
Add structured logging across API

### DIFF
--- a/feedme.Server/Controllers/CatalogController.cs
+++ b/feedme.Server/Controllers/CatalogController.cs
@@ -1,36 +1,100 @@
 using feedme.Server.Models;
 using feedme.Server.Repositories;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 
 namespace feedme.Server.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
-public class CatalogController : ControllerBase
+public partial class CatalogController : ControllerBase
 {
     private readonly ICatalogRepository _repository;
+    private readonly ILogger<CatalogController> _logger;
 
-    public CatalogController(ICatalogRepository repository)
+    public CatalogController(ICatalogRepository repository, ILogger<CatalogController> logger)
     {
         _repository = repository;
+        _logger = logger;
     }
 
     [HttpGet]
     public async Task<ActionResult<IEnumerable<CatalogItem>>> Get()
-        => Ok(await _repository.GetAllAsync());
+    {
+        Log.RequestingCatalogItems(_logger);
+
+        try
+        {
+            var items = (await _repository.GetAllAsync()).ToArray();
+
+            Log.CatalogItemsRetrieved(_logger, items.Length);
+
+            return Ok(items);
+        }
+        catch (Exception exception)
+        {
+            Log.CatalogItemsRetrievalFailed(_logger, exception);
+            throw;
+        }
+    }
 
     [HttpGet("{id}")]
     public async Task<ActionResult<CatalogItem>> GetById(string id)
     {
-        var item = await _repository.GetByIdAsync(id);
-        return item is null ? NotFound() : Ok(item);
+        var normalizedId = id?.Trim() ?? string.Empty;
+
+        if (string.IsNullOrWhiteSpace(normalizedId))
+        {
+            Log.MissingCatalogItemIdentifier(_logger);
+            return NotFound();
+        }
+
+        Log.RequestingCatalogItem(_logger, normalizedId);
+
+        try
+        {
+            var item = await _repository.GetByIdAsync(normalizedId);
+
+            if (item is null)
+            {
+                Log.CatalogItemNotFound(_logger, normalizedId);
+                return NotFound();
+            }
+
+            Log.CatalogItemReturned(_logger, normalizedId);
+            return Ok(item);
+        }
+        catch (Exception exception)
+        {
+            Log.CatalogItemRetrievalFailed(_logger, normalizedId, exception);
+            throw;
+        }
     }
 
     [HttpPost]
     public async Task<ActionResult<CatalogItem>> Create([FromBody] CatalogItem item)
     {
-        var created = await _repository.AddAsync(item);
-        return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
+        if (item is null)
+        {
+            Log.CatalogItemPayloadMissing(_logger);
+            return BadRequest();
+        }
+
+        Log.CreatingCatalogItem(_logger, item.Id);
+
+        try
+        {
+            var created = await _repository.AddAsync(item);
+
+            Log.CatalogItemCreated(_logger, created.Id);
+
+            return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
+        }
+        catch (Exception exception)
+        {
+            Log.CatalogItemCreationFailed(_logger, exception);
+            throw;
+        }
     }
 
     [HttpDelete("{id?}")]
@@ -40,10 +104,77 @@ public class CatalogController : ControllerBase
 
         if (string.IsNullOrWhiteSpace(normalizedId))
         {
+            Log.MissingCatalogItemIdentifier(_logger);
             return NotFound();
         }
 
-        var deleted = await _repository.DeleteAsync(normalizedId!);
-        return deleted ? NoContent() : NotFound();
+        Log.DeletingCatalogItem(_logger, normalizedId!);
+
+        try
+        {
+            var deleted = await _repository.DeleteAsync(normalizedId!);
+
+            if (!deleted)
+            {
+                Log.CatalogItemNotFound(_logger, normalizedId!);
+                return NotFound();
+            }
+
+            Log.CatalogItemDeleted(_logger, normalizedId!);
+            return NoContent();
+        }
+        catch (Exception exception)
+        {
+            Log.CatalogItemDeletionFailed(_logger, normalizedId!, exception);
+            throw;
+        }
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(EventId = 1, Level = LogLevel.Information, Message = "Retrieving all catalog items.")]
+        public static partial void RequestingCatalogItems(ILogger logger);
+
+        [LoggerMessage(EventId = 2, Level = LogLevel.Information, Message = "Retrieved {Count} catalog items.")]
+        public static partial void CatalogItemsRetrieved(ILogger logger, int count);
+
+        [LoggerMessage(EventId = 3, Level = LogLevel.Error, Message = "Failed to retrieve catalog items.")]
+        public static partial void CatalogItemsRetrievalFailed(ILogger logger, Exception exception);
+
+        [LoggerMessage(EventId = 4, Level = LogLevel.Warning, Message = "Catalog item identifier is missing or empty.")]
+        public static partial void MissingCatalogItemIdentifier(ILogger logger);
+
+        [LoggerMessage(EventId = 5, Level = LogLevel.Information, Message = "Retrieving catalog item with identifier '{CatalogItemId}'.")]
+        public static partial void RequestingCatalogItem(ILogger logger, string catalogItemId);
+
+        [LoggerMessage(EventId = 6, Level = LogLevel.Warning, Message = "Catalog item with identifier '{CatalogItemId}' was not found.")]
+        public static partial void CatalogItemNotFound(ILogger logger, string catalogItemId);
+
+        [LoggerMessage(EventId = 7, Level = LogLevel.Information, Message = "Catalog item with identifier '{CatalogItemId}' was retrieved successfully.")]
+        public static partial void CatalogItemReturned(ILogger logger, string catalogItemId);
+
+        [LoggerMessage(EventId = 8, Level = LogLevel.Error, Message = "Failed to retrieve catalog item with identifier '{CatalogItemId}'.")]
+        public static partial void CatalogItemRetrievalFailed(ILogger logger, string catalogItemId, Exception exception);
+
+        [LoggerMessage(EventId = 9, Level = LogLevel.Warning, Message = "Catalog item payload is missing.")]
+        public static partial void CatalogItemPayloadMissing(ILogger logger);
+
+        [LoggerMessage(EventId = 10, Level = LogLevel.Information, Message = "Creating catalog item (incoming identifier: '{CatalogItemId}').")]
+        public static partial void CreatingCatalogItem(ILogger logger, string? catalogItemId);
+
+        [LoggerMessage(EventId = 11, Level = LogLevel.Information, Message = "Catalog item with identifier '{CatalogItemId}' was created successfully.")]
+        public static partial void CatalogItemCreated(ILogger logger, string catalogItemId);
+
+        [LoggerMessage(EventId = 12, Level = LogLevel.Error, Message = "Failed to create catalog item.")]
+        public static partial void CatalogItemCreationFailed(ILogger logger, Exception exception);
+
+        [LoggerMessage(EventId = 13, Level = LogLevel.Information, Message = "Deleting catalog item with identifier '{CatalogItemId}'.")]
+        public static partial void DeletingCatalogItem(ILogger logger, string catalogItemId);
+
+        [LoggerMessage(EventId = 14, Level = LogLevel.Information, Message = "Catalog item with identifier '{CatalogItemId}' was deleted successfully.")]
+        public static partial void CatalogItemDeleted(ILogger logger, string catalogItemId);
+
+        [LoggerMessage(EventId = 15, Level = LogLevel.Error, Message = "Failed to delete catalog item with identifier '{CatalogItemId}'.")]
+        public static partial void CatalogItemDeletionFailed(ILogger logger, string catalogItemId, Exception exception);
     }
 }

--- a/feedme.Server/Controllers/ReceiptsController.cs
+++ b/feedme.Server/Controllers/ReceiptsController.cs
@@ -6,40 +6,102 @@ using feedme.Server.Models;
 using feedme.Server.Repositories;
 using feedme.Server.Services;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 
 namespace feedme.Server.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
-public class ReceiptsController : ControllerBase
+public partial class ReceiptsController : ControllerBase
 {
     private readonly IReceiptRepository _repository;
+    private readonly ILogger<ReceiptsController> _logger;
 
-    public ReceiptsController(IReceiptRepository repository)
+    public ReceiptsController(IReceiptRepository repository, ILogger<ReceiptsController> logger)
     {
         _repository = repository;
+        _logger = logger;
     }
 
     [HttpGet]
     public async Task<ActionResult<IEnumerable<ReceiptResponse>>> Get()
     {
-        var receipts = await _repository.GetAllAsync();
-        return Ok(receipts.Select(MapReceipt));
+        Log.RequestingReceipts(_logger);
+
+        try
+        {
+            var receipts = (await _repository.GetAllAsync()).ToArray();
+            var responses = receipts.Select(MapReceipt).ToArray();
+
+            Log.ReceiptsRetrieved(_logger, responses.Length);
+
+            return Ok(responses);
+        }
+        catch (Exception exception)
+        {
+            Log.ReceiptsRetrievalFailed(_logger, exception);
+            throw;
+        }
     }
 
     [HttpGet("{id}")]
     public async Task<ActionResult<ReceiptResponse>> GetById(string id)
     {
-        var receipt = await _repository.GetByIdAsync(id);
-        return receipt is null ? NotFound() : Ok(MapReceipt(receipt));
+        var normalizedId = id?.Trim() ?? string.Empty;
+
+        if (string.IsNullOrWhiteSpace(normalizedId))
+        {
+            Log.MissingReceiptIdentifier(_logger);
+            return NotFound();
+        }
+
+        Log.RequestingReceipt(_logger, normalizedId);
+
+        try
+        {
+            var receipt = await _repository.GetByIdAsync(normalizedId);
+
+            if (receipt is null)
+            {
+                Log.ReceiptNotFound(_logger, normalizedId);
+                return NotFound();
+            }
+
+            Log.ReceiptReturned(_logger, normalizedId);
+            return Ok(MapReceipt(receipt));
+        }
+        catch (Exception exception)
+        {
+            Log.ReceiptRetrievalFailed(_logger, normalizedId, exception);
+            throw;
+        }
     }
 
     [HttpPost]
     public async Task<ActionResult<ReceiptResponse>> Create([FromBody] Receipt receipt)
     {
-        var created = await _repository.AddAsync(receipt);
-        var response = MapReceipt(created);
-        return CreatedAtAction(nameof(GetById), new { id = response.Id }, response);
+        if (receipt is null)
+        {
+            Log.ReceiptPayloadMissing(_logger);
+            return BadRequest();
+        }
+
+        Log.CreatingReceipt(_logger, receipt.Id);
+
+        try
+        {
+            var created = await _repository.AddAsync(receipt);
+            var response = MapReceipt(created);
+
+            Log.ReceiptCreated(_logger, response.Id);
+
+            return CreatedAtAction(nameof(GetById), new { id = response.Id }, response);
+        }
+        catch (Exception exception)
+        {
+            Log.ReceiptCreationFailed(_logger, exception);
+            throw;
+        }
     }
 
     [HttpPut("{id}")]
@@ -47,23 +109,69 @@ public class ReceiptsController : ControllerBase
     {
         if (receipt is null)
         {
+            Log.ReceiptPayloadMissing(_logger);
             return BadRequest();
         }
 
         if (!string.Equals(id, receipt.Id, StringComparison.OrdinalIgnoreCase))
         {
+            Log.ReceiptIdentifierAdjusted(_logger, receipt.Id, id);
             receipt.Id = id;
         }
 
-        var updated = await _repository.UpdateAsync(receipt);
-        return updated is null ? NotFound() : Ok(MapReceipt(updated));
+        Log.UpdatingReceipt(_logger, id);
+
+        try
+        {
+            var updated = await _repository.UpdateAsync(receipt);
+
+            if (updated is null)
+            {
+                Log.ReceiptNotFound(_logger, id);
+                return NotFound();
+            }
+
+            Log.ReceiptUpdated(_logger, id);
+            return Ok(MapReceipt(updated));
+        }
+        catch (Exception exception)
+        {
+            Log.ReceiptUpdateFailed(_logger, id, exception);
+            throw;
+        }
     }
 
     [HttpDelete("{id}")]
     public async Task<IActionResult> Delete(string id)
     {
-        var removed = await _repository.RemoveAsync(id);
-        return removed ? NoContent() : NotFound();
+        var normalizedId = id?.Trim() ?? string.Empty;
+
+        if (string.IsNullOrWhiteSpace(normalizedId))
+        {
+            Log.MissingReceiptIdentifier(_logger);
+            return NotFound();
+        }
+
+        Log.DeletingReceipt(_logger, normalizedId);
+
+        try
+        {
+            var removed = await _repository.RemoveAsync(normalizedId);
+
+            if (!removed)
+            {
+                Log.ReceiptNotFound(_logger, normalizedId);
+                return NotFound();
+            }
+
+            Log.ReceiptDeleted(_logger, normalizedId);
+            return NoContent();
+        }
+        catch (Exception exception)
+        {
+            Log.ReceiptDeletionFailed(_logger, normalizedId, exception);
+            throw;
+        }
     }
 
     private static ReceiptResponse MapReceipt(Receipt receipt)
@@ -102,5 +210,65 @@ public class ReceiptsController : ControllerBase
             line.TotalCost,
             line.ExpiryDate,
             status);
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(EventId = 1, Level = LogLevel.Information, Message = "Retrieving all receipts.")]
+        public static partial void RequestingReceipts(ILogger logger);
+
+        [LoggerMessage(EventId = 2, Level = LogLevel.Information, Message = "Retrieved {Count} receipts.")]
+        public static partial void ReceiptsRetrieved(ILogger logger, int count);
+
+        [LoggerMessage(EventId = 3, Level = LogLevel.Error, Message = "Failed to retrieve receipts.")]
+        public static partial void ReceiptsRetrievalFailed(ILogger logger, Exception exception);
+
+        [LoggerMessage(EventId = 4, Level = LogLevel.Warning, Message = "Receipt identifier is missing or empty.")]
+        public static partial void MissingReceiptIdentifier(ILogger logger);
+
+        [LoggerMessage(EventId = 5, Level = LogLevel.Information, Message = "Retrieving receipt with identifier '{ReceiptId}'.")]
+        public static partial void RequestingReceipt(ILogger logger, string receiptId);
+
+        [LoggerMessage(EventId = 6, Level = LogLevel.Warning, Message = "Receipt with identifier '{ReceiptId}' was not found.")]
+        public static partial void ReceiptNotFound(ILogger logger, string receiptId);
+
+        [LoggerMessage(EventId = 7, Level = LogLevel.Information, Message = "Receipt with identifier '{ReceiptId}' was retrieved successfully.")]
+        public static partial void ReceiptReturned(ILogger logger, string receiptId);
+
+        [LoggerMessage(EventId = 8, Level = LogLevel.Error, Message = "Failed to retrieve receipt with identifier '{ReceiptId}'.")]
+        public static partial void ReceiptRetrievalFailed(ILogger logger, string receiptId, Exception exception);
+
+        [LoggerMessage(EventId = 9, Level = LogLevel.Warning, Message = "Receipt payload is missing.")]
+        public static partial void ReceiptPayloadMissing(ILogger logger);
+
+        [LoggerMessage(EventId = 10, Level = LogLevel.Information, Message = "Creating receipt (incoming identifier: '{ReceiptId}').")]
+        public static partial void CreatingReceipt(ILogger logger, string? receiptId);
+
+        [LoggerMessage(EventId = 11, Level = LogLevel.Information, Message = "Receipt with identifier '{ReceiptId}' was created successfully.")]
+        public static partial void ReceiptCreated(ILogger logger, string receiptId);
+
+        [LoggerMessage(EventId = 12, Level = LogLevel.Error, Message = "Failed to create receipt.")]
+        public static partial void ReceiptCreationFailed(ILogger logger, Exception exception);
+
+        [LoggerMessage(EventId = 13, Level = LogLevel.Information, Message = "Updating receipt with identifier '{ReceiptId}'.")]
+        public static partial void UpdatingReceipt(ILogger logger, string receiptId);
+
+        [LoggerMessage(EventId = 14, Level = LogLevel.Information, Message = "Receipt identifier adjusted from '{OriginalReceiptId}' to '{NormalizedReceiptId}'.")]
+        public static partial void ReceiptIdentifierAdjusted(ILogger logger, string? originalReceiptId, string normalizedReceiptId);
+
+        [LoggerMessage(EventId = 15, Level = LogLevel.Information, Message = "Receipt with identifier '{ReceiptId}' was updated successfully.")]
+        public static partial void ReceiptUpdated(ILogger logger, string receiptId);
+
+        [LoggerMessage(EventId = 16, Level = LogLevel.Error, Message = "Failed to update receipt with identifier '{ReceiptId}'.")]
+        public static partial void ReceiptUpdateFailed(ILogger logger, string receiptId, Exception exception);
+
+        [LoggerMessage(EventId = 17, Level = LogLevel.Information, Message = "Deleting receipt with identifier '{ReceiptId}'.")]
+        public static partial void DeletingReceipt(ILogger logger, string receiptId);
+
+        [LoggerMessage(EventId = 18, Level = LogLevel.Information, Message = "Receipt with identifier '{ReceiptId}' was deleted successfully.")]
+        public static partial void ReceiptDeleted(ILogger logger, string receiptId);
+
+        [LoggerMessage(EventId = 19, Level = LogLevel.Error, Message = "Failed to delete receipt with identifier '{ReceiptId}'.")]
+        public static partial void ReceiptDeletionFailed(ILogger logger, string receiptId, Exception exception);
     }
 }

--- a/feedme.Server/Repositories/PostgresCatalogRepository.cs
+++ b/feedme.Server/Repositories/PostgresCatalogRepository.cs
@@ -1,63 +1,128 @@
 using feedme.Server.Data;
 using feedme.Server.Models;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
 namespace feedme.Server.Repositories;
 
-public class PostgresCatalogRepository(AppDbContext context) : ICatalogRepository
+public partial class PostgresCatalogRepository(AppDbContext context, ILogger<PostgresCatalogRepository> logger) : ICatalogRepository
 {
     private readonly AppDbContext _context = context;
+    private readonly ILogger<PostgresCatalogRepository> _logger = logger;
 
     public async Task<IEnumerable<CatalogItem>> GetAllAsync()
     {
-        return await _context.CatalogItems
-            .AsNoTracking()
-            .OrderBy(item => item.Name)
-            .ToListAsync();
+        Log.RequestingCatalogItems(_logger);
+
+        try
+        {
+            var items = await _context.CatalogItems
+                .AsNoTracking()
+                .OrderBy(item => item.Name)
+                .ToListAsync();
+
+            Log.CatalogItemsRetrieved(_logger, items.Count);
+
+            return items;
+        }
+        catch (Exception exception)
+        {
+            Log.CatalogItemsRetrievalFailed(_logger, exception);
+            throw;
+        }
     }
 
     public async Task<CatalogItem?> GetByIdAsync(string id)
     {
         if (string.IsNullOrWhiteSpace(id))
         {
+            Log.MissingIdentifier(_logger);
             return null;
         }
 
-        return await _context.CatalogItems
-            .AsNoTracking()
-            .SingleOrDefaultAsync(item => item.Id == id);
+        Log.RequestingCatalogItem(_logger, id);
+
+        try
+        {
+            var item = await _context.CatalogItems
+                .AsNoTracking()
+                .SingleOrDefaultAsync(item => item.Id == id);
+
+            if (item is null)
+            {
+                Log.CatalogItemNotFound(_logger, id);
+            }
+            else
+            {
+                Log.CatalogItemRetrieved(_logger, id);
+            }
+
+            return item;
+        }
+        catch (Exception exception)
+        {
+            Log.CatalogItemRetrievalFailed(_logger, id, exception);
+            throw;
+        }
     }
 
     public async Task<CatalogItem> AddAsync(CatalogItem item)
     {
         var normalized = Normalize(item);
 
-        _context.CatalogItems.Add(normalized);
-        await _context.SaveChangesAsync();
+        Log.CreatingCatalogItem(_logger, normalized.Id);
 
-        return (await GetByIdAsync(normalized.Id))!;
+        try
+        {
+            _context.CatalogItems.Add(normalized);
+            await _context.SaveChangesAsync();
+
+            Log.CatalogItemCreated(_logger, normalized.Id);
+
+            return (await GetByIdAsync(normalized.Id))!;
+        }
+        catch (Exception exception)
+        {
+            Log.CatalogItemCreationFailed(_logger, normalized.Id, exception);
+            throw;
+        }
     }
 
     public async Task<bool> DeleteAsync(string id)
     {
         if (string.IsNullOrWhiteSpace(id))
         {
+            Log.MissingIdentifier(_logger);
             return false;
         }
 
         var normalizedId = id.Trim();
-        var existingItem = await _context.CatalogItems
-            .SingleOrDefaultAsync(item => item.Id == normalizedId);
 
-        if (existingItem is null)
+        Log.DeletingCatalogItem(_logger, normalizedId);
+
+        try
         {
-            return false;
+            var existingItem = await _context.CatalogItems
+                .SingleOrDefaultAsync(item => item.Id == normalizedId);
+
+            if (existingItem is null)
+            {
+                Log.CatalogItemNotFound(_logger, normalizedId);
+                return false;
+            }
+
+            _context.CatalogItems.Remove(existingItem);
+            await _context.SaveChangesAsync();
+
+            Log.CatalogItemDeleted(_logger, normalizedId);
+
+            return true;
         }
-
-        _context.CatalogItems.Remove(existingItem);
-        await _context.SaveChangesAsync();
-
-        return true;
+        catch (Exception exception)
+        {
+            Log.CatalogItemDeletionFailed(_logger, normalizedId, exception);
+            throw;
+        }
     }
 
     private static CatalogItem Normalize(CatalogItem item)
@@ -100,4 +165,49 @@ public class PostgresCatalogRepository(AppDbContext context) : ICatalogRepositor
     }
 
     private static string Sanitize(string value) => value?.Trim() ?? string.Empty;
+
+    private static partial class Log
+    {
+        [LoggerMessage(EventId = 1, Level = LogLevel.Information, Message = "Retrieving catalog items from the database.")]
+        public static partial void RequestingCatalogItems(ILogger logger);
+
+        [LoggerMessage(EventId = 2, Level = LogLevel.Information, Message = "Retrieved {Count} catalog items from the database.")]
+        public static partial void CatalogItemsRetrieved(ILogger logger, int count);
+
+        [LoggerMessage(EventId = 3, Level = LogLevel.Error, Message = "Failed to retrieve catalog items from the database.")]
+        public static partial void CatalogItemsRetrievalFailed(ILogger logger, Exception exception);
+
+        [LoggerMessage(EventId = 4, Level = LogLevel.Warning, Message = "Catalog item identifier is missing.")]
+        public static partial void MissingIdentifier(ILogger logger);
+
+        [LoggerMessage(EventId = 5, Level = LogLevel.Information, Message = "Retrieving catalog item '{CatalogItemId}' from the database.")]
+        public static partial void RequestingCatalogItem(ILogger logger, string catalogItemId);
+
+        [LoggerMessage(EventId = 6, Level = LogLevel.Warning, Message = "Catalog item '{CatalogItemId}' was not found in the database.")]
+        public static partial void CatalogItemNotFound(ILogger logger, string catalogItemId);
+
+        [LoggerMessage(EventId = 7, Level = LogLevel.Information, Message = "Catalog item '{CatalogItemId}' was retrieved from the database.")]
+        public static partial void CatalogItemRetrieved(ILogger logger, string catalogItemId);
+
+        [LoggerMessage(EventId = 8, Level = LogLevel.Error, Message = "Failed to retrieve catalog item '{CatalogItemId}' from the database.")]
+        public static partial void CatalogItemRetrievalFailed(ILogger logger, string catalogItemId, Exception exception);
+
+        [LoggerMessage(EventId = 9, Level = LogLevel.Information, Message = "Creating catalog item '{CatalogItemId}'.")]
+        public static partial void CreatingCatalogItem(ILogger logger, string catalogItemId);
+
+        [LoggerMessage(EventId = 10, Level = LogLevel.Information, Message = "Catalog item '{CatalogItemId}' was created in the database.")]
+        public static partial void CatalogItemCreated(ILogger logger, string catalogItemId);
+
+        [LoggerMessage(EventId = 11, Level = LogLevel.Error, Message = "Failed to create catalog item '{CatalogItemId}'.")]
+        public static partial void CatalogItemCreationFailed(ILogger logger, string catalogItemId, Exception exception);
+
+        [LoggerMessage(EventId = 12, Level = LogLevel.Information, Message = "Deleting catalog item '{CatalogItemId}'.")]
+        public static partial void DeletingCatalogItem(ILogger logger, string catalogItemId);
+
+        [LoggerMessage(EventId = 13, Level = LogLevel.Information, Message = "Catalog item '{CatalogItemId}' was deleted from the database.")]
+        public static partial void CatalogItemDeleted(ILogger logger, string catalogItemId);
+
+        [LoggerMessage(EventId = 14, Level = LogLevel.Error, Message = "Failed to delete catalog item '{CatalogItemId}'.")]
+        public static partial void CatalogItemDeletionFailed(ILogger logger, string catalogItemId, Exception exception);
+    }
 }


### PR DESCRIPTION
## Summary
- add structured logging to catalog endpoints to trace request flow and failure scenarios
- introduce detailed receipt logging to capture missing identifiers, CRUD operations, and error handling
- extend PostgreSQL repositories with structured diagnostics around database operations

## Testing
- `dotnet test` *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2fc988ca08323a65364ba84ed320e