### PR TITLE
Improve database connection string overrides

### DIFF
--- a/feedme.Server.Tests/Configuration/PostgresConnectionStringFactoryTests.cs
+++ b/feedme.Server.Tests/Configuration/PostgresConnectionStringFactoryTests.cs
@@ -86,6 +86,109 @@ public class PostgresConnectionStringFactoryTests
     }
 
     [Fact]
+    public void Create_AppliesAdditionalEnvironmentOverrides()
+    {
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            [$"ConnectionStrings:{ConnectionStringName}"] = "Host=localhost;Port=5432;Database=feedme_dev;Username=postgres;Password=postgres",
+            ["DATABASE_HOST"] = "database.example.com",
+            ["DB_PORT"] = "6543",
+            ["DATABASE_NAME"] = "warehouse",
+            ["DB_USER"] = "warehouse-user",
+            ["DATABASE_PASSWORD"] = "warehouse-password",
+            ["DATABASE_SSLMODE"] = "Disable"
+        });
+
+        var connectionString = PostgresConnectionStringFactory.Create(configuration, ConnectionStringName);
+        var builder = new NpgsqlConnectionStringBuilder(connectionString);
+
+        Assert.Equal("database.example.com", builder.Host);
+        Assert.Equal(6543, builder.Port);
+        Assert.Equal("warehouse", builder.Database);
+        Assert.Equal("warehouse-user", builder.Username);
+        Assert.Equal("warehouse-password", builder.Password);
+        Assert.Equal(SslMode.Disable, builder.SslMode);
+    }
+
+    [Fact]
+    public void Create_UsesDatabaseConnectionStringOverride()
+    {
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["Database:ConnectionString"] = "Host=185.251.90.40;Port=5432;Database=feedme;Username=feedme;Password=feedme"
+        });
+
+        var connectionString = PostgresConnectionStringFactory.Create(configuration, ConnectionStringName);
+        var builder = new NpgsqlConnectionStringBuilder(connectionString);
+
+        Assert.Equal("185.251.90.40", builder.Host);
+        Assert.Equal(5432, builder.Port);
+        Assert.Equal("feedme", builder.Database);
+        Assert.Equal("feedme", builder.Username);
+        Assert.Equal("feedme", builder.Password);
+    }
+
+    [Fact]
+    public void Create_UsesDatabaseUrlOverride()
+    {
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["Database:Url"] = "postgres://feedme-user:secret@185.251.90.40:5434/feedme"
+        });
+
+        var connectionString = PostgresConnectionStringFactory.Create(configuration, ConnectionStringName);
+        var builder = new NpgsqlConnectionStringBuilder(connectionString);
+
+        Assert.Equal("185.251.90.40", builder.Host);
+        Assert.Equal(5434, builder.Port);
+        Assert.Equal("feedme", builder.Database);
+        Assert.Equal("feedme-user", builder.Username);
+        Assert.Equal("secret", builder.Password);
+    }
+
+    [Fact]
+    public void Create_UsesDatabaseUrlOverride_WithQueryParameters()
+    {
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["Database:Url"] = "postgresql://feedme:password@185.251.90.40/feedme?SslMode=Require&Pooling=true"
+        });
+
+        var connectionString = PostgresConnectionStringFactory.Create(configuration, ConnectionStringName);
+        var builder = new NpgsqlConnectionStringBuilder(connectionString);
+
+        Assert.Equal("185.251.90.40", builder.Host);
+        Assert.Equal(5432, builder.Port);
+        Assert.Equal("feedme", builder.Database);
+        Assert.Equal("feedme", builder.Username);
+        Assert.Equal("password", builder.Password);
+        Assert.Equal(SslMode.Require, builder.SslMode);
+        Assert.True(builder.Pooling);
+    }
+
+    [Fact]
+    public void Create_ThrowsInvalidOperationException_ForUnsupportedUrlScheme()
+    {
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["Database:Url"] = "mysql://feedme:password@localhost/feedme"
+        });
+
+        Assert.Throws<InvalidOperationException>(() => PostgresConnectionStringFactory.Create(configuration, ConnectionStringName));
+    }
+
+    [Fact]
+    public void Create_ThrowsInvalidOperationException_ForInvalidUrl()
+    {
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["Database:Url"] = "not-a-valid-url"
+        });
+
+        Assert.Throws<InvalidOperationException>(() => PostgresConnectionStringFactory.Create(configuration, ConnectionStringName));
+    }
+
+    [Fact]
     public void Create_ThrowsInvalidOperationException_ForInvalidPort()
     {
         var configuration = BuildConfiguration(new Dictionary<string, string?>

--- a/feedme.Server/Configuration/PostgresConnectionStringFactory.cs
+++ b/feedme.Server/Configuration/PostgresConnectionStringFactory.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Linq;
 using Microsoft.Extensions.Configuration;
 using Npgsql;
 
@@ -7,6 +8,8 @@ namespace feedme.Server.Configuration;
 public static class PostgresConnectionStringFactory
 {
     private const string FallbackConnectionStringName = "Default";
+    private static readonly string[] SupportedUriSchemes = ["postgres", "postgresql"];
+    private const int DefaultPostgresPort = 5432;
 
     public static string Create(IConfiguration configuration, string connectionStringName)
     {
@@ -23,6 +26,13 @@ public static class PostgresConnectionStringFactory
 
     private static string ResolveBaseConnectionString(IConfiguration configuration, string connectionStringName)
     {
+        var overrideConnectionString = ResolveConnectionStringOverride(configuration, connectionStringName);
+
+        if (!string.IsNullOrWhiteSpace(overrideConnectionString))
+        {
+            return NormalizeConnectionString(overrideConnectionString);
+        }
+
         var primaryConnectionString = configuration.GetConnectionString(connectionStringName);
 
         if (!string.IsNullOrWhiteSpace(primaryConnectionString))
@@ -45,7 +55,11 @@ public static class PostgresConnectionStringFactory
     {
         var host = FirstNonEmpty(
             configuration["Database:Host"],
-            configuration["POSTGRES_HOST"]);
+            configuration["Database:Hostname"],
+            configuration["POSTGRES_HOST"],
+            configuration["DATABASE_HOST"],
+            configuration["DB_HOST"],
+            configuration["PGHOST"]);
 
         if (!string.IsNullOrWhiteSpace(host))
         {
@@ -54,7 +68,10 @@ public static class PostgresConnectionStringFactory
 
         var portValue = FirstNonEmpty(
             configuration["Database:Port"],
-            configuration["POSTGRES_PORT"]);
+            configuration["POSTGRES_PORT"],
+            configuration["DATABASE_PORT"],
+            configuration["DB_PORT"],
+            configuration["PGPORT"]);
 
         if (!string.IsNullOrWhiteSpace(portValue))
         {
@@ -69,7 +86,11 @@ public static class PostgresConnectionStringFactory
         var databaseName = FirstNonEmpty(
             configuration["Database:Name"],
             configuration["Database:Database"],
-            configuration["POSTGRES_DB"]);
+            configuration["Database:Db"],
+            configuration["POSTGRES_DB"],
+            configuration["DATABASE_NAME"],
+            configuration["DB_NAME"],
+            configuration["PGDATABASE"]);
 
         if (!string.IsNullOrWhiteSpace(databaseName))
         {
@@ -79,7 +100,13 @@ public static class PostgresConnectionStringFactory
         var username = FirstNonEmpty(
             configuration["Database:Username"],
             configuration["Database:User"],
-            configuration["POSTGRES_USER"]);
+            configuration["Database:Login"],
+            configuration["POSTGRES_USER"],
+            configuration["DATABASE_USERNAME"],
+            configuration["DATABASE_USER"],
+            configuration["DB_USERNAME"],
+            configuration["DB_USER"],
+            configuration["PGUSER"]);
 
         if (!string.IsNullOrWhiteSpace(username))
         {
@@ -88,7 +115,10 @@ public static class PostgresConnectionStringFactory
 
         var password = FirstNonEmpty(
             configuration["Database:Password"],
-            configuration["POSTGRES_PASSWORD"]);
+            configuration["POSTGRES_PASSWORD"],
+            configuration["DATABASE_PASSWORD"],
+            configuration["DB_PASSWORD"],
+            configuration["PGPASSWORD"]);
 
         if (!string.IsNullOrEmpty(password))
         {
@@ -97,11 +127,152 @@ public static class PostgresConnectionStringFactory
 
         var sslMode = FirstNonEmpty(
             configuration["Database:SslMode"],
-            configuration["POSTGRES_SSLMODE"]);
+            configuration["POSTGRES_SSLMODE"],
+            configuration["DATABASE_SSLMODE"],
+            configuration["DB_SSLMODE"]);
 
         if (!string.IsNullOrWhiteSpace(sslMode))
         {
             builder.SslMode = ParseSslMode(sslMode);
+        }
+    }
+
+    private static string? ResolveConnectionStringOverride(IConfiguration configuration, string connectionStringName)
+    {
+        var overrideValue = FirstNonEmpty(
+            configuration["Database:ConnectionString"],
+            configuration["Database:Connection"],
+            configuration["Database:ConnectionUri"],
+            configuration["Database:Uri"],
+            configuration["Database:Url"],
+            configuration[$"POSTGRESQLCONNSTR_{connectionStringName}"],
+            configuration[$"SQLCONNSTR_{connectionStringName}"],
+            configuration[$"PGCONNSTR_{connectionStringName}"],
+            configuration["POSTGRES_CONNECTION_STRING"],
+            configuration["POSTGRES_CONNECTION_URI"],
+            configuration["POSTGRES_URL"],
+            configuration["DATABASE_URL"],
+            configuration["DB_CONNECTION_STRING"],
+            configuration["DB_URL"]);
+
+        return string.IsNullOrWhiteSpace(overrideValue) ? null : overrideValue;
+    }
+
+    private static string NormalizeConnectionString(string value)
+    {
+        var trimmed = value.Trim();
+
+        if (trimmed.Contains("://", StringComparison.Ordinal))
+        {
+            return BuildConnectionStringFromUri(trimmed);
+        }
+
+        return trimmed;
+    }
+
+    private static string BuildConnectionStringFromUri(string uriValue)
+    {
+        if (!Uri.TryCreate(uriValue, UriKind.Absolute, out var uri))
+        {
+            throw new InvalidOperationException($"The database connection URI '{uriValue}' is not a valid absolute URI.");
+        }
+
+        if (!SupportedUriSchemes.Contains(uri.Scheme, StringComparer.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                $"Unsupported database URI scheme '{uri.Scheme}'. Only the following schemes are supported: {string.Join(", ", SupportedUriSchemes)}.");
+        }
+
+        if (string.IsNullOrWhiteSpace(uri.Host))
+        {
+            throw new InvalidOperationException("The database connection URI must specify a host name.");
+        }
+
+        var builder = new NpgsqlConnectionStringBuilder
+        {
+            Host = uri.Host,
+            Port = uri.IsDefaultPort ? DefaultPostgresPort : uri.Port
+        };
+
+        var databaseName = uri.AbsolutePath.Trim('/');
+
+        if (!string.IsNullOrWhiteSpace(databaseName))
+        {
+            builder.Database = Uri.UnescapeDataString(databaseName);
+        }
+
+        if (!string.IsNullOrEmpty(uri.UserInfo))
+        {
+            var userInfoParts = uri.UserInfo.Split(':', 2, StringSplitOptions.TrimEntries);
+            builder.Username = Uri.UnescapeDataString(userInfoParts[0]);
+
+            if (userInfoParts.Length > 1)
+            {
+                builder.Password = Uri.UnescapeDataString(userInfoParts[1]);
+            }
+        }
+
+        ApplyQueryParameters(uri, builder);
+
+        return builder.ConnectionString;
+    }
+
+    private static void ApplyQueryParameters(Uri uri, NpgsqlConnectionStringBuilder builder)
+    {
+        if (string.IsNullOrEmpty(uri.Query) || uri.Query.Length <= 1)
+        {
+            return;
+        }
+
+        var parameters = uri.Query.TrimStart('?').Split('&', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        foreach (var parameter in parameters)
+        {
+            if (string.IsNullOrEmpty(parameter))
+            {
+                continue;
+            }
+
+            var parts = parameter.Split('=', 2);
+            var key = Uri.UnescapeDataString(parts[0]);
+            var value = parts.Length > 1 ? Uri.UnescapeDataString(parts[1]) : string.Empty;
+
+            if (string.Equals(key, nameof(NpgsqlConnectionStringBuilder.Host), StringComparison.OrdinalIgnoreCase))
+            {
+                builder.Host = value;
+                continue;
+            }
+
+            if (string.Equals(key, nameof(NpgsqlConnectionStringBuilder.Port), StringComparison.OrdinalIgnoreCase))
+            {
+                if (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedPort) || parsedPort <= 0)
+                {
+                    throw new InvalidOperationException("The port value specified in the database connection URI query string must be a positive integer.");
+                }
+
+                builder.Port = parsedPort;
+                continue;
+            }
+
+            if (string.Equals(key, nameof(NpgsqlConnectionStringBuilder.Database), StringComparison.OrdinalIgnoreCase))
+            {
+                builder.Database = value;
+                continue;
+            }
+
+            if (string.Equals(key, nameof(NpgsqlConnectionStringBuilder.Username), StringComparison.OrdinalIgnoreCase))
+            {
+                builder.Username = value;
+                continue;
+            }
+
+            if (string.Equals(key, nameof(NpgsqlConnectionStringBuilder.Password), StringComparison.OrdinalIgnoreCase))
+            {
+                builder.Password = value;
+                continue;
+            }
+
+            builder[key] = value;
         }
     }
 


### PR DESCRIPTION
## Summary
- expand the Postgres connection string factory to honor additional configuration keys and database URLs
- add parsing for postgres:// style URIs and query parameters when building the connection string
- cover the new scenarios with unit tests for the connection string factory

## Testing
- dotnet test *(fails: `dotnet` CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e301203cfc8323b31ef766bd8d45b7