### PR TITLE
Add NgRx dependency check before Angular builds

### DIFF
--- a/feedme.client/package.json
+++ b/feedme.client/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "prebuild": "node ./scripts/prepare-build-folders.mjs",
+    "prestart": "node ./scripts/verify-dependencies.mjs",
+    "prebuild": "node ./scripts/verify-dependencies.mjs && node ./scripts/prepare-build-folders.mjs",
     "pretest": "npm ci || npm i",
     "start": "npx ng serve --open --proxy-config proxy.conf.cjs",
     "build": "npx ng build",

--- a/feedme.client/scripts/verify-dependencies.mjs
+++ b/feedme.client/scripts/verify-dependencies.mjs
@@ -1,0 +1,50 @@
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+
+const requiredPackages = [
+  '@ngrx/store',
+  '@ngrx/effects',
+  '@ngrx/store-devtools',
+];
+
+function packageIsResolvable(packageName) {
+  try {
+    require.resolve(`${packageName}/package.json`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function ensureDependencies() {
+  const missingPackages = requiredPackages.filter(
+    packageName => !packageIsResolvable(packageName)
+  );
+
+  if (missingPackages.length === 0) {
+    return;
+  }
+
+  const formattedList = missingPackages.map(name => `  • ${name}`).join('\n');
+  const message = [
+    'Не найдены обязательные зависимости Angular проекта:',
+    formattedList,
+    '',
+    'Установите их командой:',
+    '  npm install',
+    '',
+    'После установки повторите сборку.',
+  ].join('\n');
+
+  process.stderr.write(`${message}\n`);
+  process.exit(1);
+}
+
+try {
+  ensureDependencies();
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`${message}\n`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add a preflight script that verifies the NgRx packages required by the Angular client are installed
- run the verification automatically before starting or building the client so developers get clear guidance if dependencies are missing

## Testing
- CI=1 npx ng build --configuration production --progress=false --output-path dist-test

------
https://chatgpt.com/codex/tasks/task_e_68e392ca8a188323861d9295cefb9549