### PR TITLE
Allow CORS from dynamic localhost origins

### DIFF
--- a/feedme.Server/appsettings.json
+++ b/feedme.Server/appsettings.json
@@ -28,6 +28,8 @@
   "Cors": {
     "AllowedOrigins": [
       "http://localhost:4200",
+      "http://localhost:*",
+      "http://127.0.0.1:*",
       "http://185.251.90.40:*"
     ]
   }


### PR DESCRIPTION
## Summary
- allow the API to accept cross-origin requests from dynamically assigned localhost ports and loopback interfaces by default

## Testing
- `dotnet test feedme.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68e63c4a567c832394d29a25638f44c4