### PR TITLE
Fix runtime destroy errors in supply dialogs

### DIFF
--- a/feedme.client/src/app/components/add-receipt-popup/add-receipt-popup.component.ts
+++ b/feedme.client/src/app/components/add-receipt-popup/add-receipt-popup.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Component, DestroyRef, EventEmitter, Input, OnInit, Output, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormBuilder, FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -67,6 +67,7 @@ export class AddReceiptPopupComponent implements OnInit {
   catalog: CatalogItem[] = [];
   units: string[] = [];
   private selectedProduct: CatalogItem | null = null;
+  private readonly destroyRef = inject(DestroyRef);
 
   constructor(
     private fb: FormBuilder,
@@ -77,20 +78,20 @@ export class AddReceiptPopupComponent implements OnInit {
   ngOnInit(): void {
     this.catalogService
       .getAll()
-      .pipe(takeUntilDestroyed())
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(items => (this.catalog = items));
 
     this.units = ['шт', 'кг', 'л', 'упаковка'];
 
     this.form.controls.productId.valueChanges
-      .pipe(takeUntilDestroyed())
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(id => this.onProductChange(id));
 
     combineLatest([
       this.form.controls.quantity.valueChanges.pipe(startWith(this.form.controls.quantity.value)),
       this.form.controls.unitPrice.valueChanges.pipe(startWith(this.form.controls.unitPrice.getRawValue()))
     ])
-      .pipe(takeUntilDestroyed())
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(([quantity, unitPrice]) => this.updateTotalCost(Number(quantity), Number(unitPrice)));
   }
 
@@ -107,7 +108,7 @@ export class AddReceiptPopupComponent implements OnInit {
 
     this.catalogService
       .getById(id)
-      .pipe(takeUntilDestroyed())
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(item => {
         this.selectedProduct = item;
         this.form.controls.supplier.setValue(item.supplier, { emitEvent: false });

--- a/feedme.client/src/app/warehouse/ui/create-supply-dialog.component.ts
+++ b/feedme.client/src/app/warehouse/ui/create-supply-dialog.component.ts
@@ -2,6 +2,7 @@ import { CommonModule } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
+  DestroyRef,
   EventEmitter,
   Output,
   computed,
@@ -39,6 +40,7 @@ export class CreateSupplyDialogComponent {
 
   private readonly catalogService = inject(WarehouseCatalogService);
   private readonly fb = inject(NonNullableFormBuilder);
+  private readonly destroyRef = inject(DestroyRef);
 
   private static readonly maxSuggestions = 8;
 
@@ -100,7 +102,7 @@ export class CreateSupplyDialogComponent {
 
   constructor() {
     this.form.controls.productQuery.valueChanges
-      .pipe(takeUntilDestroyed())
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((value: string) => {
         const selected = this.selectedProduct();
         if (!selected) {


### PR DESCRIPTION
## Summary
- inject DestroyRef into the new supply dialog to safely use takeUntilDestroyed
- apply the same DestroyRef-managed teardown to the legacy add-receipt popup subscriptions

## Testing
- npm test *(fails: ChromeHeadless missing libatk-1.0.so.0 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e649e9507c83238edf90c602aced40