### PR TITLE
Add structured log rotation for backend

### DIFF
--- a/feedme.Server/Configuration/FileLoggingOptions.cs
+++ b/feedme.Server/Configuration/FileLoggingOptions.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace feedme.Server.Configuration;
+
+public sealed class FileLoggingOptions
+{
+    public const string SectionName = "Logging:File";
+
+    public string Directory { get; init; } = "Logs";
+
+    public string FileName { get; init; } = "feedme";
+
+    public string RollingInterval { get; init; } = "Day";
+
+    public int? RetainedFileCountLimit { get; init; } = 14;
+
+    public long FileSizeLimitBytes { get; init; } = 20 * 1_024 * 1_024;
+
+    public TimeSpan FlushInterval { get; init; } = TimeSpan.FromSeconds(1);
+}

--- a/feedme.Server/Extensions/LoggingBuilderExtensions.cs
+++ b/feedme.Server/Extensions/LoggingBuilderExtensions.cs
@@ -1,20 +1,78 @@
 using System;
-using Microsoft.Extensions.Logging;
+using System.IO;
+using feedme.Server.Configuration;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Serilog;
+using Serilog.Events;
+using Serilog.Formatting.Json;
 
 namespace feedme.Server.Extensions;
 
 public static class LoggingBuilderExtensions
 {
-    public static ILoggingBuilder ConfigureServerLogging(this ILoggingBuilder builder)
+    public static void ConfigureServerLogging(this WebApplicationBuilder builder)
     {
         ArgumentNullException.ThrowIfNull(builder);
 
-        builder.AddFilter("Microsoft", LogLevel.Warning);
-        builder.AddFilter("System", LogLevel.Warning);
-        builder.AddFilter("Microsoft.EntityFrameworkCore.Database.Command", LogLevel.Warning);
-        builder.AddFilter("Microsoft.AspNetCore.Hosting.Diagnostics", LogLevel.Warning);
-        builder.AddFilter("Microsoft.AspNetCore.Routing.EndpointMiddleware", LogLevel.Warning);
+        builder.Host.UseSerilog((context, services, loggerConfiguration) =>
+        {
+            var fileOptions = context.Configuration
+                .GetSection(FileLoggingOptions.SectionName)
+                .Get<FileLoggingOptions>() ?? new FileLoggingOptions();
 
-        return builder;
+            var logDirectory = ResolveLogDirectory(fileOptions.Directory);
+            var rollingInterval = ResolveRollingInterval(fileOptions.RollingInterval);
+            var logFilePath = Path.Combine(logDirectory, $"{fileOptions.FileName}-.json");
+
+            loggerConfiguration
+                .ReadFrom.Configuration(context.Configuration)
+                .ReadFrom.Services(services)
+                .Enrich.FromLogContext()
+                .Enrich.WithProperty("Application", context.HostingEnvironment.ApplicationName)
+                .Enrich.WithProperty("Environment", context.HostingEnvironment.EnvironmentName)
+                .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
+                .MinimumLevel.Override("System", LogEventLevel.Warning)
+                .MinimumLevel.Override("Microsoft.EntityFrameworkCore.Database.Command", LogEventLevel.Warning)
+                .MinimumLevel.Override("Microsoft.AspNetCore.Hosting.Diagnostics", LogEventLevel.Warning)
+                .MinimumLevel.Override("Microsoft.AspNetCore.Routing.EndpointMiddleware", LogEventLevel.Warning)
+                .WriteTo.Console()
+                .WriteTo.Async(writeTo =>
+                    writeTo.File(
+                        formatter: new JsonFormatter(renderMessage: true),
+                        path: logFilePath,
+                        rollingInterval: rollingInterval,
+                        retainedFileCountLimit: fileOptions.RetainedFileCountLimit,
+                        fileSizeLimitBytes: fileOptions.FileSizeLimitBytes,
+                        rollOnFileSizeLimit: true,
+                        shared: true,
+                        flushToDiskInterval: fileOptions.FlushInterval));
+        });
+    }
+
+    private static string ResolveLogDirectory(string? configuredDirectory)
+    {
+        var directoryPath = string.IsNullOrWhiteSpace(configuredDirectory)
+            ? Path.Combine(AppContext.BaseDirectory, "Logs")
+            : configuredDirectory!;
+
+        return Directory.CreateDirectory(directoryPath).FullName;
+    }
+
+    private static RollingInterval ResolveRollingInterval(string? configuredInterval)
+    {
+        if (string.IsNullOrWhiteSpace(configuredInterval))
+        {
+            return RollingInterval.Day;
+        }
+
+        if (Enum.TryParse<RollingInterval>(configuredInterval, true, out var rollingInterval))
+        {
+            return rollingInterval;
+        }
+
+        throw new InvalidOperationException(
+            $"Unsupported log rolling interval '{configuredInterval}'. See {nameof(RollingInterval)} for allowed values.");
     }
 }

--- a/feedme.Server/Program.cs
+++ b/feedme.Server/Program.cs
@@ -20,8 +20,8 @@ public class Program
     public static async Task Main(string[] args)
     {
         var builder = WebApplication.CreateBuilder(args);
+        builder.ConfigureServerLogging();
         builder.AddServiceDefaults();
-        builder.Logging.ConfigureServerLogging();
 
         // Add services to the container.
 

--- a/feedme.Server/appsettings.Development.json
+++ b/feedme.Server/appsettings.Development.json
@@ -3,6 +3,14 @@
     "LogLevel": {
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
+    },
+    "File": {
+      "Directory": "Logs",
+      "FileName": "feedme-development",
+      "RollingInterval": "Day",
+      "RetainedFileCountLimit": 7,
+      "FileSizeLimitBytes": 10485760,
+      "FlushInterval": "00:00:01"
     }
   },
   "Database": {

--- a/feedme.Server/appsettings.json
+++ b/feedme.Server/appsettings.json
@@ -3,6 +3,14 @@
     "LogLevel": {
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
+    },
+    "File": {
+      "Directory": "Logs",
+      "FileName": "feedme",
+      "RollingInterval": "Day",
+      "RetainedFileCountLimit": 14,
+      "FileSizeLimitBytes": 20971520,
+      "FlushInterval": "00:00:01"
     }
   },
   "AllowedHosts": "*",

--- a/feedme.Server/feedme.Server.csproj
+++ b/feedme.Server/feedme.Server.csproj
@@ -20,6 +20,9 @@
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="9.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.2" />
+    <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- integrate Serilog with the ASP.NET host to provide structured console and file logging
- add configurable file logging options with rolling files, retention, and size limits
- extend configuration files with sensible defaults for production and development environments

## Testing
- `dotnet test` *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e30073bf2c83239c6e0f03e6bb446c