### PR TITLE
Ensure receipt responsible column exists and harden connection string validation

### DIFF
--- a/feedme.Server/Configuration/PostgresConnectionStringFactory.cs
+++ b/feedme.Server/Configuration/PostgresConnectionStringFactory.cs
@@ -17,11 +17,21 @@ public static class PostgresConnectionStringFactory
         ArgumentException.ThrowIfNullOrWhiteSpace(connectionStringName);
 
         var baseConnectionString = ResolveBaseConnectionString(configuration, connectionStringName);
-        var builder = new NpgsqlConnectionStringBuilder(baseConnectionString);
 
-        ApplyOverrides(builder, configuration);
+        try
+        {
+            var builder = new NpgsqlConnectionStringBuilder(baseConnectionString);
 
-        return builder.ConnectionString;
+            ApplyOverrides(builder, configuration);
+
+            return builder.ConnectionString;
+        }
+        catch (Exception exception) when (exception is ArgumentException or FormatException)
+        {
+            throw new InvalidOperationException(
+                "The configured database connection string is invalid. Provide a valid PostgreSQL connection string or URL.",
+                exception);
+        }
     }
 
     private static string ResolveBaseConnectionString(IConfiguration configuration, string connectionStringName)

--- a/feedme.Server/Data/Migrations/20250918000000_EnsureResponsibleColumn.cs
+++ b/feedme.Server/Data/Migrations/20250918000000_EnsureResponsibleColumn.cs
@@ -1,0 +1,50 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace feedme.Server.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class EnsureResponsibleColumn : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                """
+                ALTER TABLE receipts
+                ADD COLUMN IF NOT EXISTS responsible character varying(128);
+                """);
+
+            migrationBuilder.Sql(
+                """
+                ALTER TABLE receipts
+                ALTER COLUMN responsible TYPE character varying(128);
+                """);
+
+            migrationBuilder.Sql(
+                """
+                UPDATE receipts
+                SET responsible = 'Не назначен'
+                WHERE responsible IS NULL
+                   OR BTRIM(responsible) = '';
+                """);
+
+            migrationBuilder.Sql(
+                """
+                ALTER TABLE receipts
+                ALTER COLUMN responsible SET NOT NULL;
+                """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                """
+                ALTER TABLE receipts
+                DROP COLUMN IF EXISTS responsible;
+                """);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a defensive migration that creates the `responsible` column on existing receipt tables and enforces non-null values
- wrap connection string parsing in `PostgresConnectionStringFactory` to surface invalid configurations as `InvalidOperationException`

## Testing
- dotnet test

------
https://chatgpt.com/codex/tasks/task_e_68e57b46764c83238331afbae1e3719a