### PR TITLE
Fix CORS wildcard origin handling

### DIFF
--- a/feedme.Server/Configuration/CorsPolicyConfigurator.cs
+++ b/feedme.Server/Configuration/CorsPolicyConfigurator.cs
@@ -67,7 +67,10 @@ public sealed class CorsPolicyConfigurator : IConfigureNamedOptions<CorsOptions>
 
             rules.Add(rule);
 
-            allowedOrigins.Add(rule.NormalizedOrigin);
+            if (!rule.AllowsAnyPort)
+            {
+                allowedOrigins.Add(rule.NormalizedOrigin);
+            }
         }
 
         return new CorsOriginRuleSet(rules, allowedOrigins);


### PR DESCRIPTION
## Summary
- prevent wildcard origin entries from being registered as exact matches in the configured CORS policy
- rely on rule matching to allow any-port origins so wildcard localhost origins are correctly respected

## Testing
- `dotnet test feedme.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68e658b5ea8c83239afba88688a4f8e1