### PR TITLE
Configure logging filters for server

### DIFF
--- a/feedme.Server/Extensions/LoggingBuilderExtensions.cs
+++ b/feedme.Server/Extensions/LoggingBuilderExtensions.cs
@@ -1,0 +1,20 @@
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace feedme.Server.Extensions;
+
+public static class LoggingBuilderExtensions
+{
+    public static ILoggingBuilder ConfigureServerLogging(this ILoggingBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.AddFilter("Microsoft", LogLevel.Warning);
+        builder.AddFilter("System", LogLevel.Warning);
+        builder.AddFilter("Microsoft.EntityFrameworkCore.Database.Command", LogLevel.Warning);
+        builder.AddFilter("Microsoft.AspNetCore.Hosting.Diagnostics", LogLevel.Warning);
+        builder.AddFilter("Microsoft.AspNetCore.Routing.EndpointMiddleware", LogLevel.Warning);
+
+        return builder;
+    }
+}

--- a/feedme.Server/Program.cs
+++ b/feedme.Server/Program.cs
@@ -21,6 +21,7 @@ public class Program
     {
         var builder = WebApplication.CreateBuilder(args);
         builder.AddServiceDefaults();
+        builder.Logging.ConfigureServerLogging();
 
         // Add services to the container.
 


### PR DESCRIPTION
## Summary
- add a dedicated logging builder extension that registers filters for noisy framework categories
- invoke the shared logging configuration during server startup to keep production logs focused on application events

## Testing
- Not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e2ff71178883238aad98f329189b34