### PR TITLE
Restore Postgres-backed development configuration

### DIFF
--- a/feedme.Server/Program.cs
+++ b/feedme.Server/Program.cs
@@ -42,14 +42,16 @@ public class Program
             var hostEnvironment = serviceProvider.GetRequiredService<IHostEnvironment>();
             var databaseOptions = serviceProvider.GetRequiredService<IOptions<DatabaseOptions>>().Value;
 
-            var fallbackProvider = DatabaseProvider.InMemory;
+            var fallbackProvider = DatabaseProvider.Postgres;
             var resolvedProvider = databaseOptions.ResolveProvider(fallbackProvider);
 
-            if (!hostEnvironment.IsDevelopment() && string.IsNullOrWhiteSpace(databaseOptions.Provider))
+            if (resolvedProvider == DatabaseProvider.Postgres
+                && string.IsNullOrWhiteSpace(databaseOptions.Provider)
+                && !hostEnvironment.IsDevelopment())
             {
                 var logger = serviceProvider.GetRequiredService<ILogger<Program>>();
                 logger.LogWarning(
-                    "Database provider is not configured. Falling back to the in-memory provider in the '{Environment}' environment.",
+                    "Database provider is not configured. Using the default PostgreSQL provider in the '{Environment}' environment.",
                     hostEnvironment.EnvironmentName);
             }
 


### PR DESCRIPTION
## Summary
- point the development configuration back to the managed PostgreSQL instance on 185.251.90.40
- default the application startup logic to PostgreSQL when no database provider is configured and update the warning message accordingly

## Testing
- `dotnet test` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3d3def39c8323a1b4526382391587