### PR TITLE
Fix new product flag selector markup

### DIFF
--- a/feedme.client/src/app/components/catalog-new-product-popup/catalog-new-product-popup.component.html
+++ b/feedme.client/src/app/components/catalog-new-product-popup/catalog-new-product-popup.component.html
@@ -48,16 +48,20 @@
               >
                 <ng-container *ngIf="selectedFlags?.length; else flagsEmpty">
                   <div class="fm-flags__chips">
-                    <span
-                      *ngFor="let code of selectedFlags | slice:0:3"
-                      class="flag"
-                      [ngClass]="'flag--' + code"
-                      [title]="FLAG_FULL[code]"
-                    >
-                      <i class="dot"></i>{{ FLAG_SHORT[code] }}
-                    </span>
-                    <span *ngIf="selectedFlags.length > 3" class="flag more">
-                      +{{ selectedFlags.length - 3 }}
+                    <ng-container *ngFor="let code of selectedFlags | slice:0:maxVisibleFlags">
+                      <ng-container *ngFor="let flag of flagOptions">
+                        <span
+                          *ngIf="flag.code === code"
+                          class="flag"
+                          [ngClass]="'flag--' + flag.code"
+                          [title]="flag.full"
+                        >
+                          <i class="dot"></i>{{ flag.short }}
+                        </span>
+                      </ng-container>
+                    </ng-container>
+                    <span *ngIf="selectedFlags.length > maxVisibleFlags" class="flag more">
+                      +{{ selectedFlags.length - maxVisibleFlags }}
                     </span>
                   </div>
                 </ng-container>
@@ -74,20 +78,20 @@
               >
                 <label
                   class="fm-flags__item"
-                  *ngFor="let f of ALL_FLAGS"
-                  [title]="FLAG_FULL[f.code]"
-                  (click)="toggleFlag(f.code)"
+                  *ngFor="let flag of flagOptions"
+                  [title]="flag.full"
+                  (click)="toggleFlag(flag.code)"
                 >
                   <input
                     type="checkbox"
                     class="fm-checkbox"
-                    [checked]="selectedFlags?.includes(f.code)"
+                    [checked]="selectedFlags?.includes(flag.code)"
                     (click)="$event.stopPropagation()"
                   />
-                  <span class="flag" [ngClass]="'flag--' + f.code">
-                    <i class="dot"></i>{{ FLAG_SHORT[f.code] }}
+                  <span class="flag" [ngClass]="'flag--' + flag.code">
+                    <i class="dot"></i>{{ flag.short }}
                   </span>
-                  <span class="label">{{ FLAG_FULL[f.code] }}</span>
+                  <span class="label">{{ flag.full }}</span>
                 </label>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- restructure the new product flag selector markup to render up to three chips with a +N badge and prevent wrapping
- feed the dropdown menu from the existing flag definition collection so titles and badges use the correct text per design

## Testing
- npm run lint *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_68f6c638be4c8323a144b7bf0fef8dd2