### PR TITLE
chore: type ngrx store access

### DIFF
--- a/feedme.client/src/app/components/catalog/catalog.component.ts
+++ b/feedme.client/src/app/components/catalog/catalog.component.ts
@@ -24,6 +24,7 @@ import {
   selectCatalogItems,
   selectCatalogLoadError,
 } from '../../store/catalog/catalog.reducer';
+import { AppState } from '../../store/app.state';
 
 @Pipe({
   name: 'booleanLabel',
@@ -53,7 +54,7 @@ export class BooleanLabelPipe implements PipeTransform {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CatalogComponent implements OnInit {
-  private readonly store = inject(Store);
+  private readonly store = inject<Store<AppState>>(Store);
 
   activeTab: 'info' | 'logistics' = 'info';
   private readonly newProductPopupOpen = signal(false);

--- a/feedme.client/src/app/store/app.state.ts
+++ b/feedme.client/src/app/store/app.state.ts
@@ -1,0 +1,13 @@
+import { CatalogState, catalogFeatureKey } from './catalog/catalog.reducer';
+
+/**
+ * Корневое состояние хранилища приложения.
+ *
+ * Мы описываем структуру стора явно, чтобы получать строгую типизацию
+ * при обращении к NgRx Store через inject(). Это позволяет редактору и
+ * компилятору подсказывать доступные свойства и предотвращает ошибки
+ * вроде "dispatch/select отсутствует у unknown".
+ */
+export interface AppState {
+  readonly [catalogFeatureKey]: CatalogState;
+}

--- a/feedme.client/src/app/store/catalog/catalog.effects.ts
+++ b/feedme.client/src/app/store/catalog/catalog.effects.ts
@@ -6,12 +6,13 @@ import { catchError, filter, map, of, switchMap, withLatestFrom } from 'rxjs';
 import { catalogActions } from './catalog.actions';
 import { CatalogService } from '../../services/catalog.service';
 import { selectCatalogLoaded } from './catalog.reducer';
+import { AppState } from '../app.state';
 
 @Injectable()
 export class CatalogEffects {
   private readonly actions$ = inject(Actions);
   private readonly catalogService = inject(CatalogService);
-  private readonly store = inject(Store);
+  private readonly store = inject<Store<AppState>>(Store);
 
   readonly loadCatalog$ = createEffect(() =>
     this.actions$.pipe(


### PR DESCRIPTION
## Summary
- define the application store interface to describe the catalog feature slice
- type NgRx store injections in the catalog component and effects for stronger signal typing

## Testing
- npm exec ng build -- --progress=false

------
https://chatgpt.com/codex/tasks/task_e_68e38f79e7ec83238a37bffa47a19358