### PR TITLE
Fix CORS wildcard handling when specific origins configured

### DIFF
--- a/feedme.Server.Tests/CorsTests.cs
+++ b/feedme.Server.Tests/CorsTests.cs
@@ -91,4 +91,32 @@ public class CorsTests
         Assert.True(response.Headers.TryGetValues("Access-Control-Allow-Origin", out var origins));
         Assert.Contains("http://example.com:8080", origins);
     }
+
+    [Fact]
+    public async Task PreflightRequest_ReturnsCorsHeadersForWildcardPortOrigin_WhenSpecificOriginsAreConfigured()
+    {
+        await using var factory = new FeedmeApplicationFactory()
+            .WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureAppConfiguration((_, configuration) =>
+                {
+                    configuration.AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        [$"{CorsSettings.SectionName}:{nameof(CorsSettings.AllowedOrigins)}:0"] = "http://localhost:4200",
+                        [$"{CorsSettings.SectionName}:{nameof(CorsSettings.AllowedOrigins)}:1"] = "http://example.com:*"
+                    });
+                });
+            });
+
+        using var client = factory.CreateClient();
+        using var request = new HttpRequestMessage(HttpMethod.Options, "/api/receipts");
+        request.Headers.Add("Origin", "http://example.com:63191");
+        request.Headers.Add("Access-Control-Request-Method", "GET");
+
+        using var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        Assert.True(response.Headers.TryGetValues("Access-Control-Allow-Origin", out var origins));
+        Assert.Contains("http://example.com:63191", origins);
+    }
 }


### PR DESCRIPTION
## Summary
- skip registering explicit origins when any wildcard port rules are configured so the custom predicate can evaluate every request origin
- extend CORS integration tests to cover scenarios that mix wildcard-port rules with specific origins

## Testing
- `dotnet test feedme.sln` *(fails: feedme.Server.Tests.ReceiptsApiTests.PostReceipt_TruncatesFieldsExceedingDatabaseLimits currently fails on main)*

------
https://chatgpt.com/codex/tasks/task_e_68e65cfb2af08323b8c48568e65af4f9