### PR TITLE
feat: add reusable catalog name search

### DIFF
--- a/feedme.client/src/app/warehouse/catalog/catalog.component.html
+++ b/feedme.client/src/app/warehouse/catalog/catalog.component.html
@@ -2,57 +2,76 @@
   <header class="catalog__header">
     <div>
       <h1 class="catalog__title">Каталог</h1>
-      <p class="catalog__subtitle">{{ productsCount() }} позиций</p>
+      <p class="catalog__subtitle">{{ productsCountLabel() }}</p>
     </div>
     <button type="button" class="button button--primary" (click)="openDialog()">
       + Новый товар
     </button>
   </header>
 
-  <div class="table-wrapper" *ngIf="products().length; else emptyCatalog">
-    <table class="table">
-      <thead>
-        <tr>
-          <th>Название</th>
-          <th>Тип</th>
-          <th class="is-mono">SKU</th>
-          <th>Категория</th>
-          <th class="is-centered">Ед. изм.</th>
-          <th class="is-right">Цена закупки</th>
-          <th class="is-right">Цена продажи</th>
-          <th>Поставщик</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr *ngFor="let product of products(); trackBy: trackByProductId">
-          <td>
-            <div class="truncate" [title]="product.name">{{ product.name }}</div>
-          </td>
-          <td>{{ product.type }}</td>
-          <td class="is-mono">
-            <span class="truncate" [title]="product.sku">{{ product.sku }}</span>
-          </td>
-          <td>
-            <div class="truncate" [title]="product.category">{{ product.category }}</div>
-          </td>
-          <td class="is-centered">{{ product.unit }}</td>
-          <td class="is-right">
-            {{ product.purchasePrice ?? '—' }}
-          </td>
-          <td class="is-right">
-            {{ product.salePrice ?? '—' }}
-          </td>
-          <td>
-            <div class="truncate" [title]="product.supplierMain || '—'">
-              {{ product.supplierMain || '—' }}
-            </div>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
+  <ng-container *ngIf="totalProductsCount(); else emptyCatalog">
+    <div class="catalog__toolbar">
+      <input
+        #searchInput
+        class="catalog__search"
+        type="search"
+        placeholder="Поиск по названию"
+        [value]="searchQuery()"
+        (input)="updateSearch(searchInput.value)"
+        aria-label="Поиск по названию"
+      />
+    </div>
+
+    <div class="table-wrapper" *ngIf="filteredProductsCount(); else noSearchResults">
+      <table class="table">
+        <thead>
+          <tr>
+            <th>Название</th>
+            <th>Тип</th>
+            <th class="is-mono">SKU</th>
+            <th>Категория</th>
+            <th class="is-centered">Ед. изм.</th>
+            <th class="is-right">Цена закупки</th>
+            <th class="is-right">Цена продажи</th>
+            <th>Поставщик</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr *ngFor="let product of filteredProducts(); trackBy: trackByProductId">
+            <td>
+              <div class="truncate" [title]="product.name">{{ product.name }}</div>
+            </td>
+            <td>{{ product.type }}</td>
+            <td class="is-mono">
+              <span class="truncate" [title]="product.sku">{{ product.sku }}</span>
+            </td>
+            <td>
+              <div class="truncate" [title]="product.category">{{ product.category }}</div>
+            </td>
+            <td class="is-centered">{{ product.unit }}</td>
+            <td class="is-right">
+              {{ product.purchasePrice ?? '—' }}
+            </td>
+            <td class="is-right">
+              {{ product.salePrice ?? '—' }}
+            </td>
+            <td>
+              <div class="truncate" [title]="product.supplierMain || '—'">
+                {{ product.supplierMain || '—' }}
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </ng-container>
   <ng-template #emptyCatalog>
     <div class="catalog__empty">Каталог пока пуст. Добавьте первую позицию.</div>
+  </ng-template>
+  <ng-template #noSearchResults>
+    <div class="catalog__empty">
+      По запросу «{{ normalizedSearchQuery() }}» ничего не найдено.
+    </div>
   </ng-template>
 
   <div class="dialog-backdrop" *ngIf="dialogOpen()">

--- a/feedme.client/src/app/warehouse/catalog/catalog.component.scss
+++ b/feedme.client/src/app/warehouse/catalog/catalog.component.scss
@@ -10,6 +10,27 @@
   margin-bottom: 1.5rem;
 }
 
+.catalog__toolbar {
+  display: flex;
+  justify-content: flex-start;
+  margin-bottom: 1rem;
+}
+
+.catalog__search {
+  width: min(320px, 100%);
+  border: 1px solid #d1d5db;
+  padding: 0.65rem 0.75rem;
+  font-size: 0.95rem;
+  border-radius: 0;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.catalog__search:focus {
+  outline: none;
+  border-color: #fa4b00;
+  box-shadow: 0 0 0 1px rgba(250, 75, 0, 0.15);
+}
+
 .catalog__title {
   margin: 0;
   font-size: 1.5rem;

--- a/feedme.client/src/app/warehouse/catalog/catalog.component.ts
+++ b/feedme.client/src/app/warehouse/catalog/catalog.component.ts
@@ -16,6 +16,7 @@ import { toSignal } from '@angular/core/rxjs-interop';
 
 import { WarehouseCatalogService } from './catalog.service';
 import { Product } from '../shared/models';
+import { filterByName } from './filter-by-name';
 
 interface ProductFormValue {
   name: string;
@@ -75,6 +76,7 @@ export class CatalogComponent {
 
   readonly dialogOpen = signal(false);
   readonly submitting = signal(false);
+  readonly searchQuery = signal('');
 
   readonly productForm = this.fb.group({
     name: this.fb.control(this.defaults.name, {
@@ -122,7 +124,21 @@ export class CatalogComponent {
     initialValue: [] as Product[],
   });
 
-  readonly productsCount = computed(() => this.products().length);
+  readonly totalProductsCount = computed(() => this.products().length);
+  readonly filteredProducts = computed(() => filterByName(this.products(), this.searchQuery(), 'ru-RU'));
+  readonly filteredProductsCount = computed(() => this.filteredProducts().length);
+  readonly normalizedSearchQuery = computed(() => this.searchQuery().trim());
+  readonly productsCountLabel = computed(() => {
+    const total = this.totalProductsCount();
+    const filtered = this.filteredProductsCount();
+    const hasSearch = this.normalizedSearchQuery().length > 0;
+
+    if (!hasSearch || filtered === total) {
+      return `${total} позиций`;
+    }
+
+    return `${filtered} из ${total} позиций`;
+  });
 
   openDialog(): void {
     this.dialogOpen.set(true);
@@ -185,6 +201,10 @@ export class CatalogComponent {
 
   trackByProductId(_: number, product: Product): string {
     return product.id;
+  }
+
+  updateSearch(query: string): void {
+    this.searchQuery.set(query);
   }
 
   private resetForm(): void {

--- a/feedme.client/src/app/warehouse/catalog/filter-by-name.spec.ts
+++ b/feedme.client/src/app/warehouse/catalog/filter-by-name.spec.ts
@@ -1,0 +1,27 @@
+import { filterByName } from './filter-by-name';
+
+describe('filterByName', () => {
+  const items = [
+    { id: '1', name: 'Говядина варёная' },
+    { id: '2', name: 'Гороховый суп' },
+    { id: '3', name: 'Жареная курица' },
+  ];
+
+  it('возвращает исходный список при пустом запросе', () => {
+    const result = filterByName(items, '');
+
+    expect(result).toBe(items);
+  });
+
+  it('игнорирует регистр и пробелы по краям', () => {
+    const result = filterByName(items, '  КуРИ  ');
+
+    expect(result).toEqual([{ id: '3', name: 'Жареная курица' }]);
+  });
+
+  it('возвращает пустой массив, если совпадений нет', () => {
+    const result = filterByName(items, 'Рыба');
+
+    expect(result).toEqual([]);
+  });
+});

--- a/feedme.client/src/app/warehouse/catalog/filter-by-name.ts
+++ b/feedme.client/src/app/warehouse/catalog/filter-by-name.ts
@@ -1,0 +1,17 @@
+/**
+ * Фильтрует элементы по подстроке в поле `name`, сохраняя исходный порядок.
+ * Логика вынесена в отдельный модуль для переиспользования в других частях приложения.
+ */
+export function filterByName<T extends { name: string }>(
+  items: readonly T[],
+  query: string,
+  locale?: string | string[]
+): readonly T[] {
+  const normalizedQuery = query.trim().toLocaleLowerCase(locale);
+
+  if (!normalizedQuery) {
+    return items;
+  }
+
+  return items.filter(item => item.name.toLocaleLowerCase(locale).includes(normalizedQuery));
+}


### PR DESCRIPTION
## Summary
- add a shared `filterByName` helper for catalog items to keep the filtering logic reusable
- connect the warehouse catalog to the helper, expose a search field, and show a "no results" state
- add unit tests that cover the filtering helper behaviour

## Testing
- npm run test -- --watch=false --browsers=ChromeHeadless *(fails: ChromeHeadless is missing libatk-1.0.so.0 in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e591d46f088323b6fca0666c677961