### PR TITLE
Add migration ensuring receipts responsible column exists

### DIFF
--- a/feedme.Server/Data/Migrations/20250221000100_AddResponsibleColumnToReceipts.cs
+++ b/feedme.Server/Data/Migrations/20250221000100_AddResponsibleColumnToReceipts.cs
@@ -1,0 +1,41 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace feedme.Server.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddResponsibleColumnToReceipts : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "responsible",
+                table: "receipts",
+                type: "character varying(128)",
+                maxLength: 128,
+                nullable: false,
+                defaultValue: "Не назначен");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "responsible",
+                table: "receipts",
+                type: "character varying(128)",
+                maxLength: 128,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(128)",
+                oldMaxLength: 128,
+                oldDefaultValue: "Не назначен");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "responsible",
+                table: "receipts");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a database migration that creates the missing `responsible` column on `receipts`
- populate legacy rows with a safe default and drop the default constraint afterwards to match the model

## Testing
- not run (dotnet CLI is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68e436acd8548323834f845dcfb721a2