### PR TITLE
feat: hook receipts to backend and harden subscriptions

### DIFF
--- a/feedme.client/src/app/components/add-receipt-popup/add-receipt-popup.component.ts
+++ b/feedme.client/src/app/components/add-receipt-popup/add-receipt-popup.component.ts
@@ -1,4 +1,4 @@
-import { Component, DestroyRef, EventEmitter, Input, OnInit, Output, inject } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormBuilder, FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -67,7 +67,6 @@ export class AddReceiptPopupComponent implements OnInit {
   catalog: CatalogItem[] = [];
   units: string[] = [];
   private selectedProduct: CatalogItem | null = null;
-  private readonly destroyRef = inject(DestroyRef);
 
   constructor(
     private fb: FormBuilder,
@@ -78,20 +77,20 @@ export class AddReceiptPopupComponent implements OnInit {
   ngOnInit(): void {
     this.catalogService
       .getAll()
-      .pipe(takeUntilDestroyed(this.destroyRef))
+      .pipe(takeUntilDestroyed())
       .subscribe(items => (this.catalog = items));
 
     this.units = ['шт', 'кг', 'л', 'упаковка'];
 
     this.form.controls.productId.valueChanges
-      .pipe(takeUntilDestroyed(this.destroyRef))
+      .pipe(takeUntilDestroyed())
       .subscribe(id => this.onProductChange(id));
 
     combineLatest([
       this.form.controls.quantity.valueChanges.pipe(startWith(this.form.controls.quantity.value)),
       this.form.controls.unitPrice.valueChanges.pipe(startWith(this.form.controls.unitPrice.getRawValue()))
     ])
-      .pipe(takeUntilDestroyed(this.destroyRef))
+      .pipe(takeUntilDestroyed())
       .subscribe(([quantity, unitPrice]) => this.updateTotalCost(Number(quantity), Number(unitPrice)));
   }
 
@@ -108,7 +107,7 @@ export class AddReceiptPopupComponent implements OnInit {
 
     this.catalogService
       .getById(id)
-      .pipe(takeUntilDestroyed(this.destroyRef))
+      .pipe(takeUntilDestroyed())
       .subscribe(item => {
         this.selectedProduct = item;
         this.form.controls.supplier.setValue(item.supplier, { emitEvent: false });

--- a/feedme.client/src/app/services/receipt.service.spec.ts
+++ b/feedme.client/src/app/services/receipt.service.spec.ts
@@ -1,17 +1,29 @@
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { firstValueFrom, skip, take } from 'rxjs';
 
+import { API_BASE_URL } from '../tokens/api-base-url.token';
 import { CreateReceipt, ReceiptService } from './receipt.service';
 
-describe('ReceiptService (in-memory)', () => {
+describe('ReceiptService', () => {
   let service: ReceiptService;
+  let httpMock: HttpTestingController;
+  const apiBase = 'http://185.251.90.40:8080/api';
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [ReceiptService],
+      imports: [HttpClientTestingModule],
+      providers: [
+        ReceiptService,
+        { provide: API_BASE_URL, useValue: apiBase },
+      ],
     });
 
     service = TestBed.inject(ReceiptService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
   });
 
   function createPayload(overrides: Partial<CreateReceipt> = {}): CreateReceipt {
@@ -34,61 +46,203 @@ describe('ReceiptService (in-memory)', () => {
           status: 'warning',
         },
       ],
-    };
+    } satisfies CreateReceipt;
 
     return { ...base, ...overrides };
   }
 
-  it('creates receipts in memory and exposes them through the stream', async () => {
-    const payload = createPayload();
-    const emissionPromise = firstValueFrom(service.getAll().pipe(skip(1), take(1)));
-
-    const created = await firstValueFrom(service.saveReceipt(payload));
-    const receipts = await emissionPromise;
-
-    expect(created.totalAmount).toBeCloseTo(750, 5);
-    expect(created.items[0].totalCost).toBeCloseTo(750, 5);
-    expect(receipts).toEqual([created]);
-  });
-
-  it('updates existing receipts by identifier', async () => {
-    const initial = await firstValueFrom(service.saveReceipt(createPayload({ number: 'RCPT-101' })));
-    const updatedPayload = createPayload({
-      number: 'RCPT-101-UPDATED',
-      warehouse: 'Бар',
+  function createReceiptResponse(overrides: Partial<Record<string, unknown>> = {}) {
+    return {
+      id: 'receipt-1',
+      number: 'RCPT-100',
+      supplier: 'ООО Поставщик',
+      warehouse: 'Главный склад',
+      responsible: 'Не назначен',
+      receivedAt: '2024-04-15T00:00:00Z',
+      totalAmount: 750,
       items: [
         {
           catalogItemId: 'product-1',
           sku: 'PRD-001',
           itemName: 'Помидоры',
           category: 'Овощи',
-          quantity: 3,
+          quantity: 5,
           unit: 'кг',
-          unitPrice: 200,
-          expiryDate: '2024-04-30T00:00:00.000Z',
-          status: 'ok',
+          unitPrice: 150,
+          totalCost: 750,
+          expiryDate: '2024-04-25T00:00:00Z',
+          status: 'warning',
+        },
+      ],
+      ...overrides,
+    };
+  }
+
+  it('loads receipts from the API and maps numeric fields', () => {
+    const response = [createReceiptResponse()];
+    let result: unknown;
+
+    service.getAll().subscribe((receipts) => {
+      result = receipts;
+    });
+
+    const request = httpMock.expectOne(`${apiBase}/receipts`);
+    expect(request.request.method).toBe('GET');
+    request.flush(response);
+
+    expect(result).toEqual([
+      {
+        id: 'receipt-1',
+        number: 'RCPT-100',
+        supplier: 'ООО Поставщик',
+        warehouse: 'Главный склад',
+        responsible: 'Не назначен',
+        receivedAt: '2024-04-15T00:00:00.000Z',
+        totalAmount: 750,
+        items: [
+          {
+            catalogItemId: 'product-1',
+            sku: 'PRD-001',
+            itemName: 'Помидоры',
+            category: 'Овощи',
+            quantity: 5,
+            unit: 'кг',
+            unitPrice: 150,
+            totalCost: 750,
+            expiryDate: '2024-04-25T00:00:00.000Z',
+            status: 'warning',
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('creates a receipt via POST and normalizes the payload', () => {
+    const payload = createPayload();
+    let result: unknown;
+
+    service.saveReceipt(payload).subscribe((receipt) => {
+      result = receipt;
+    });
+
+    const request = httpMock.expectOne(`${apiBase}/receipts`);
+    expect(request.request.method).toBe('POST');
+    expect(request.request.body).toEqual({
+      number: 'RCPT-100',
+      supplier: 'ООО Поставщик',
+      warehouse: 'Главный склад',
+      responsible: 'Не назначен',
+      receivedAt: '2024-04-15T00:00:00.000Z',
+      items: [
+        {
+          catalogItemId: 'product-1',
+          sku: 'PRD-001',
+          itemName: 'Помидоры',
+          category: 'Овощи',
+          quantity: 5,
+          unit: 'кг',
+          unitPrice: 150,
+          expiryDate: '2024-04-25T00:00:00.000Z',
+          status: 'warning',
         },
       ],
     });
 
-    const updated = await firstValueFrom(service.updateReceipt(initial.id, updatedPayload));
+    request.flush(createReceiptResponse());
 
-    expect(updated.id).toBe(initial.id);
-    expect(updated.number).toBe('RCPT-101-UPDATED');
-    expect(updated.warehouse).toBe('Бар');
-    expect(updated.totalAmount).toBe(600);
-
-    const receipts = await firstValueFrom(service.getAll().pipe(take(1)));
-    expect(receipts[0]).toEqual(updated);
+    expect(result).toEqual({
+      id: 'receipt-1',
+      number: 'RCPT-100',
+      supplier: 'ООО Поставщик',
+      warehouse: 'Главный склад',
+      responsible: 'Не назначен',
+      receivedAt: '2024-04-15T00:00:00.000Z',
+      totalAmount: 750,
+      items: [
+        {
+          catalogItemId: 'product-1',
+          sku: 'PRD-001',
+          itemName: 'Помидоры',
+          category: 'Овощи',
+          quantity: 5,
+          unit: 'кг',
+          unitPrice: 150,
+          totalCost: 750,
+          expiryDate: '2024-04-25T00:00:00.000Z',
+          status: 'warning',
+        },
+      ],
+    });
   });
 
-  it('removes receipts and keeps stream consistent', async () => {
-    const first = await firstValueFrom(service.saveReceipt(createPayload({ number: 'RCPT-201' })));
-    const second = await firstValueFrom(service.saveReceipt(createPayload({ number: 'RCPT-202' })));
+  it('updates a receipt with PUT and keeps the identifier consistent', () => {
+    const payload = createPayload({ number: 'RCPT-200' });
+    let result: unknown;
 
-    await firstValueFrom(service.deleteReceipt(first.id));
+    service.updateReceipt('  receipt-200  ', payload).subscribe((receipt) => {
+      result = receipt;
+    });
 
-    const receipts = await firstValueFrom(service.getAll().pipe(take(1)));
-    expect(receipts).toEqual([second]);
+    const request = httpMock.expectOne(`${apiBase}/receipts/receipt-200`);
+    expect(request.request.method).toBe('PUT');
+    expect(request.request.body).toEqual({
+      id: 'receipt-200',
+      number: 'RCPT-200',
+      supplier: 'ООО Поставщик',
+      warehouse: 'Главный склад',
+      responsible: 'Не назначен',
+      receivedAt: '2024-04-15T00:00:00.000Z',
+      items: [
+        {
+          catalogItemId: 'product-1',
+          sku: 'PRD-001',
+          itemName: 'Помидоры',
+          category: 'Овощи',
+          quantity: 5,
+          unit: 'кг',
+          unitPrice: 150,
+          expiryDate: '2024-04-25T00:00:00.000Z',
+          status: 'warning',
+        },
+      ],
+    });
+
+    request.flush(createReceiptResponse({ id: 'receipt-200', number: 'RCPT-200' }));
+
+    expect(result).toEqual({
+      id: 'receipt-200',
+      number: 'RCPT-200',
+      supplier: 'ООО Поставщик',
+      warehouse: 'Главный склад',
+      responsible: 'Не назначен',
+      receivedAt: '2024-04-15T00:00:00.000Z',
+      totalAmount: 750,
+      items: [
+        {
+          catalogItemId: 'product-1',
+          sku: 'PRD-001',
+          itemName: 'Помидоры',
+          category: 'Овощи',
+          quantity: 5,
+          unit: 'кг',
+          unitPrice: 150,
+          totalCost: 750,
+          expiryDate: '2024-04-25T00:00:00.000Z',
+          status: 'warning',
+        },
+      ],
+    });
+  });
+
+  it('deletes a receipt by identifier', () => {
+    service.deleteReceipt(' receipt-300 ').subscribe();
+
+    const request = httpMock.expectOne(`${apiBase}/receipts/receipt-300`);
+    expect(request.request.method).toBe('DELETE');
+    request.flush(null);
+  });
+
+  it('throws an error when deleting without an identifier', () => {
+    expect(() => service.deleteReceipt('   ')).toThrowError('Receipt identifier is required.');
   });
 });

--- a/feedme.client/src/app/warehouse/ui/create-supply-dialog.component.ts
+++ b/feedme.client/src/app/warehouse/ui/create-supply-dialog.component.ts
@@ -2,7 +2,6 @@ import { CommonModule } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
-  DestroyRef,
   EventEmitter,
   Output,
   computed,
@@ -40,7 +39,6 @@ export class CreateSupplyDialogComponent {
 
   private readonly catalogService = inject(WarehouseCatalogService);
   private readonly fb = inject(NonNullableFormBuilder);
-  private readonly destroyRef = inject(DestroyRef);
 
   private static readonly maxSuggestions = 8;
 
@@ -102,7 +100,7 @@ export class CreateSupplyDialogComponent {
 
   constructor() {
     this.form.controls.productQuery.valueChanges
-      .pipe(takeUntilDestroyed(this.destroyRef))
+      .pipe(takeUntilDestroyed())
       .subscribe((value: string) => {
         const selected = this.selectedProduct();
         if (!selected) {


### PR DESCRIPTION
## Summary
- replace the in-memory receipt service with an HttpClient-based integration that maps backend payloads into UI-friendly models
- update the receipt service unit tests to rely on HttpTestingController and verify HTTP requests and response normalization
- switch supply dialogs to context-aware takeUntilDestroyed usage to prevent DestroyRef runtime errors

## Testing
- npm run test -- --include src/app/services/receipt.service.spec.ts *(fails: ChromeHeadless missing libatk-1.0.so.0 in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68e6538c41a08323b91e06ede86166da