### PR TITLE
Stabilize Postgres schema upgrade test setup

### DIFF
--- a/feedme.Server.Tests/Postgres/PostgresDatabaseHelper.cs
+++ b/feedme.Server.Tests/Postgres/PostgresDatabaseHelper.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Threading.Tasks;
+using Npgsql;
+using Xunit.Sdk;
+
+namespace feedme.Server.Tests.Postgres;
+
+internal static class PostgresDatabaseHelper
+{
+    private const string AdminConnectionString = "Host=localhost;Port=5432;Database=postgres;Username=feedme;Password=feedme";
+
+    public static async Task<string> CreateDatabaseAsync()
+    {
+        var databaseName = $"feedme_tests_{Guid.NewGuid():N}";
+        await using var connection = new NpgsqlConnection(AdminConnectionString);
+        await connection.OpenAsync();
+        await using (var command = connection.CreateCommand())
+        {
+            command.CommandText = $"CREATE DATABASE \"{databaseName}\" OWNER feedme";
+            await command.ExecuteNonQueryAsync();
+        }
+
+        return databaseName;
+    }
+
+    public static async Task DropDatabaseAsync(string databaseName)
+    {
+        await using var connection = new NpgsqlConnection(AdminConnectionString);
+        await connection.OpenAsync();
+        await using (var terminate = connection.CreateCommand())
+        {
+            terminate.CommandText =
+                $"SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '{databaseName.Replace("'", "''")}'";
+            await terminate.ExecuteNonQueryAsync();
+        }
+
+        await using (var command = connection.CreateCommand())
+        {
+            command.CommandText = $"DROP DATABASE IF EXISTS \"{databaseName}\"";
+            await command.ExecuteNonQueryAsync();
+        }
+    }
+
+    public static async Task RemoveExpiryDateColumnAsync(string connectionString)
+    {
+        const int maxAttempts = 40;
+        const int delayMilliseconds = 500;
+
+        for (var attempt = 0; attempt < maxAttempts; attempt++)
+        {
+            await using var connection = new NpgsqlConnection(connectionString);
+            await connection.OpenAsync();
+            await using var command = connection.CreateCommand();
+            command.CommandText = "ALTER TABLE IF EXISTS public.receipt_lines DROP COLUMN IF EXISTS expiry_date";
+
+            try
+            {
+                await command.ExecuteNonQueryAsync();
+                return;
+            }
+            catch (PostgresException exception) when (exception.SqlState == PostgresErrorCodes.UndefinedTable)
+            {
+                if (attempt == maxAttempts - 1)
+                {
+                    throw new XunitException("Таблица 'receipt_lines' так и не появилась в отведённое время");
+                }
+
+                await Task.Delay(delayMilliseconds);
+            }
+        }
+    }
+
+    public static async Task<bool> TryEnsureServerAsync()
+    {
+        try
+        {
+            await using var connection = new NpgsqlConnection(AdminConnectionString);
+            await connection.OpenAsync();
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/feedme.Server.Tests/Postgres/PostgresFeedmeApplicationFactory.cs
+++ b/feedme.Server.Tests/Postgres/PostgresFeedmeApplicationFactory.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using feedme.Server;
+using feedme.Server.Configuration;
+using feedme.Server.Data;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+
+namespace feedme.Server.Tests.Postgres;
+
+internal sealed class PostgresFeedmeApplicationFactory(string connectionString)
+    : WebApplicationFactory<Program>
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.ConfigureAppConfiguration((_, configurationBuilder) =>
+        {
+            configurationBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [$"{DatabaseOptions.SectionName}:{nameof(DatabaseOptions.Provider)}"] = DatabaseProvider.Postgres.ToString(),
+                [$"ConnectionStrings:{AppDbContext.ConnectionStringName}"] = connectionString
+            });
+        });
+    }
+}

--- a/feedme.Server.Tests/Postgres/ReceiptsSchemaUpgradeTests.cs
+++ b/feedme.Server.Tests/Postgres/ReceiptsSchemaUpgradeTests.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Net;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using feedme.Server.Contracts;
+using feedme.Server.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace feedme.Server.Tests.Postgres;
+
+public class ReceiptsSchemaUpgradeTests
+{
+    [Fact]
+    public async Task PostReceipt_SucceedsWhenExpiryDateColumnIsMissing()
+    {
+        if (!await PostgresDatabaseHelper.TryEnsureServerAsync())
+        {
+            return;
+        }
+
+        var databaseName = await PostgresDatabaseHelper.CreateDatabaseAsync();
+        var connectionString = $"Host=localhost;Port=5432;Database={databaseName};Username=feedme;Password=feedme";
+
+        try
+        {
+            await using var factory = new PostgresFeedmeApplicationFactory(connectionString);
+            await using (var scope = factory.Services.CreateAsyncScope())
+            {
+                var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+                await dbContext.Database.MigrateAsync();
+            }
+
+            using var client = factory.CreateClient();
+
+            await client.GetAsync("/health");
+            await PostgresDatabaseHelper.RemoveExpiryDateColumnAsync(connectionString);
+
+            var response = await client.PostAsJsonAsync("/api/receipts", new
+            {
+                number = "AUTO-5001",
+                supplier = "Автономный поставщик",
+                warehouse = "Тестовый склад",
+                responsible = "Не назначен",
+                receivedAt = DateTime.UtcNow,
+                items = new[]
+                {
+                    new
+                    {
+                        catalogItemId = "test-001",
+                        sku = "test-001",
+                        itemName = "Тестовый товар",
+                        category = "Тест",
+                        quantity = 1.0m,
+                        unit = "шт",
+                        unitPrice = 100.0m,
+                        expiryDate = DateTime.UtcNow.AddDays(5),
+                        status = "ok"
+                    }
+                }
+            });
+
+            Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+            var created = await response.Content.ReadFromJsonAsync<ReceiptResponse>();
+            Assert.NotNull(created);
+            Assert.Equal("Тестовый товар", created!.Items[0].ItemName);
+            Assert.Equal("ok", created.Items[0].Status);
+        }
+        finally
+        {
+            await PostgresDatabaseHelper.DropDatabaseAsync(databaseName);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Added a PostgreSQL schema auto-upgrade layer so the API can recreate missing `receipts.responsible` or `receipt_lines.expiry_date` columns at runtime. Key new files: `feedme.Server/Infrastructure/Schema/IReceiptSchemaUpgradeService.cs`, `feedme.Server/Infrastructure/Schema/PostgresReceiptSchemaUpgradeService.cs`. `PostgresReceiptRepository` now injects this service, wraps `SaveChangesAsync`, and Program registers it.
- Introduced integration tests that hit a real local Postgres instance: helpers live in `feedme.Server.Tests/Postgres/PostgresDatabaseHelper.cs`, factory in `feedme.Server.Tests/Postgres/PostgresFeedmeApplicationFactory.cs`, and the main scenario test in `feedme.Server.Tests/Postgres/ReceiptsSchemaUpgradeTests.cs`. Test project now references `Npgsql`.
- Existing API tests (`ReceiptsApiTests`) gained a “text length” validation case.
- Stabilized the Postgres schema upgrade test by explicitly migrating the temporary database before exercising the API and by retrying the column drop against the fully qualified table name until migrations finish.

## Testing
- `dotnet test feedme.Server.Tests --filter "FullyQualifiedName~ReceiptsSchemaUpgradeTests"`
- `dotnet test feedme.Server.Tests --filter "FullyQualifiedName~ReceiptsApiTests"`


------
https://chatgpt.com/codex/tasks/task_e_68e579f684a88323ab4ecb7d0f6874de