### PR TITLE
feat: refresh warehouse top tabs layout

### DIFF
--- a/feedme.client/src/app/warehouse/warehouse-page.component.css
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.css
@@ -12,6 +12,9 @@
   --text: #111827;
   --blue: #2563eb;
   --orange: #f97316;
+  --accent: #ff6600;
+  --accent-2: #ff3a00;
+  --border: #edf0f3;
 }
 
 .warehouse-page {
@@ -86,6 +89,69 @@
   min-width: 0;
   min-height: 100vh;
   overflow: visible;
+}
+
+.warehouse-page__tabs-wrapper {
+  padding: 28px 32px 8px;
+}
+
+.primary-tabs {
+  display: flex;
+  gap: 14px;
+  align-items: flex-end;
+  background: #fff;
+  border-radius: 14px 14px 0 0;
+  padding: 8px 14px 0;
+  border-bottom: 1px solid var(--border);
+  box-shadow: 0 8px 30px rgba(2, 8, 23, 0.06);
+  position: relative;
+}
+
+.primary-tab {
+  position: relative;
+  background: transparent;
+  border: 0;
+  margin: 0;
+  padding: 14px 6px 12px;
+  color: #667085;
+  font-weight: 700;
+  font-size: 15px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: color 0.2s ease, opacity 0.2s ease;
+}
+
+.primary-tab:hover,
+.primary-tab:focus-visible {
+  color: var(--accent);
+  outline: none;
+}
+
+.primary-tab--active {
+  color: var(--accent);
+}
+
+.primary-tab--active::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 3px;
+  border-radius: 3px 3px 0 0;
+  background: linear-gradient(90deg, var(--accent), var(--accent-2));
+  box-shadow: 0 0 0 2px rgba(255, 102, 0, 0.05), 0 6px 14px rgba(255, 102, 0, 0.35);
+}
+
+.primary-tabs .indicator {
+  position: absolute;
+  bottom: 0;
+  left: 14px;
+  width: 0;
+  height: 3px;
+  background: linear-gradient(90deg, var(--accent), var(--accent-2));
+  border-radius: 3px;
+  box-shadow: 0 0 0 2px rgba(255, 102, 0, 0.05), 0 6px 14px rgba(255, 102, 0, 0.35);
 }
 
 .warehouse-page__overview {
@@ -344,11 +410,6 @@
 
 .filters button.btn {
   justify-self: start;
-}
-
-.warehouse-page__tabs {
-  display: block;
-  margin: 18px 32px 0;
 }
 
 .sr-only {

--- a/feedme.client/src/app/warehouse/warehouse-page.component.html
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.html
@@ -22,6 +22,48 @@
   </aside>
 
   <main class="warehouse-page__content">
+    <div class="warehouse-page__tabs-wrapper">
+      <div class="primary-tabs" role="tablist" aria-label="Разделы склада">
+        <button
+          type="button"
+          class="primary-tab"
+          [class.primary-tab--active]="activeTab() === 'supplies'"
+          [attr.aria-selected]="activeTab() === 'supplies'"
+          (click)="selectTab('supplies')"
+        >
+          Поставки
+        </button>
+        <button
+          type="button"
+          class="primary-tab"
+          [class.primary-tab--active]="activeTab() === 'stock'"
+          [attr.aria-selected]="activeTab() === 'stock'"
+          (click)="selectTab('stock')"
+        >
+          Остатки
+        </button>
+        <button
+          type="button"
+          class="primary-tab"
+          [class.primary-tab--active]="activeTab() === 'catalog'"
+          [attr.aria-selected]="activeTab() === 'catalog'"
+          (click)="selectTab('catalog')"
+        >
+          Каталог
+        </button>
+        <button
+          type="button"
+          class="primary-tab"
+          [class.primary-tab--active]="activeTab() === 'inventory'"
+          [attr.aria-selected]="activeTab() === 'inventory'"
+          (click)="selectTab('inventory')"
+        >
+          Инвентаризация
+        </button>
+        <span class="indicator" aria-hidden="true"></span>
+      </div>
+    </div>
+
     <section class="warehouse-page__overview" aria-label="Обзор склада">
       <header class="header-crumbs">
         <nav class="breadcrumbs" aria-label="Хлебные крошки">
@@ -46,27 +88,33 @@
         </div>
       </header>
 
-      <section *ngIf="overviewMetrics() as snapshot" class="kpi" aria-label="Ключевые показатели склада">
-        <article class="card" aria-live="polite">
-          <p class="title">Поставок за 7 дней</p>
-          <p class="value">{{ snapshot.suppliesLastWeek }}</p>
-        </article>
+      <ng-container *ngIf="activeTab() === 'supplies'">
+        <section
+          *ngIf="overviewMetrics() as snapshot"
+          class="kpi"
+          aria-label="Ключевые показатели склада"
+        >
+          <article class="card" aria-live="polite">
+            <p class="title">Поставок за 7 дней</p>
+            <p class="value">{{ snapshot.suppliesLastWeek }}</p>
+          </article>
 
-        <article class="card" aria-live="polite">
-          <p class="title">Сумма закупок / 7 дн.</p>
-          <p class="value">{{ formatCurrency(snapshot.purchaseAmountLastWeek) }}</p>
-        </article>
+          <article class="card" aria-live="polite">
+            <p class="title">Сумма закупок / 7 дн.</p>
+            <p class="value">{{ formatCurrency(snapshot.purchaseAmountLastWeek) }}</p>
+          </article>
 
-        <article class="card" aria-live="polite">
-          <p class="title">Позиций на складе</p>
-          <p class="value">{{ snapshot.positions }}</p>
-        </article>
+          <article class="card" aria-live="polite">
+            <p class="title">Позиций на складе</p>
+            <p class="value">{{ snapshot.positions }}</p>
+          </article>
 
-        <article class="card" aria-live="polite">
-          <p class="title">Просрочено</p>
-          <p class="value" [ngClass]="{ neg: snapshot.expired > 0 }">{{ snapshot.expired }}</p>
-        </article>
-      </section>
+          <article class="card" aria-live="polite">
+            <p class="title">Просрочено</p>
+            <p class="value" [ngClass]="{ neg: snapshot.expired > 0 }">{{ snapshot.expired }}</p>
+          </article>
+        </section>
+      </ng-container>
     </section>
 
     <section class="toolbar" aria-label="Фильтры и действия по поставкам">
@@ -114,12 +162,6 @@
         <button type="button" class="btn btn-orange" (click)="openCreateDialog()">+ Новая поставка</button>
       </div>
     </section>
-
-    <app-supply-controls
-      class="warehouse-page__tabs"
-      [activeTab]="activeTab()"
-      (activeTabChange)="selectTab($event)"
-    ></app-supply-controls>
 
     <section *ngIf="activeTab() === 'supplies'" class="warehouse-page__tab-panel">
         <section class="warehouse-page__bulk" *ngIf="hasSelection()" aria-live="polite">

--- a/feedme.client/src/app/warehouse/warehouse-page.component.ts
+++ b/feedme.client/src/app/warehouse/warehouse-page.component.ts
@@ -21,7 +21,6 @@ import { EmptyStateComponent } from './ui/empty-state.component';
 import { FieldComponent } from './ui/field.component';
 import { StatusBadgeClassPipe } from '../pipes/status-badge-class.pipe';
 import { StatusBadgeLabelPipe } from '../pipes/status-badge-label.pipe';
-import { SupplyControlsComponent } from '../components/supply-controls/supply-controls.component';
 import { CatalogComponent as LegacyCatalogComponent } from '../components/catalog/catalog.component';
 import { CreateSupplyDialogComponent, CreateSupplyDialogResult } from './ui/create-supply-dialog.component';
 import { computeExpiryStatus } from './shared/status.util';
@@ -54,7 +53,6 @@ type SupplyHistoryEntry = {
     EmptyStateComponent,
     StatusBadgeClassPipe,
     StatusBadgeLabelPipe,
-    SupplyControlsComponent,
     LegacyCatalogComponent,
     CreateSupplyDialogComponent,
   ],


### PR DESCRIPTION
## Summary
- move the warehouse section switcher above the filters and KPI area and restyle it with the orange underline treatment
- gate KPI cards behind the supplies tab while keeping existing filter controls and table views intact for every tab

## Testing
- npm run lint *(fails: Angular workspace has no lint target configured)*

------
https://chatgpt.com/codex/tasks/task_e_68e6545042b88323a6200c29afaf0ac9