### PR TITLE
Fix catalog signal typing for NgRx integration

### DIFF
--- a/feedme.client/src/app/components/catalog/catalog.component.ts
+++ b/feedme.client/src/app/components/catalog/catalog.component.ts
@@ -26,6 +26,8 @@ import {
 } from '../../store/catalog/catalog.reducer';
 import { AppState } from '../../store/app.state';
 
+const EMPTY_CATALOG: readonly CatalogItem[] = [];
+
 @Pipe({
   name: 'booleanLabel',
   standalone: true,
@@ -60,9 +62,12 @@ export class CatalogComponent implements OnInit {
   private readonly newProductPopupOpen = signal(false);
 
   readonly isNewProductPopupVisible = this.newProductPopupOpen.asReadonly();
-  private readonly catalogItems = toSignal(this.store.select(selectCatalogItems), {
-    initialValue: [] as CatalogItem[],
-  });
+  private readonly catalogItems = toSignal<readonly CatalogItem[], readonly CatalogItem[]>(
+    this.store.select(selectCatalogItems),
+    {
+      initialValue: EMPTY_CATALOG,
+    }
+  );
   readonly loadErrorMessage = toSignal(this.store.select(selectCatalogLoadError), {
     initialValue: null,
   });
@@ -81,7 +86,6 @@ export class CatalogComponent implements OnInit {
       this.closeNewProductPopup();
     }
   });
-
 
   ngOnInit(): void {
     this.store.dispatch(catalogActions.loadCatalog({}));
@@ -110,7 +114,7 @@ export class CatalogComponent implements OnInit {
     this.store.dispatch(catalogActions.createCatalogItem({ item: payload }));
   }
 
-  protected get catalogData(): CatalogItem[] {
+  protected get catalogData(): readonly CatalogItem[] {
     return this.catalogItems();
   }
 }


### PR DESCRIPTION
## Summary
- declare a shared empty catalog constant and use it when creating the catalog signal
- type the catalog signal explicitly to ensure the getter exposes a readonly list for templates

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e390c6f5d883238ea115de7b0dbbdc